### PR TITLE
Add integrated demo shell for Gestão de Convidados

### DIFF
--- a/shared/projectStore.js
+++ b/shared/projectStore.js
@@ -1,16 +1,189 @@
-// projectStore.js (v1)
-// IndexedDB para múltiplos eventos. Sem migração (ainda).
+// projectStore.js (v2)
+// IndexedDB para múltiplos eventos — agora com shape unificado (schemaVersion 2).
 
 const DB_NAME = "marco_db";                  // banco
 const DB_VER  = 1;                           // versão do IndexedDB (não confundir com schema do payload)
 const STORE   = "kv";                        // objectStore único
 const INDEX_KEY = "ac:index:v1";             // índice de projetos
 const KEY = id => `ac:project:${id}:v1`;     // chave de cada projeto
-const SCHEMA_VERSION = 1;                    // << nosso schema inicial
+const SCHEMA_VERSION = 2;                    // schema lógico salvo no payload
+const META_VERSION = 2;                      // versão do índice cacheado
 
 const now  = () => Date.now();
 const uid  = () => crypto.randomUUID();
 const deep = o => JSON.parse(JSON.stringify(o));
+
+const ensureString = (v) => (v == null ? "" : String(v));
+
+function ensureEndereco(val){
+  if (!val || typeof val !== "object") {
+    return {
+      logradouro: "",
+      numero: "",
+      bairro: "",
+      cidade: "",
+      uf: "",
+      cep: "",
+      complemento: "",
+      textoLivre: ensureString(val)
+    };
+  }
+  return {
+    logradouro: ensureString(val.logradouro),
+    numero: ensureString(val.numero),
+    bairro: ensureString(val.bairro),
+    cidade: ensureString(val.cidade),
+    uf: ensureString(val.uf),
+    cep: ensureString(val.cep),
+    complemento: ensureString(val.complemento),
+    textoLivre: ensureString(val.textoLivre)
+  };
+}
+
+function ensurePessoa(val){
+  if (!val || typeof val !== "object") {
+    return { nome: ensureString(val), telefone: "", email: "" };
+  }
+  return {
+    nome: ensureString(val.nome),
+    telefone: ensureString(val.telefone),
+    email: ensureString(val.email)
+  };
+}
+
+function ensureCerimonialista(val){
+  if (!val || typeof val !== "object") {
+    return {
+      nomeCompleto: ensureString(val),
+      telefone: "",
+      redeSocial: "",
+      email: ""
+    };
+  }
+  return {
+    nomeCompleto: ensureString(val.nomeCompleto ?? val.nome ?? ""),
+    telefone: ensureString(val.telefone),
+    redeSocial: ensureString(val.redeSocial),
+    email: ensureString(val.email)
+  };
+}
+
+function ensureEvento(val){
+  const obj = (!val || typeof val !== "object") ? { nome: ensureString(val) } : val;
+  return {
+    nome: ensureString(obj.nome ?? obj.titulo),
+    dataISO: ensureString(obj.dataISO ?? obj.data ?? obj.dataEvento),
+    horario: ensureString(obj.horario ?? obj.hora ?? obj.horarioPrevisto),
+    local: ensureString(obj.local ?? obj.espaco),
+    descricao: ensureString(obj.descricao),
+    endereco: ensureEndereco(obj.endereco),
+    anfitriao: ensurePessoa(obj.anfitriao)
+  };
+}
+
+function ensureConvites(val){
+  if (Array.isArray(val)) return deep(val);
+  return [];
+}
+
+function countPessoas(project){
+  if (!project) return 0;
+  const convites = Array.isArray(project.convites) ? project.convites : [];
+  if (convites.length) {
+    return convites.reduce((total, item) => {
+      if (typeof item?.total === "number" && !Number.isNaN(item.total)) {
+        return total + item.total;
+      }
+      const acompanhantes = Array.isArray(item?.acompanhantes) ? item.acompanhantes.length : 0;
+      return total + 1 + acompanhantes;
+    }, 0);
+  }
+  const lista = Array.isArray(project.lista) ? project.lista : [];
+  return lista.length;
+}
+
+function toMeta(project){
+  const evento = project?.evento || {};
+  return {
+    id: project?.id,
+    nome: evento.nome || "Sem nome",
+    dataISO: evento.dataISO || "",
+    horario: evento.horario || "",
+    local: evento.local || "",
+    cidade: evento.endereco?.cidade || "",
+    uf: evento.endereco?.uf || "",
+    convites: Array.isArray(project?.convites) ? project.convites.length : 0,
+    pessoas: countPessoas(project),
+    updatedAt: project?.updatedAt || now(),
+    metaVersion: META_VERSION
+  };
+}
+
+function normalizeMeta(meta){
+  if (!meta) return null;
+  return {
+    id: meta.id,
+    nome: meta.nome ?? "Sem nome",
+    dataISO: meta.dataISO ?? "",
+    horario: meta.horario ?? meta.hora ?? "",
+    local: meta.local ?? "",
+    cidade: meta.cidade ?? "",
+    uf: meta.uf ?? "",
+    convites: typeof meta.convites === "number" ? meta.convites : 0,
+    pessoas: typeof meta.pessoas === "number" ? meta.pessoas : (typeof meta.convites === "number" ? meta.convites : 0),
+    updatedAt: meta.updatedAt ?? now(),
+    metaVersion: meta.metaVersion ?? 1
+  };
+}
+
+function ensureShape(p){
+  p ||= {};
+  p.schemaVersion = SCHEMA_VERSION;
+  p.createdAt = p.createdAt || now();
+  p.updatedAt = p.updatedAt || now();
+  p.cerimonialista = ensureCerimonialista(p.cerimonialista);
+  p.evento = ensureEvento(p.evento);
+  p.convites = ensureConvites(p.convites);
+  p.lista = Array.isArray(p.lista) ? deep(p.lista) : [];
+  p.tipos = Array.isArray(p.tipos) ? deep(p.tipos) : [];
+  p.modelos = p.modelos && typeof p.modelos === "object" ? deep(p.modelos) : {};
+  p.vars = p.vars && typeof p.vars === "object" ? deep(p.vars) : {};
+  p.mensagens = Array.isArray(p.mensagens) ? deep(p.mensagens) : [];
+  p.relatorios = Array.isArray(p.relatorios) ? deep(p.relatorios) : [];
+  return p;
+}
+
+function mergeProject(base, partial = {}){
+  const out = deep(base || {});
+  for (const key of Object.keys(partial || {})) {
+    const val = partial[key];
+    if (val === undefined) continue;
+    if (key === "evento") {
+      const evento = partial.evento || {};
+      out.evento = {
+        ...(out.evento || {}),
+        ...deep(evento),
+        endereco: {
+          ...(out.evento?.endereco || {}),
+          ...deep(evento.endereco || {})
+        },
+        anfitriao: {
+          ...(out.evento?.anfitriao || {}),
+          ...deep(evento.anfitriao || {})
+        }
+      };
+    } else if (key === "cerimonialista") {
+      out.cerimonialista = { ...(out.cerimonialista || {}), ...deep(val) };
+    } else if (Array.isArray(val)) {
+      out[key] = deep(val);
+    } else if (val && typeof val === "object") {
+      out[key] = { ...(out[key] || {}), ...deep(val) };
+    } else {
+      out[key] = val;
+    }
+  }
+  return ensureShape(out);
+}
 
 // ---------- IndexedDB minimal ----------
 function openDB(){
@@ -49,83 +222,117 @@ function kvDel(key){
   }));
 }
 
-// ---------- Shape inicial (v1) ----------
-function ensureShape(p){
-  // Garante que o objeto tenha o "formato v1" — útil para robustez, mas não faz migração incremental.
-  p ||= {};
-  p.schemaVersion = SCHEMA_VERSION; // fixa v1
-  p.cerimonialista ||= { nomeCompleto:"", telefone:"", redeSocial:"" };
-  p.evento ||= { nome:"", data:"", hora:"", local:"", endereco:"", anfitriao:"" };
-  p.lista ||= [];
-  p.tipos ||= [];
-  p.modelos ||= {};
-  p.vars ||= {};
-  return p;
-}
-function toMeta(p){
-  return { id: p.id, nome: p.evento?.nome || "Sem nome", updatedAt: now() };
-}
-
 // ---------- Cache do índice ----------
 let indexCache = null;
 
+async function rebuildMetaIfNeeded(meta){
+  const normalized = normalizeMeta(meta);
+  if (!normalized?.id) return null;
+  if (normalized.metaVersion === META_VERSION) return normalized;
+  const project = await kvGet(KEY(normalized.id));
+  if (!project) return normalized;
+  const shaped = ensureShape(project);
+  await kvSet(KEY(normalized.id), shaped);
+  return toMeta(shaped);
+}
+
 // ---------- API ----------
 export async function init(){
-  indexCache = (await kvGet(INDEX_KEY)) || [];
+  const idx = (await kvGet(INDEX_KEY)) || [];
+  const upgraded = [];
+  for (const entry of idx) {
+    if (!entry) continue;
+    try {
+      const fresh = await rebuildMetaIfNeeded(entry);
+      if (fresh) upgraded.push(fresh);
+    } catch (err) {
+      console.error("projectStore.init: erro ao reconstruir meta", err);
+    }
+  }
+  indexCache = upgraded;
+  await kvSet(INDEX_KEY, indexCache);
   return listProjects();
 }
+
 export function listProjects(){
   const idx = indexCache || [];
-  return [...idx].sort((a,b)=>b.updatedAt - a.updatedAt);
+  return [...idx].sort((a,b)=> (b.updatedAt || 0) - (a.updatedAt || 0));
 }
+
 export async function createProject(data = {}){
   const id = uid();
   const payload = ensureShape({
     id,
-    cerimonialista: data.cerimonialista || { nomeCompleto:"", telefone:"", redeSocial:"" },
-    evento: data.evento || { nome:"", data:"", hora:"", local:"", endereco:"", anfitriao:"" },
-    lista: data.lista || [],
-    tipos: data.tipos || [],
-    modelos: data.modelos || {},
-    vars: data.vars || {}
+    cerimonialista: data.cerimonialista,
+    evento: data.evento,
+    convites: data.convites,
+    lista: data.lista,
+    tipos: data.tipos,
+    modelos: data.modelos,
+    vars: data.vars,
+    mensagens: data.mensagens,
+    relatorios: data.relatorios
   });
+  payload.createdAt = now();
+  payload.updatedAt = payload.createdAt;
   await kvSet(KEY(id), payload);
   const meta = toMeta(payload);
-  const idx = indexCache || (await kvGet(INDEX_KEY)) || [];
-  idx.push(meta); indexCache = idx; await kvSet(INDEX_KEY, idx);
-  return { meta, payload: deep(payload) };
+  const idx = (indexCache || (await kvGet(INDEX_KEY)) || []).filter(Boolean);
+  idx.push(meta);
+  indexCache = idx;
+  await kvSet(INDEX_KEY, indexCache);
+  return { meta: deep(meta), payload: deep(payload) };
 }
+
 export async function getProject(id){
   const raw = await kvGet(KEY(id));
   if (!raw) return null;
-  const shaped = ensureShape(raw);               // segura contra campos faltando
+  const shaped = ensureShape(raw);
   if (JSON.stringify(shaped) !== JSON.stringify(raw)) await kvSet(KEY(id), shaped);
   return deep(shaped);
 }
+
 export async function updateProject(id, partial){
   const curr = await kvGet(KEY(id));
   if (!curr) throw new Error("Projeto não encontrado");
-  const next = ensureShape({ ...curr, ...deep(partial) });
-  await kvSet(KEY(id), next);
+  const merged = mergeProject(ensureShape(curr), deep(partial));
+  merged.updatedAt = now();
+  await kvSet(KEY(id), merged);
 
-  const idx = indexCache || (await kvGet(INDEX_KEY)) || [];
+  const idx = (indexCache || (await kvGet(INDEX_KEY)) || []).filter(Boolean);
+  const meta = toMeta(merged);
   const i = idx.findIndex(x => x.id === id);
-  if (i >= 0) idx[i] = { ...idx[i], nome: next.evento?.nome || idx[i].nome, updatedAt: now() };
-  indexCache = idx; await kvSet(INDEX_KEY, idx);
+  if (i >= 0) idx[i] = meta; else idx.push(meta);
+  indexCache = idx;
+  await kvSet(INDEX_KEY, indexCache);
 
-  return deep(next);
+  return deep(merged);
 }
+
 export async function deleteProject(id){
   await kvDel(KEY(id));
-  const idx = indexCache || (await kvGet(INDEX_KEY)) || [];
-  indexCache = idx.filter(x => x.id !== id); await kvSet(INDEX_KEY, indexCache);
+  const idx = (indexCache || (await kvGet(INDEX_KEY)) || []).filter(Boolean);
+  indexCache = idx.filter(x => x.id !== id);
+  await kvSet(INDEX_KEY, indexCache);
 }
+
 export async function exportProject(id){
   const p = await getProject(id); if (!p) throw new Error("Projeto não encontrado");
   return JSON.stringify(p, null, 2);
 }
+
 export async function importProject(jsonOrObj){
   const o = typeof jsonOrObj === "string" ? JSON.parse(jsonOrObj) : jsonOrObj;
-  const { cerimonialista, evento, lista, tipos, modelos, vars } = o || {};
-  return createProject({ cerimonialista, evento, lista, tipos, modelos, vars });
+  const {
+    cerimonialista,
+    evento,
+    convites,
+    lista,
+    tipos,
+    modelos,
+    vars,
+    mensagens,
+    relatorios
+  } = o || {};
+  return createProject({ cerimonialista, evento, convites, lista, tipos, modelos, vars, mensagens, relatorios });
 }

--- a/shared/ui.css
+++ b/shared/ui.css
@@ -1,316 +1,119 @@
 /* ==========================================================================
-   5Horas UI – base compartilhada para widgets do app
-   Responsivo, leve e extensível via CSS vars
+   5Horas UI – utilitários neutros para responsividade e bordas
    ========================================================================== */
 
-/* -------------------- Tokens (tema) -------------------- */
-:root{
-  /* Cores */
-  --paper: #ffffff;
-  --bg: #f8fafc;
-  --ink: #0f172a;
-  --mut: #64748b;
-  --line: #e5e7eb;
-
-  --pri: #2563eb;        /* primário (azul) */
-  --pri-ink: #ffffff;
-  --pri-ring: rgba(37,99,235,.25);
-
-  --accent: #f97316;     /* acento (laranja) */
-  --danger: #ef4444;
-  --success: #16a34a;
-  --warning: #f59e0b;
-  --info: #0ea5e9;
-
-  /* Raios & sombra */
-  --radius: 12px;
-  --shadow: 0 10px 30px rgba(2,6,23,.08);
-
-  /* Tipografia (ajustada por breakpoint) */
-  --fs-sm: 12px;
-  --fs-md: 14px;
-  --fs-lg: 18px;
-
-  /* Espaços */
-  --space-1: 6px;
-  --space-2: 10px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 20px;
-
-  /* Larguras container */
-  --container: 1100px;
+:root {
+  --gdg-container: min(1100px, 100%);
+  --gdg-gutter: 16px;
+  --gdg-radius: 12px;
+  --gdg-line-color: #e5e7eb;
 }
 
-/* -------------------- Reset leve -------------------- */
-* { box-sizing: border-box; }
-html, body {
-  margin: 0;
-  color: var(--ink);
-  background: var(--bg);
-  font: 400 var(--fs-md)/1.55 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial;
+* {
+  box-sizing: border-box;
 }
-img, svg { max-width: 100%; height: auto; }
-a { color: var(--pri); text-decoration: none; }
-a:hover { text-decoration: underline; }
-:focus-visible { outline: 0; box-shadow: 0 0 0 3px var(--pri-ring); border-radius: 6px; }
 
-/* -------------------- Layout helpers -------------------- */
-.container { max-width: var(--container); margin: 0 auto; padding: 0 var(--space-4); }
-.hidden { display: none !important; }
-.visually-hidden { position:absolute !important; width:1px;height:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);white-space:nowrap; }
+img,
+svg {
+  max-width: 100%;
+  height: auto;
+}
 
-/* -------------------- Grid 12 colunas -------------------- */
-.row { display: grid; grid-template-columns: repeat(12, 1fr); gap: var(--space-2); }
+.hidden {
+  display: none !important;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+
+.container {
+  max-width: var(--gdg-container);
+  margin: 0 auto;
+  padding: 0 var(--gdg-gutter);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--gdg-gutter);
+}
+
 .col-12 { grid-column: span 12; }
 .col-8  { grid-column: span 8; }
 .col-6  { grid-column: span 6; }
 .col-4  { grid-column: span 4; }
 .col-3  { grid-column: span 3; }
 
-/* Breakpoints */
-@media (max-width: 1024px){
-  :root { --fs-md: 15px; }
+@media (max-width: 1024px) {
+  .lg-col-12 { grid-column: span 12; }
+  .lg-col-6  { grid-column: span 6; }
+  .lg-col-4  { grid-column: span 4; }
 }
-@media (max-width: 768px){
-  :root { --fs-md: 14px; }
+
+@media (max-width: 768px) {
   .md-col-12 { grid-column: span 12; }
   .md-col-6  { grid-column: span 6; }
   .md-col-4  { grid-column: span 4; }
 }
-@media (max-width: 640px){
-  :root { --fs-md: 14px; --fs-lg: 17px; }
-  .col-8, .col-6, .col-4, .col-3 { grid-column: span 12; } /* empilha no mobile */
+
+@media (max-width: 640px) {
+  .col-8,
+  .col-6,
+  .col-4,
+  .col-3 {
+    grid-column: span 12;
+  }
 }
 
-/* -------------------- Cartões & estruturas -------------------- */
-.card{
-  background: var(--paper);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  padding: var(--space-3);
-  margin: var(--space-3) 0;
-  box-shadow: var(--shadow);
-}
-.card > h3, .card > h4 { margin: 4px 0 10px 0; }
-.actions { display: flex; gap: var(--space-2); justify-content: flex-end; flex-wrap: wrap; }
-.actions-sticky{
-  position: sticky; bottom: 0; background: var(--paper);
-  border: 1px solid var(--line); border-radius: var(--radius);
-  padding: var(--space-2); display:flex; gap:var(--space-2); justify-content:flex-end;
-  box-shadow: 0 -6px 14px rgba(2,6,23,.04);
+.card {
+  border: 1px solid var(--gdg-line-color);
+  border-radius: var(--gdg-radius);
+  padding: var(--gdg-gutter);
 }
 
-/* -------------------- Formularios -------------------- */
-label{ display:block; margin: var(--space-1) 0; font-weight:600; }
-input, select, textarea{
-  width: 100%;
-  padding: var(--space-2);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: #fff;
-  font-size: var(--fs-md);
-  outline: none;
-  transition: border-color .15s ease, box-shadow .15s ease;
-}
-textarea{ min-height: 120px; resize: vertical; }
-input:focus, select:focus, textarea:focus{
-  border-color: var(--pri);
-  box-shadow: 0 0 0 3px var(--pri-ring);
-}
-input[disabled], select[disabled], textarea[disabled]{ background: #f1f5f9; color: var(--mut); }
-
-.help { font-size: var(--fs-sm); color: var(--mut); }
-.is-invalid{ border-color: var(--danger) !important; }
-.field-error{ color: var(--danger); font-size: var(--fs-sm); margin-top: 4px; }
-
-/* -------------------- Botões -------------------- */
-.btn{
-  appearance: none; border: 1px solid var(--pri);
-  background: var(--pri); color: var(--pri-ink);
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius); font-weight: 700; cursor: pointer;
-  transition: filter .15s ease, transform .02s ease;
-}
-.btn:hover { filter: brightness(1.05); }
-.btn:active { transform: translateY(1px); }
-.btn:disabled { opacity: .6; cursor: default; }
-.btn.block { width: 100%; }
-
-.btn.ghost{
-  background: #fff; color: var(--ink);
-  border-color: var(--line);
-}
-.btn.danger{
-  background: var(--danger);
-  border-color: var(--danger);
-  color: #fff;
-}
-.btn.icon{ display:inline-flex; align-items:center; gap:8px; }
-
-/* Mobile: ações podem virar bloco completo */
-@media (max-width: 480px){
-  .actions .btn { flex: 1 1 auto; }      /* botões se expandem igualmente */
-  .btn.block-sm { width: 100%; }
+.card > h2,
+.card > h3,
+.card > h4 {
+  margin-top: 0;
 }
 
-/* -------------------- Tipos e utilidades -------------------- */
-.mut { color: var(--mut); }
-.badge{
-  display:inline-flex; align-items:center; gap:6px;
-  padding: 4px 10px; border-radius: 999px; border:1px solid var(--line);
-  background: #fff; font-size: var(--fs-sm);
-}
-.pill{
-  display:inline-flex; gap:6px; align-items:center;
-  padding: 6px 10px; border-radius: 999px; border:1px solid var(--line);
-  background:#fff; font-size: var(--fs-sm);
-}
-.accent { color: var(--accent); }
-
-/* -------------------- Abas simples (se quiser fora do Elementor) -------------------- */
-.tabs{ display:flex; gap: var(--space-2); border-bottom: 1px solid var(--line); }
-.tab{
-  padding: var(--space-2) var(--space-3); border: 1px solid var(--line);
-  border-bottom: none; border-radius: var(--radius) var(--radius) 0 0;
-  background:#fff; color: var(--mut); cursor:pointer;
-}
-.tab[aria-selected="true"]{ color:#fff; background: var(--pri); border-color: var(--pri); }
-
-/* -------------------- Tabelas (listas, RSVP, etc.) -------------------- */
-.table{ width:100%; border-collapse: collapse; font-size: var(--fs-md); }
-.table th, .table td{ border:1px solid var(--line); padding: 8px 10px; text-align:left; }
-.table th{ background:#f8fafc; font-weight:700; }
-.table tr:hover td{ background:#fbfdff; }
-
-/* -------------------- Overlay / Dialog -------------------- */
-.overlay{
-  position: fixed; inset: 0; background: rgba(0,0,0,.45);
-  display:flex; align-items:center; justify-content:center; z-index: 9999;
-}
-.dialog{
-  background: #fff; border:1px solid var(--line); border-radius: var(--radius);
-  box-shadow: var(--shadow); padding: var(--space-4); width: min(520px, 90vw);
-}
-.list{ max-height: 280px; overflow: auto; margin: var(--space-2) 0; }
-.rowi{ display:flex; justify-content:space-between; align-items:center; gap:8px;
-  padding: var(--space-2); border:1px solid var(--line); border-radius: var(--radius);
-  margin: 6px 0; }
-.rowi strong{ display:block; max-width:300px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-
-/* -------------------- Toast (feedback leve) -------------------- */
-.toast{
-  position: fixed; right: 14px; bottom: 14px; z-index: 99999;
-  background: #fff; color: var(--ink);
-  border: 1px solid var(--line); border-radius: var(--radius);
-  padding: 10px 12px; box-shadow: var(--shadow);
-  display: none; min-width: 200px;
-}
-.toast.show{ display:block; animation: pop .18s ease-out; }
-.toast.success{ border-color: rgba(22,163,74,.35); }
-.toast.error{ border-color: rgba(239,68,68,.35); }
-.toast.info{ border-color: rgba(14,165,233,.35); }
-
-/* -------------------- Spinners / animações -------------------- */
-.spinner{
-  width: 18px; height: 18px; border-radius: 50%;
-  border: 2px solid #e2e8f0; border-top-color: var(--pri);
-  animation: spin .8s linear infinite;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
-@keyframes pop { from { transform: scale(.98); opacity: .6; } to { transform: scale(1); opacity: 1; } }
-
-/* Respeita usuários com redução de movimento */
-@media (prefers-reduced-motion: reduce){
-  * { animation: none !important; transition: none !important; }
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gdg-gutter);
+  justify-content: flex-end;
 }
 
-/* -------------------- Impressão (oculta elementos desnecessários) -------------------- */
-@media print{
-  .actions, .actions-sticky, .overlay, .toast { display: none !important; }
-  .card { box-shadow: none; border-color: #bbb; }
+.actions-sticky {
+  position: sticky;
+  bottom: 0;
+  border: 1px solid var(--gdg-line-color);
+  border-radius: var(--gdg-radius);
+  padding: var(--gdg-gutter);
+  background: inherit;
 }
 
-/* -------------------- Espaçamentos utilitários (compacto) -------------------- */
-.mt-1{ margin-top: var(--space-1) } .mt-2{ margin-top: var(--space-2) } .mt-3{ margin-top: var(--space-3) }
-.mb-1{ margin-bottom: var(--space-1) } .mb-2{ margin-bottom: var(--space-2) } .mb-3{ margin-bottom: var(--space-3) }
-.p-2{ padding: var(--space-2) } .p-3{ padding: var(--space-3) } .p-4{ padding: var(--space-4) }
-
-/* ====== Refinos visuais (patch de teste) ====== */
-
-/* 1) Tokens mais suaves */
-:root{
-  --radius: 14px;              /* cantos mais arredondados */
-  --line: #e9eef5;             /* borda mais clara */
-  --shadow: 0 8px 24px rgba(2,6,23,.06); /* sombra discreta */
-}
-
-/* 2) Cards mais leves */
-.card{
-  border-color: var(--line);
-  box-shadow: var(--shadow);
-}
-
-/* 3) Títulos maiores (use <h2> nas seções novas) */
-.card > h2{                    /* quando você trocar para h2 */
-  font-size: clamp(18px, 2.2vw, 22px);
-  font-weight: 800;
-  letter-spacing: .2px;
-  margin: 4px 0 12px;
-}
-.card > h3{                    /* compat: títulos atuais continuam bons */
-  font-size: clamp(16px, 2vw, 20px);
-  font-weight: 700;
-  margin: 4px 0 10px;
-}
-
-/* 4) Inputs “soft rounded” */
-input, select, textarea{
-  border-radius: var(--radius);
-  border-color: var(--line);
-  background: #fff;
-  transition: border-color .15s ease, box-shadow .15s ease, background-color .15s;
-}
-input:focus, select:focus, textarea:focus{
-  border-color: var(--pri);
-  box-shadow: 0 0 0 4px var(--pri-ring);
-}
-
-/* 5) Placeholders menores e mais fracos */
-::placeholder{
-  color: var(--mut);
-  opacity: .75;
-  font-size: var(--fs-sm);
-}
-
-/* 6) Labels mais compactos, coerentes em linha vertical */
-label{
-  margin: 4px 0;              /* menos espaço */
-  font-weight: 600;
-}
-
-/* 7) Botões: visual sólido + versões “fantasma” bem discretas */
-.btn{ border-radius: var(--radius); }
-.btn.ghost{ border-color: var(--line); color: #0f172a; }
-.btn.danger{ filter: saturate(.95); }
-
-/* 8) Ações sticky com sombra de separação sutil */
-.actions-sticky{
-  box-shadow: 0 -6px 18px rgba(2,6,23,.05);
-}
-
-/* 9) Variante opcional “flat” (sem bordas nos campos) — aplique na seção inteira */
-.form--flat input,
-.form--flat select,
-.form--flat textarea{
-  border: none;
-  border-bottom: 1px solid var(--line);
-  border-radius: 0;
+.btn {
+  appearance: none;
+  border: 1px solid var(--gdg-line-color);
+  border-radius: var(--gdg-radius);
+  padding: 8px 16px;
   background: transparent;
+  cursor: pointer;
 }
-.form--flat input:focus,
-.form--flat select:focus,
-.form--flat textarea:focus{
-  border-bottom-color: var(--pri);
-  box-shadow: none;
+
+.btn.block {
+  width: 100%;
+}
+
+@media (max-width: 480px) {
+  .actions .btn {
+    flex: 1 1 auto;
+  }
 }

--- a/tools/gestao-de-convidados/app.html
+++ b/tools/gestao-de-convidados/app.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestão de Convidados – Aplicativo</title>
+    <link rel="stylesheet" href="../../shared/ui.css" />
+    <style>
+      body {
+        margin: 0;
+        font: 400 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, Inter, Arial, sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      .gdg-shell {
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+        padding: 32px 0 64px;
+      }
+
+      .gdg-header-block,
+      .gdg-tabs-block {
+        position: relative;
+      }
+
+      .gdg-content {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .gdg-pane {
+        display: none;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .gdg-pane[aria-hidden="false"] {
+        display: flex;
+      }
+
+      .gdg-pane__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 20px;
+      }
+
+      .gdg-pane__card {
+        background: #ffffff;
+        border: 1px solid var(--gdg-line-color);
+        border-radius: var(--gdg-radius);
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .gdg-pane__card h2 {
+        margin: 0;
+        font-size: 20px;
+      }
+
+      .gdg-pane__placeholder {
+        color: #475569;
+        font-size: 15px;
+        line-height: 1.6;
+      }
+
+      .gdg-badge-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 12px;
+      }
+
+      .gdg-badge {
+        border: 1px dashed var(--gdg-line-color);
+        border-radius: calc(var(--gdg-radius) - 4px);
+        padding: 12px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .gdg-badge strong {
+        font-size: 28px;
+      }
+
+      .gdg-badge span {
+        font-size: 13px;
+        color: #475569;
+      }
+
+      .gdg-pane__list {
+        display: grid;
+        gap: 12px;
+      }
+
+      .gdg-pane__list-item {
+        padding: 16px;
+        border: 1px solid var(--gdg-line-color);
+        border-radius: var(--gdg-radius);
+        background: #fff;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .gdg-pane__list-item strong {
+        font-size: 16px;
+      }
+
+      footer {
+        margin-top: 32px;
+        font-size: 12px;
+        color: #64748b;
+        text-align: center;
+      }
+
+      @media (max-width: 640px) {
+        .gdg-shell {
+          gap: 24px;
+          padding: 24px 0 48px;
+        }
+
+        .gdg-pane__card {
+          padding: 16px;
+        }
+
+        .gdg-pane__grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="gdg-shell container">
+      <div class="gdg-header-block" id="gdg-header"></div>
+      <div class="gdg-tabs-block" id="gdg-tabs"></div>
+
+      <div class="gdg-content">
+        <section class="gdg-pane" data-tab-pane="painel" aria-hidden="true">
+          <div class="gdg-pane__grid">
+            <article class="gdg-pane__card">
+              <h2>Visão geral</h2>
+              <div class="gdg-pane__placeholder">
+                <p>Selecione um evento para visualizar o resumo geral. Este espaço pode receber widgets adicionais, como gráficos ou indicadores personalizados.</p>
+                <p>Enquanto nenhuma peça adicional é montada, mantemos um layout neutro pronto para que você adicione componentes futuros.</p>
+              </div>
+              <div class="gdg-badge-grid">
+                <div class="gdg-badge"><strong id="gdg-pane-convites">0</strong><span>Convites planejados</span></div>
+                <div class="gdg-badge"><strong id="gdg-pane-pessoas">0</strong><span>Pessoas estimadas</span></div>
+                <div class="gdg-badge"><strong id="gdg-pane-msgs">0</strong><span>Mensagens agendadas</span></div>
+              </div>
+            </article>
+
+            <article class="gdg-pane__card">
+              <h2>Próximos passos</h2>
+              <div class="gdg-pane__placeholder">
+                <p>Use esta área para guiar a operação do evento: inclua atalhos, links de relatórios ou checklists específicos da sua rotina.</p>
+                <p>À medida que criarmos novos módulos (convidados, mensagens, relatórios), atualizaremos este painel automaticamente.</p>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="gdg-pane" data-tab-pane="dados-evento" aria-hidden="true">
+          <div class="gdg-pane__card" style="padding: 0">
+            <div id="gdg-event-editor"></div>
+          </div>
+        </section>
+
+        <section class="gdg-pane" data-tab-pane="convidados" aria-hidden="true">
+          <div class="gdg-pane__card">
+            <h2>Convidados</h2>
+            <div class="gdg-pane__placeholder">
+              <p>Este bloco está preparado para receber o módulo de gestão de convidados. Assim que a peça estiver disponível, basta montá-la neste container.</p>
+            </div>
+            <div class="gdg-pane__list">
+              <div class="gdg-pane__list-item">
+                <strong>Importações e sincronização</strong>
+                <span>Planeje aqui os botões para importar planilhas ou sincronizar listas.</span>
+              </div>
+              <div class="gdg-pane__list-item">
+                <strong>Filtros e buscas</strong>
+                <span>Reserve espaço para filtros rápidos, pesquisa por nome e segmentações.</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="gdg-pane" data-tab-pane="mensagens" aria-hidden="true">
+          <div class="gdg-pane__card">
+            <h2>Mensagens</h2>
+            <div class="gdg-pane__placeholder">
+              <p>Configuração de disparos, agendamentos e templates poderá ser posicionada aqui. O layout mantém a mesma linguagem visual, facilitando a evolução do produto.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="gdg-pane" data-tab-pane="relatorios" aria-hidden="true">
+          <div class="gdg-pane__card">
+            <h2>Relatórios</h2>
+            <div class="gdg-pane__placeholder">
+              <p>Quando os relatórios estiverem definidos, basta montar os componentes correspondentes neste espaço.</p>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <footer>
+        Gestão de Convidados – protótipo integrado das peças atuais.
+      </footer>
+    </div>
+
+    <script type="module">
+      import { mount as mountHeader } from "./app_header.mjs";
+      import { mount as mountTabs } from "./nav_tabs.mjs";
+      import { mount as mountEditor } from "./event_editor.mjs";
+      import { subscribe } from "../../shared/marcoBus.js";
+
+      const panes = Array.from(document.querySelectorAll("[data-tab-pane]"));
+      const convitesEl = document.getElementById("gdg-pane-convites");
+      const pessoasEl = document.getElementById("gdg-pane-pessoas");
+      const msgsEl = document.getElementById("gdg-pane-msgs");
+
+      function updatePaneVisibility(activeId) {
+        panes.forEach((pane) => {
+          const isActive = pane.getAttribute("data-tab-pane") === activeId;
+          pane.setAttribute("aria-hidden", String(!isActive));
+        });
+      }
+
+      function getCounts(project) {
+        if (!project) {
+          return { convites: 0, pessoas: 0 };
+        }
+        const convitesArr = Array.isArray(project.convites) ? project.convites : null;
+        if (convitesArr) {
+          const convites = convitesArr.length;
+          const pessoas = convitesArr.reduce((total, invite) => {
+            if (typeof invite?.total === "number" && !Number.isNaN(invite.total)) {
+              return total + invite.total;
+            }
+            const acomp = Array.isArray(invite?.acompanhantes) ? invite.acompanhantes.length : 0;
+            return total + 1 + acomp;
+          }, 0);
+          return { convites, pessoas };
+        }
+        const lista = Array.isArray(project.lista) ? project.lista.length : 0;
+        return { convites: lista, pessoas: lista };
+      }
+
+      function applyMetrics(project) {
+        const { convites, pessoas } = getCounts(project);
+        const mensagens = Array.isArray(project?.mensagens) ? project.mensagens.length : 0;
+        if (convitesEl) convitesEl.textContent = String(convites);
+        if (pessoasEl) pessoasEl.textContent = String(pessoas);
+        if (msgsEl) msgsEl.textContent = String(mensagens);
+      }
+
+      let currentProjectId = null;
+
+      subscribe("marco:project-selected", ({ project }) => {
+        currentProjectId = project?.id ?? null;
+        applyMetrics(project);
+      });
+
+      subscribe("marco:project-updated", ({ id, project }) => {
+        if (!id) return;
+        if (currentProjectId && id !== currentProjectId) return;
+        currentProjectId = project?.id ?? currentProjectId;
+        applyMetrics(project);
+      });
+
+      window.abas = function (id) {
+        updatePaneVisibility(id);
+      };
+
+      document.addEventListener("DOMContentLoaded", () => {
+        mountHeader("#gdg-header");
+        mountTabs("#gdg-tabs", { initial: "painel" });
+        mountEditor("#gdg-event-editor");
+        updatePaneVisibility("painel");
+      });
+    </script>
+  </body>
+</html>

--- a/tools/gestao-de-convidados/app_header.mjs
+++ b/tools/gestao-de-convidados/app_header.mjs
@@ -1,18 +1,25 @@
 // tools/gestao-de-convidados/app_header.mjs
-// Cabeçalho + Painel (somente UI) — consome funções do /shared
+// Cabeçalho + Painel (UI) — integra com o store e com o event bus compartilhado.
 
-import * as store from "../../shared/projectStore.js";   // init, listProjects, getProject, createProject, deleteProject, updateProject, exportProject (conforme seu shared)
+import * as store from "../../shared/projectStore.js";   // init, listProjects, getProject, createProject, deleteProject, updateProject, exportProject
 import * as inviteUtils from "../../shared/inviteUtils.js"; // opcional (reserva para futuras ações)
 import * as listUtils   from "../../shared/listUtils.js";   // opcional (reserva para futuras ações)
+import { publish, subscribe } from "../../shared/marcoBus.js";
 
 // ---------- helpers mínimos de UI ----------
-const $ = (root, sel) => root.querySelector(sel);
+const $ = (root, sel) => root?.querySelector?.(sel);
 const esc = (s) => (s ?? "").replace(/[&<>]/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;" }[c]));
-const fmtDate = (iso) => (iso ? new Date(iso + "T00:00:00").toLocaleDateString() : "—");
+const fmtDate = (iso) => {
+  if (!iso) return "—";
+  const d = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString();
+};
 const phoneDigits = (v) => { let d = (v || "").replace(/\D/g, ""); if (d.startsWith("55") && d.length > 11) d = d.slice(2); return d.slice(-11); };
 const phoneDisplay = (d) => !d ? "" : (d.length===11 ? `(${d.slice(0,2)}) ${d.slice(2,7)}-${d.slice(7)}` :
                                         d.length===10 ? `(${d.slice(0,2)}) ${d.slice(2,6)}-${d.slice(6)}` :
                                         d.length>2 ? `(${d.slice(0,2)}) ${d.slice(2)}` : d);
+const timeNow = () => Date.now();
 
 const css = `
 .ac-app{--bg:#fff;--fg:#111;--muted:#666;--line:#111;--radius:10px;--sp-3:12px;--brand:#111;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Arial;color:var(--fg);line-height:1.45}
@@ -148,18 +155,281 @@ const html = `
   </div>
 `;
 
-// ---------- lógica principal ----------
+// ---------- estado compartilhado ----------
 let currentRoot = null;
 let currentPanel = null;
 let currentBtn = null;
 let listenersBound = false;
+let busBound = false;
+let statusTimer = null;
+let setStatus = (text) => { if (currentRoot) { const st = $(currentRoot, "#status"); if (st) st.textContent = text; } };
 
-const globalToggleMenu = (state) => {
+let metaList = [];
+const projectCache = new Map();
+let activeIndex = -1;
+let activeMeta = null;
+let activeProject = null;
+
+const cloneProject = (data) => {
+  if (typeof globalThis.structuredClone === "function") {
+    try { return globalThis.structuredClone(data); } catch {}
+  }
+  return JSON.parse(JSON.stringify(data ?? null));
+};
+
+function getCounts(project){
+  if (!project) return { convites: 0, pessoas: 0 };
+  const convitesArr = Array.isArray(project.convites) ? project.convites : null;
+  if (convitesArr) {
+    const convites = convitesArr.length;
+    const pessoas = convitesArr.reduce((sum, invite) => {
+      if (typeof invite?.total === "number" && !Number.isNaN(invite.total)) return sum + invite.total;
+      const acomp = Array.isArray(invite?.acompanhantes) ? invite.acompanhantes.length : 0;
+      return sum + 1 + acomp;
+    }, 0);
+    return { convites, pessoas };
+  }
+  const lista = Array.isArray(project.lista) ? project.lista.length : 0;
+  return { convites: lista, pessoas: lista };
+}
+
+function metaFromProject(project){
+  const evento = project?.evento || {};
+  const counts = getCounts(project);
+  return {
+    id: project?.id,
+    nome: evento.nome || "Sem nome",
+    dataISO: evento.dataISO || "",
+    horario: evento.horario || "",
+    local: evento.local || "",
+    cidade: evento.endereco?.cidade || "",
+    uf: evento.endereco?.uf || "",
+    convites: counts.convites,
+    pessoas: counts.pessoas,
+    updatedAt: project?.updatedAt || timeNow(),
+    metaVersion: 2
+  };
+}
+
+async function ensureProjectCached(id){
+  if (!id) return null;
+  if (projectCache.has(id)) return projectCache.get(id);
+  const full = await store.getProject?.(id);
+  if (full) projectCache.set(id, full);
+  return full;
+}
+
+function announceSelection(){
+  if (!activeMeta || !activeProject) {
+    publish("marco:project-selected", { id: null, meta: null, project: null });
+    return;
+  }
+  publish("marco:project-selected", {
+    id: activeMeta.id,
+    meta: { ...activeMeta },
+    project: cloneProject(activeProject)
+  });
+}
+
+function publishList(){
+  publish("marco:project-list-changed", { list: metaList.map(m => ({ ...m })) });
+}
+
+function renderUserPanel(){
+  if (!currentRoot) return;
+  $(currentRoot, "#kpi-ev").textContent = String(metaList.length);
+  const totalConvites = metaList.reduce((sum, item) => sum + (item?.convites || 0), 0);
+  const totalPessoas = metaList.reduce((sum, item) => sum + (item?.pessoas || item?.convites || 0), 0);
+  $(currentRoot, "#kpi-convites").textContent = String(totalConvites);
+  $(currentRoot, "#kpi-pessoas").textContent = String(totalPessoas);
+
+  const tbody = $(currentRoot, "#user-last");
+  if (tbody) {
+    const rows = metaList.map(meta => {
+      const updated = meta.updatedAt ? new Date(meta.updatedAt).toLocaleString() : "—";
+      return `<tr><td>${esc(meta?.nome || "—")}</td><td>${fmtDate(meta?.dataISO)}</td><td>${meta?.convites || 0}</td><td>${updated}</td></tr>`;
+    }).join("");
+    tbody.innerHTML = rows || `<tr><td colspan="4" style="color:#666">Sem eventos.</td></tr>`;
+  }
+
+  const tbl = $(currentRoot, "#tbl-user");
+  const hint = $(currentRoot, "#user-hint");
+  if (tbl && hint && tbody) {
+    if (metaList.length > 3) {
+      tbl.classList.add("ac-table--scroll");
+      requestAnimationFrame(()=>{
+        const r = tbody.querySelector("tr");
+        const rh = r ? r.getBoundingClientRect().height : 36;
+        tbody.style.maxHeight = Math.round(rh*3 + 2) + "px";
+        hint.hidden = false;
+      });
+    } else {
+      tbl.classList.remove("ac-table--scroll");
+      tbody.style.maxHeight = "";
+      hint.hidden = true;
+    }
+  }
+
+  const foot = $(currentRoot, "#user-foot");
+  if (foot) foot.textContent = `${metaList.length} eventos`;
+}
+
+function renderModalList(){
+  if (!currentRoot) return;
+  const tb = $(currentRoot, "#tbl-evs");
+  if (!tb) return;
+  const rows = metaList.map((meta, idx) => {
+    const updated = meta.updatedAt ? new Date(meta.updatedAt).toLocaleString() : "—";
+    return `
+      <tr>
+        <td>${esc(meta?.nome || "—")}</td>
+        <td>${fmtDate(meta?.dataISO)}</td>
+        <td>${meta?.convites || 0}</td>
+        <td>${updated}</td>
+        <td><button class="ac-iconbtn" data-load="${idx}" title="Selecionar">→</button></td>
+      </tr>`;
+  }).join("");
+  tb.innerHTML = rows || `<tr><td colspan="5" style="color:#666">Nenhum evento salvo.</td></tr>`;
+}
+
+function renderEvento(){
+  if (!currentRoot) return;
+  if (!activeProject || !activeMeta) {
+    $(currentRoot, "#ev-title").textContent = "—";
+    $(currentRoot, "#ev-date").textContent = "—";
+    $(currentRoot, "#ev-time").textContent = "—";
+    $(currentRoot, "#ev-local").textContent = "—";
+    $(currentRoot, "#ev-convites").textContent = "0";
+    $(currentRoot, "#ev-pessoas").textContent = "0";
+    $(currentRoot, "#ev-msgs").textContent = "0";
+    $(currentRoot, "#ev-host").textContent = "—";
+    $(currentRoot, "#ev-host-contato").textContent = "—";
+    $(currentRoot, "#ev-end").textContent = "—";
+    return;
+  }
+  const evento = activeProject.evento || {};
+  const endereco = evento.endereco || {};
+  const counts = getCounts(activeProject);
+  const mensagens = Array.isArray(activeProject.mensagens) ? activeProject.mensagens.length : 0;
+  $(currentRoot, "#ev-title").textContent = evento.nome || "—";
+  $(currentRoot, "#ev-date").textContent = fmtDate(evento.dataISO);
+  $(currentRoot, "#ev-time").textContent = evento.horario || "—";
+  const cidadeUF = [endereco.cidade, endereco.uf].filter(Boolean).join("/");
+  $(currentRoot, "#ev-local").textContent = [evento.local, cidadeUF].filter(Boolean).join(", ") || "—";
+  $(currentRoot, "#ev-convites").textContent = String(counts.convites || 0);
+  $(currentRoot, "#ev-pessoas").textContent = String(counts.pessoas || 0);
+  $(currentRoot, "#ev-msgs").textContent = String(mensagens);
+
+  const host = evento.anfitriao || {};
+  $(currentRoot, "#ev-host").textContent = host.nome || "—";
+  const tel = phoneDigits(host.telefone || "");
+  const contato = [phoneDisplay(tel), host.email].filter(Boolean).join(" • ") || "—";
+  $(currentRoot, "#ev-host-contato").textContent = contato;
+
+  const enderecoParts = [
+    endereco.logradouro,
+    endereco.numero,
+    endereco.bairro,
+    endereco.cidade && endereco.uf ? `${endereco.cidade}/${endereco.uf}` : (endereco.cidade || endereco.uf || ""),
+    endereco.complemento,
+    endereco.cep
+  ].filter(Boolean);
+  const textoLivre = endereco.textoLivre ? endereco.textoLivre : "";
+  $(currentRoot, "#ev-end").textContent = enderecoParts.join(", ") || textoLivre || "—";
+}
+
+function fillSelect(){
+  if (!currentRoot) return;
+  const sel = $(currentRoot, "#ev-select");
+  if (!sel) return;
+  if (!metaList.length) {
+    sel.innerHTML = "";
+    sel.disabled = true;
+    return;
+  }
+  sel.disabled = false;
+  sel.innerHTML = metaList.map((meta, idx) => {
+    const linha = [meta?.nome || "—", meta?.dataISO || "—", [meta?.local, meta?.cidade, meta?.uf].filter(Boolean).join(" • ")].join(" • ");
+    return `<option value="${idx}">${esc(linha)}</option>`;
+  }).join("");
+  sel.value = activeIndex >= 0 ? String(activeIndex) : "0";
+}
+
+async function setActiveIndex(idx, { silent = false } = {}){
+  if (idx < 0 || idx >= metaList.length) {
+    activeIndex = -1;
+    activeMeta = null;
+    activeProject = null;
+    renderEvento();
+    if (!silent) announceSelection();
+    return;
+  }
+  activeIndex = idx;
+  activeMeta = metaList[idx];
+  const cached = await ensureProjectCached(activeMeta.id);
+  activeProject = cached ? cloneProject(cached) : null;
+  renderEvento();
+  if (!silent) announceSelection();
+}
+
+async function refreshIndex({ keepSelection = true } = {}){
+  const listRaw = (await (store.listProjects?.() ?? Promise.resolve([]))) || [];
+  const normalized = listRaw.map(item => ({
+    ...item,
+    updatedAt: item?.updatedAt ?? timeNow(),
+    convites: typeof item?.convites === "number" ? item.convites : 0,
+    pessoas: typeof item?.pessoas === "number" ? item.pessoas : (typeof item?.convites === "number" ? item.convites : 0),
+    metaVersion: item?.metaVersion ?? 1
+  })).filter(meta => meta?.id);
+  const ids = new Set(normalized.map(m => m.id));
+  for (const key of Array.from(projectCache.keys())) {
+    if (!ids.has(key)) projectCache.delete(key);
+  }
+  metaList = normalized;
+  await Promise.all(metaList.map(meta => ensureProjectCached(meta.id)));
+  fillSelect();
+  renderUserPanel();
+  renderModalList();
+  publishList();
+
+  if (!metaList.length) {
+    activeIndex = -1;
+    activeMeta = null;
+    activeProject = null;
+    renderEvento();
+    announceSelection();
+    return;
+  }
+
+  if (keepSelection && activeMeta) {
+    const idx = metaList.findIndex(m => m.id === activeMeta.id);
+    if (idx >= 0) {
+      activeMeta = metaList[idx];
+      const cached = await ensureProjectCached(activeMeta.id);
+      activeProject = cached ? cloneProject(cached) : null;
+      activeIndex = idx;
+      fillSelect();
+      renderEvento();
+      announceSelection();
+      return;
+    }
+  }
+
+  activeIndex = 0;
+  activeMeta = metaList[0];
+  const cached = await ensureProjectCached(activeMeta.id);
+  activeProject = cached ? cloneProject(cached) : null;
+  fillSelect();
+  renderEvento();
+  announceSelection();
+}
+
+function globalToggleMenu(state){
   if(!currentPanel || !currentBtn) return;
   const shouldOpen = typeof state === "boolean" ? state : currentPanel.hidden;
   currentPanel.hidden = !shouldOpen;
   currentBtn.setAttribute("aria-expanded", String(shouldOpen));
-};
+}
 
 function bindGlobalListeners(){
   if(listenersBound) return;
@@ -176,208 +446,199 @@ function bindGlobalListeners(){
   listenersBound = true;
 }
 
-const cloneProject = (data) => {
-  if(typeof globalThis.structuredClone === "function"){
-    return globalThis.structuredClone(data);
+function bindBusListeners(){
+  if (busBound) return;
+  subscribe("marco:project-updated", ({ id, project, meta }) => {
+    if (!id) return;
+    if (project) {
+      projectCache.set(id, cloneProject(project));
+      const derivedMeta = meta ? { ...meta } : metaFromProject(project);
+      const idx = metaList.findIndex(m => m.id === id);
+      if (idx >= 0) {
+        metaList[idx] = { ...metaList[idx], ...derivedMeta };
+      } else {
+        metaList.push(derivedMeta);
+      }
+      if (activeMeta?.id === id) {
+        activeMeta = metaList.find(m => m.id === id) || derivedMeta;
+        activeProject = cloneProject(project);
+        renderEvento();
+      }
+      renderUserPanel();
+      fillSelect();
+      renderModalList();
+      publishList();
+    } else if (meta) {
+      const idx = metaList.findIndex(m => m.id === id);
+      if (idx >= 0) {
+        metaList[idx] = { ...metaList[idx], ...meta };
+        renderUserPanel();
+        fillSelect();
+        renderModalList();
+        publishList();
+      }
+    }
+  });
+
+  subscribe("marco:request-project-refresh", async () => {
+    await refreshIndex({ keepSelection: true });
+  });
+
+  subscribe("marco:request-project-select", async ({ id }) => {
+    if (!id) return;
+    const idx = metaList.findIndex(m => m.id === id);
+    if (idx >= 0) {
+      if (currentRoot) {
+        const sel = $(currentRoot, "#ev-select");
+        if (sel) sel.value = String(idx);
+      }
+      await setActiveIndex(idx);
+    }
+  });
+
+  busBound = true;
+}
+
+async function createNew(){
+  const res = await store.createProject?.({});
+  if (res?.payload && res?.meta) {
+    projectCache.set(res.meta.id, cloneProject(res.payload));
   }
-  return JSON.parse(JSON.stringify(data));
-};
+  await refreshIndex({ keepSelection: false });
+  if (res?.meta?.id) {
+    const idx = metaList.findIndex(m => m.id === res.meta.id);
+    if (idx >= 0 && currentRoot) {
+      const sel = $(currentRoot, "#ev-select");
+      if (sel) sel.value = String(idx);
+      await setActiveIndex(idx, { silent: true });
+      announceSelection();
+    }
+  }
+  setStatus("Evento criado");
+}
+
+async function duplicateActive(){
+  if (!activeMeta) { setStatus("Sem evento ativo"); return; }
+  const base = projectCache.get(activeMeta.id) || await ensureProjectCached(activeMeta.id);
+  if (!base) { setStatus("Falha ao duplicar"); return; }
+  const clone = cloneProject(base);
+  delete clone.id;
+  clone.evento = clone.evento || {};
+  clone.evento.nome = (clone.evento.nome || activeMeta.nome || "Evento") + " (cópia)";
+  const res = await store.createProject?.(clone);
+  if (res?.payload && res?.meta) {
+    projectCache.set(res.meta.id, cloneProject(res.payload));
+  }
+  await refreshIndex({ keepSelection: false });
+  if (res?.meta?.id) {
+    const idx = metaList.findIndex(m => m.id === res.meta.id);
+    if (idx >= 0 && currentRoot) {
+      const sel = $(currentRoot, "#ev-select");
+      if (sel) sel.value = String(idx);
+      await setActiveIndex(idx);
+    }
+  }
+  setStatus("Duplicado");
+}
+
+async function deleteActive(){
+  if (!activeMeta) { setStatus("Sem evento ativo"); return; }
+  const ok = confirm("Excluir este evento? Esta ação não pode ser desfeita.");
+  if (!ok) return;
+  await store.deleteProject?.(activeMeta.id);
+  projectCache.delete(activeMeta.id);
+  setStatus("Excluído");
+  await refreshIndex({ keepSelection: false });
+}
+
+function bindMenu(root){
+  const panel = $(root, "#menu-panel"); const btn = $(root, "#btn-menu");
+  currentRoot = root;
+  currentPanel = panel;
+  currentBtn = btn;
+  btn?.addEventListener("click", ()=>globalToggleMenu());
+}
+
+async function handleSelectChange(value){
+  const idx = Number.parseInt(value, 10);
+  if (Number.isNaN(idx)) return;
+  await setActiveIndex(idx);
+  setStatus("Evento carregado");
+}
+
+function handleRootClicks(root, e){
+  if(e.target.matches('[data-action="fechar-modal"]')) $(root, "#modal").hidden = true;
+
+  const it = e.target.closest(".ac-dd__item");
+  if(it){
+    const act = it.getAttribute("data-action");
+    if(act==="novo")     createNew().catch(console.error);
+    if(act==="carregar") { renderModalList(); $(root, "#modal").hidden = false; }
+    if(act==="duplicar") duplicateActive().catch(console.error);
+    if(act==="deletar")  deleteActive().catch(console.error);
+    if(act==="imprimir") window.print();
+    globalToggleMenu(false);
+  }
+  const b = e.target.closest("[data-load]");
+  if(b){
+    const i = parseInt(b.getAttribute("data-load"),10);
+    if (!Number.isNaN(i)) {
+      if (currentRoot) {
+        const sel = $(currentRoot, "#ev-select");
+        if (sel) sel.value = String(i);
+      }
+      setActiveIndex(i).then(()=>{
+        $(root, "#modal").hidden = true;
+        setStatus("Evento carregado");
+      });
+    }
+  }
+}
 
 export async function render(rootEl){
-  // cria shell
   const root = document.createElement("div");
   root.className = "ac-app";
-  // injeta CSS escopado
   const style = document.createElement("style");
   style.textContent = css;
   root.appendChild(style);
-  // injeta HTML
   const host = document.createElement("div");
   host.innerHTML = html;
   root.appendChild(host);
   rootEl.replaceChildren(root);
 
-  const setStatus = (text) => {
-    const dot = $(root, "#dot");
-    const st  = $(root, "#status");
-    st.textContent = text;
-    dot.style.background = text.includes("Salv") ? "#d97706" : "#1a7f37";
-    clearTimeout(setStatus._t);
-    setStatus._t = setTimeout(()=>{ st.textContent = "Pronto"; dot.style.background = "#bbb"; }, 1600);
+  currentRoot = root;
+  const statusEl = $(root, "#status");
+  const dot = $(root, "#dot");
+  setStatus = (text) => {
+    if (statusEl) statusEl.textContent = text;
+    if (dot) {
+      dot.style.background = text.includes("Salv") || text.includes("carregado") ? "#d97706" : "#1a7f37";
+    }
+    clearTimeout(statusTimer);
+    statusTimer = setTimeout(()=>{
+      if (statusEl) statusEl.textContent = "Pronto";
+      if (dot) dot.style.background = "#bbb";
+    }, 1600);
   };
 
-  // dados
-  await (store.init?.() ?? Promise.resolve());
-  let lista = (await (store.listProjects?.() ?? Promise.resolve([]))) || [];
-  // se listProjects não retorna convites, a UI continua funcional (mostra 0/—)
-
-  let ativo = lista[0] || null;
-
-  // UI: select topo
-  const sel = $(root, "#ev-select");
-  function fillSelect(){
-    sel.innerHTML = (lista.map((e,i)=>
-      `<option value="${i}">${esc(e?.nome || "—")} • ${e?.dataISO || "—"} • ${esc(e?.local || "—")}</option>`
-    ).join("")) || "";
-    sel.selectedIndex = 0;
-  }
-
-  // métricas/linhas
-  const pessoasCount = (ev) => (ev?.convites || []).reduce((n, iv)=> n + 1 + (iv?.acompanhantes?.length || 0), 0);
-  function renderUserPanel(){
-    $(root, "#kpi-ev").textContent = String(lista.length);
-    $(root, "#kpi-convites").textContent = String(lista.reduce((n,ev)=> n + (ev?.convites?.length||0), 0));
-    $(root, "#kpi-pessoas").textContent  = String(lista.reduce((n,ev)=> n + pessoasCount(ev), 0));
-
-    const tbody = $(root, "#user-last");
-    const rows = lista.map(ev =>
-      `<tr><td>${esc(ev?.nome || "—")}</td><td>${fmtDate(ev?.dataISO)}</td><td>${ev?.convites?.length || 0}</td><td>${new Date(ev?.updatedAt||0).toLocaleString()}</td></tr>`
-    ).join("");
-    tbody.innerHTML = rows || `<tr><td colspan="4" style="color:#666">Sem eventos.</td></tr>`;
-
-    const tbl = $(root, "#tbl-user"); const hint = $(root, "#user-hint");
-    if(lista.length>3){
-      tbl.classList.add("ac-table--scroll");
-      requestAnimationFrame(()=>{
-        const r = tbody.querySelector("tr"); const rh = r ? r.getBoundingClientRect().height : 36;
-        tbody.style.maxHeight = Math.round(rh*3 + 2) + "px"; hint.hidden = false;
-      });
-    } else {
-      tbl.classList.remove("ac-table--scroll");
-      tbody.style.maxHeight = ""; hint.hidden = true;
-    }
-    $(root, "#user-foot").textContent = `${lista.length} eventos`;
-  }
-
-  async function renderEvento(){
-    if(!ativo){ $(root, "#ev-title").textContent="—"; return; }
-    // se precisar dados completos: const full = await store.getProject(ativo.id);
-    const ev = ativo;
-    $(root, "#ev-title").textContent = ev?.nome || "—";
-    $(root, "#ev-date").textContent  = fmtDate(ev?.dataISO);
-    $(root, "#ev-time").textContent  = ev?.horario || "—";
-    const cidadeUF = [ev?.endereco?.cidade, ev?.endereco?.uf].filter(Boolean).join("/");
-    $(root, "#ev-local").textContent = [ev?.local, cidadeUF].filter(Boolean).join(", ") || "—";
-    $(root, "#ev-convites").textContent = String(ev?.convites?.length || 0);
-    $(root, "#ev-pessoas").textContent  = String(pessoasCount(ev));
-    $(root, "#ev-msgs").textContent     = "0";
-    const end=[ev?.endereco?.logradouro,ev?.endereco?.numero,ev?.endereco?.bairro,
-               ev?.endereco?.cidade && ev?.endereco?.uf ? `${ev.endereco.cidade}/${ev.endereco.uf}` : (ev?.endereco?.cidade||"")]
-               .filter(Boolean).join(", ");
-    $(root, "#ev-end").textContent = end || "—";
-    $(root, "#ev-host").textContent = ev?.anfitriao?.nome || "—";
-    const tel = phoneDigits(ev?.anfitriao?.telefone || "");
-    $(root, "#ev-host-contato").textContent = [ phoneDisplay(tel), (ev?.anfitriao?.email||"") ].filter(Boolean).join(" • ") || "—";
-  }
-
-  // preencher e renderizar
-  fillSelect(); renderUserPanel(); renderEvento();
-
-  // select change
-  sel.addEventListener("change", (e)=>{
-    const i = parseInt(e.target.value,10);
-    ativo = lista[i] || ativo;
-    renderEvento();
-    setStatus("Evento carregado");
-  });
-
-  // menu
-  const panel = $(root, "#menu-panel"); const btn = $(root, "#btn-menu");
-  currentRoot = root;
-  currentPanel = panel;
-  currentBtn = btn;
-  btn.addEventListener("click", ()=>globalToggleMenu());
+  bindMenu(root);
   bindGlobalListeners();
+  bindBusListeners();
 
-  // modal carregar
-  function openModal(){
-    const tb = $(root, "#tbl-evs");
-    const rows = lista.map((ev,i)=>`
-      <tr>
-        <td>${esc(ev?.nome||"—")}</td>
-        <td>${fmtDate(ev?.dataISO)}</td>
-        <td>${ev?.convites?.length||0}</td>
-        <td>${new Date(ev?.updatedAt||0).toLocaleString()}</td>
-        <td><button class="ac-iconbtn" data-load="${i}" title="Selecionar">→</button></td>
-      </tr>`).join("");
-    tb.innerHTML = rows;
-    $(root, "#modal").hidden = false;
+  const sel = $(root, "#ev-select");
+  sel?.addEventListener("change", (e) => handleSelectChange(e.target.value));
+
+  root.addEventListener("click", (e)=> handleRootClicks(root, e));
+
+  await (store.init?.() ?? Promise.resolve());
+  await refreshIndex({ keepSelection: false });
+  if (metaList.length) {
+    await setActiveIndex(0, { silent: true });
+    announceSelection();
   }
-
-  root.addEventListener("click",(e)=>{
-    if(e.target.matches('[data-action="fechar-modal"]')) $(root, "#modal").hidden = true;
-
-    const it = e.target.closest(".ac-dd__item");
-    if(it){
-      const act = it.getAttribute("data-action");
-      if(act==="novo")     createNew().catch(console.error);
-      if(act==="carregar") openModal();
-      if(act==="duplicar") duplicateActive().catch(console.error);
-      if(act==="deletar")  deleteActive().catch(console.error);
-      if(act==="imprimir") window.print();
-      globalToggleMenu(false);
-    }
-    const b = e.target.closest("[data-load]");
-    if(b){
-      const i = parseInt(b.getAttribute("data-load"),10);
-      ativo = lista[i] || ativo;
-      sel.value = String(i);
-      renderEvento();
-      $(root, "#modal").hidden = true;
-      setStatus("Evento carregado");
-    }
-  });
-
-  async function refreshIndex(){
-    lista = (await (store.listProjects?.() ?? Promise.resolve([]))) || [];
-    fillSelect(); renderUserPanel(); // preserva 'ativo' se ainda existir
-    if(ativo){
-      const idx = lista.findIndex(e => e?.id === ativo.id);
-      if(idx >= 0) sel.value = String(idx);
-    }
-    await renderEvento();
-  }
-
-  async function duplicateActive(){
-    if(!ativo){ setStatus("Sem evento ativo"); return; }
-    const full = (await store.getProject?.(ativo.id)) || ativo;
-    // cria uma cópia rascunho
-    const clone = cloneProject(full);
-    delete clone.id; // força novo id
-    clone.evento = clone.evento || {};
-    clone.evento.nome = (clone.evento.nome || ativo.nome || "Evento") + " (cópia)";
-    const res = await store.createProject?.(clone);
-    setStatus("Duplicado");
-    await refreshIndex();
-    // seleciona a cópia como ativa
-    const novoId = res?.meta?.id;
-    const idx = lista.findIndex(e => e?.id === novoId);
-    if(idx >= 0){ ativo = lista[idx]; sel.value = String(idx); await renderEvento(); }
-  }
-
-  async function deleteActive(){
-    if(!ativo){ setStatus("Sem evento ativo"); return; }
-    const ok = confirm("Excluir este evento? Esta ação não pode ser desfeita.");
-    if(!ok) return;
-    await store.deleteProject?.(ativo.id);
-    setStatus("Excluído");
-    await refreshIndex();
-    ativo = lista[0] || null;
-    await renderEvento();
-  }
-
-  async function createNew(){
-    const res = await store.createProject?.({});
-    setStatus("Evento criado");
-    await refreshIndex();
-    const novoId = res?.meta?.id;
-    const idx = lista.findIndex(e => e?.id === novoId);
-    if(idx >= 0){
-      ativo = lista[idx];
-      sel.value = String(idx);
-      await renderEvento();
-    }
-  }
+  renderUserPanel();
+  renderModalList();
+  return root;
 }
 
 // atalho opcional: montar por seletor

--- a/tools/gestao-de-convidados/event_editor.mjs
+++ b/tools/gestao-de-convidados/event_editor.mjs
@@ -1,0 +1,365 @@
+// tools/gestao-de-convidados/event_editor.mjs
+// Editor de dados do evento + dados do cliente/cerimonialista.
+
+import * as store from "../../shared/projectStore.js";
+import { publish, subscribe } from "../../shared/marcoBus.js";
+
+const css = `
+.gce-root{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Arial;color:#111;line-height:1.4}
+.gce-root *{box-sizing:border-box}
+.gce-shell{border:1px solid #d4d4d8;border-radius:14px;padding:18px;background:#fff}
+.gce-title{margin:0 0 16px 0;font-weight:800;font-size:20px}
+.gce-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px}
+.gce-card{border:1px solid #e4e4e7;border-radius:12px;padding:16px;background:#fafafa}
+.gce-card h3{margin:0 0 12px 0;font-size:16px;font-weight:700}
+.gce-field{display:flex;flex-direction:column;gap:6px;margin-bottom:12px}
+.gce-field label{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.3px;color:#4b5563}
+.gce-field input,.gce-field textarea,.gce-field select{padding:10px 12px;border:1px solid #d4d4d8;border-radius:8px;font:inherit;background:#fff}
+.gce-field textarea{min-height:88px;resize:vertical}
+.gce-actions{margin-top:18px;display:flex;flex-wrap:wrap;gap:12px;align-items:center}
+.gce-btn{appearance:none;border:1px solid #111;background:#111;color:#fff;padding:10px 18px;border-radius:999px;font-weight:700;cursor:pointer;transition:background .2s,transform .2s}
+.gce-btn[disabled]{opacity:.4;cursor:not-allowed}
+.gce-btn--ghost{background:transparent;color:#111}
+.gce-status{font-size:12px;color:#4b5563}
+.gce-status--warn{color:#b45309}
+.gce-status--ok{color:#15803d}
+.gce-status--error{color:#b91c1c}
+.gce-two{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+.gce-form[aria-busy="true"]{opacity:.6;pointer-events:none}
+@media (max-width:640px){.gce-grid{grid-template-columns:1fr}}
+`;
+
+const template = `
+  <div class="gce-shell">
+    <h2 class="gce-title">Dados do evento &amp; cliente</h2>
+    <form id="evt-form" class="gce-form" autocomplete="off">
+      <div class="gce-grid">
+        <section class="gce-card" data-block="evento">
+          <h3>Evento</h3>
+          <div class="gce-field"><label for="evt-nome">Nome do evento</label><input id="evt-nome" data-field="evento.nome" required></div>
+          <div class="gce-two">
+            <div class="gce-field"><label for="evt-data">Data</label><input id="evt-data" type="date" data-field="evento.dataISO"></div>
+            <div class="gce-field"><label for="evt-hora">Horário</label><input id="evt-hora" type="time" data-field="evento.horario"></div>
+          </div>
+          <div class="gce-field"><label for="evt-local">Local</label><input id="evt-local" data-field="evento.local"></div>
+          <div class="gce-field"><label for="evt-descricao">Descrição / observações</label><textarea id="evt-descricao" data-field="evento.descricao"></textarea></div>
+        </section>
+
+        <section class="gce-card" data-block="endereco">
+          <h3>Endereço</h3>
+          <div class="gce-field"><label for="evt-logra">Logradouro</label><input id="evt-logra" data-field="evento.endereco.logradouro"></div>
+          <div class="gce-two">
+            <div class="gce-field"><label for="evt-numero">Número</label><input id="evt-numero" data-field="evento.endereco.numero"></div>
+            <div class="gce-field"><label for="evt-bairro">Bairro</label><input id="evt-bairro" data-field="evento.endereco.bairro"></div>
+          </div>
+          <div class="gce-two">
+            <div class="gce-field"><label for="evt-cidade">Cidade</label><input id="evt-cidade" data-field="evento.endereco.cidade"></div>
+            <div class="gce-field"><label for="evt-uf">UF</label><input id="evt-uf" maxlength="2" data-field="evento.endereco.uf"></div>
+          </div>
+          <div class="gce-two">
+            <div class="gce-field"><label for="evt-cep">CEP</label><input id="evt-cep" data-field="evento.endereco.cep" inputmode="numeric"></div>
+            <div class="gce-field"><label for="evt-comp">Complemento</label><input id="evt-comp" data-field="evento.endereco.complemento"></div>
+          </div>
+          <div class="gce-field"><label for="evt-endtexto">Referência / texto livre</label><textarea id="evt-endtexto" data-field="evento.endereco.textoLivre"></textarea></div>
+        </section>
+
+        <section class="gce-card" data-block="anfitriao">
+          <h3>Anfitriã(o)</h3>
+          <div class="gce-field"><label for="host-nome">Nome</label><input id="host-nome" data-field="evento.anfitriao.nome"></div>
+          <div class="gce-field"><label for="host-tel">Telefone</label><input id="host-tel" data-field="evento.anfitriao.telefone" inputmode="tel"></div>
+          <div class="gce-field"><label for="host-email">E-mail</label><input id="host-email" type="email" data-field="evento.anfitriao.email"></div>
+        </section>
+
+        <section class="gce-card" data-block="cliente">
+          <h3>Cerimonialista / Cliente</h3>
+          <div class="gce-field"><label for="cli-nome">Nome completo</label><input id="cli-nome" data-field="cerimonialista.nomeCompleto"></div>
+          <div class="gce-field"><label for="cli-tel">Telefone</label><input id="cli-tel" data-field="cerimonialista.telefone" inputmode="tel"></div>
+          <div class="gce-field"><label for="cli-rede">Rede social / @</label><input id="cli-rede" data-field="cerimonialista.redeSocial"></div>
+          <div class="gce-field"><label for="cli-email">E-mail</label><input id="cli-email" type="email" data-field="cerimonialista.email"></div>
+        </section>
+      </div>
+      <div class="gce-actions">
+        <button type="submit" class="gce-btn" id="btn-save" disabled>Salvar alterações</button>
+        <button type="button" class="gce-btn gce-btn--ghost" id="btn-reset" disabled>Descartar</button>
+        <span class="gce-status" id="gce-status">Selecione um evento para editar.</span>
+      </div>
+    </form>
+  </div>
+`;
+
+let currentRoot = null;
+let formEl = null;
+let saveBtn = null;
+let resetBtn = null;
+let statusEl = null;
+let dirty = false;
+let busy = false;
+let busBound = false;
+let currentProject = null;
+
+const cloneProject = (data) => {
+  if (typeof globalThis.structuredClone === "function") {
+    try { return globalThis.structuredClone(data); } catch {}
+  }
+  return JSON.parse(JSON.stringify(data ?? null));
+};
+
+const ensureString = (v) => (v == null ? "" : String(v));
+const cleanPhone = (v) => ensureString(v).replace(/\D+/g, "");
+
+function getCounts(project){
+  if (!project) return { convites: 0, pessoas: 0 };
+  const convitesArr = Array.isArray(project.convites) ? project.convites : null;
+  if (convitesArr) {
+    const convites = convitesArr.length;
+    const pessoas = convitesArr.reduce((sum, invite) => {
+      if (typeof invite?.total === "number" && !Number.isNaN(invite.total)) return sum + invite.total;
+      const acomp = Array.isArray(invite?.acompanhantes) ? invite.acompanhantes.length : 0;
+      return sum + 1 + acomp;
+    }, 0);
+    return { convites, pessoas };
+  }
+  const lista = Array.isArray(project.lista) ? project.lista.length : 0;
+  return { convites: lista, pessoas: lista };
+}
+
+function metaFromProject(project){
+  const evento = project?.evento || {};
+  const counts = getCounts(project);
+  return {
+    id: project?.id,
+    nome: evento.nome || "Sem nome",
+    dataISO: evento.dataISO || "",
+    horario: evento.horario || "",
+    local: evento.local || "",
+    cidade: evento.endereco?.cidade || "",
+    uf: evento.endereco?.uf || "",
+    convites: counts.convites,
+    pessoas: counts.pessoas,
+    updatedAt: project?.updatedAt || Date.now(),
+    metaVersion: 2
+  };
+}
+
+function setStatus(text, tone = "muted"){
+  if (!statusEl) return;
+  statusEl.textContent = text;
+  statusEl.classList.remove("gce-status--warn","gce-status--ok","gce-status--error");
+  if (tone === "warn") statusEl.classList.add("gce-status--warn");
+  else if (tone === "ok") statusEl.classList.add("gce-status--ok");
+  else if (tone === "error") statusEl.classList.add("gce-status--error");
+}
+
+function updateFormState(){
+  if (!formEl) return;
+  const disabled = !currentProject || busy;
+  formEl.setAttribute("aria-busy", busy ? "true" : "false");
+  formEl.querySelectorAll("[data-field]").forEach(input => {
+    input.disabled = disabled;
+  });
+  saveBtn.disabled = disabled || !dirty;
+  resetBtn.disabled = disabled || !dirty;
+}
+
+function markDirty(flag){
+  dirty = !!flag;
+  updateFormState();
+  if (dirty) setStatus("Alterações não salvas", "warn");
+}
+
+function clearForm(){
+  if (!formEl) return;
+  formEl.querySelectorAll("[data-field]").forEach(input => {
+    if (input.tagName === "INPUT" || input.tagName === "TEXTAREA") {
+      input.value = "";
+    }
+  });
+}
+
+function applyProjectToForm(project){
+  if (!formEl) return;
+  const evento = project?.evento || {};
+  const endereco = evento.endereco || {};
+  const anfitriao = evento.anfitriao || {};
+  const cerimonialista = project?.cerimonialista || {};
+  const setters = new Map([
+    ["evento.nome", ensureString(evento.nome)],
+    ["evento.dataISO", ensureString(evento.dataISO)],
+    ["evento.horario", ensureString(evento.horario)],
+    ["evento.local", ensureString(evento.local)],
+    ["evento.descricao", ensureString(evento.descricao)],
+    ["evento.endereco.logradouro", ensureString(endereco.logradouro)],
+    ["evento.endereco.numero", ensureString(endereco.numero)],
+    ["evento.endereco.bairro", ensureString(endereco.bairro)],
+    ["evento.endereco.cidade", ensureString(endereco.cidade)],
+    ["evento.endereco.uf", ensureString(endereco.uf)],
+    ["evento.endereco.cep", ensureString(endereco.cep)],
+    ["evento.endereco.complemento", ensureString(endereco.complemento)],
+    ["evento.endereco.textoLivre", ensureString(endereco.textoLivre)],
+    ["evento.anfitriao.nome", ensureString(anfitriao.nome)],
+    ["evento.anfitriao.telefone", ensureString(anfitriao.telefone)],
+    ["evento.anfitriao.email", ensureString(anfitriao.email)],
+    ["cerimonialista.nomeCompleto", ensureString(cerimonialista.nomeCompleto)],
+    ["cerimonialista.telefone", ensureString(cerimonialista.telefone)],
+    ["cerimonialista.redeSocial", ensureString(cerimonialista.redeSocial)],
+    ["cerimonialista.email", ensureString(cerimonialista.email)]
+  ]);
+  formEl.querySelectorAll("[data-field]").forEach(input => {
+    const key = input.getAttribute("data-field");
+    if (!setters.has(key)) return;
+    input.value = setters.get(key);
+  });
+}
+
+function readForm(){
+  if (!formEl) return null;
+  const val = (field) => {
+    const input = formEl.querySelector(`[data-field="${field}"]`);
+    if (!input) return "";
+    return input.value || "";
+  };
+  return {
+    evento: {
+      nome: val("evento.nome"),
+      dataISO: val("evento.dataISO"),
+      horario: val("evento.horario"),
+      local: val("evento.local"),
+      descricao: val("evento.descricao"),
+      endereco: {
+        logradouro: val("evento.endereco.logradouro"),
+        numero: val("evento.endereco.numero"),
+        bairro: val("evento.endereco.bairro"),
+        cidade: val("evento.endereco.cidade"),
+        uf: val("evento.endereco.uf"),
+        cep: val("evento.endereco.cep"),
+        complemento: val("evento.endereco.complemento"),
+        textoLivre: val("evento.endereco.textoLivre")
+      },
+      anfitriao: {
+        nome: val("evento.anfitriao.nome"),
+        telefone: cleanPhone(val("evento.anfitriao.telefone")),
+        email: val("evento.anfitriao.email")
+      }
+    },
+    cerimonialista: {
+      nomeCompleto: val("cerimonialista.nomeCompleto"),
+      telefone: cleanPhone(val("cerimonialista.telefone")),
+      redeSocial: val("cerimonialista.redeSocial"),
+      email: val("cerimonialista.email")
+    }
+  };
+}
+
+async function handleSubmit(e){
+  e.preventDefault();
+  if (!currentProject) return;
+  const payload = readForm();
+  busy = true;
+  updateFormState();
+  setStatus("Salvando alterações…");
+  try {
+    const updated = await store.updateProject(currentProject.id, payload);
+    currentProject = cloneProject(updated);
+    markDirty(false);
+    setStatus("Alterações salvas.", "ok");
+    publish("marco:project-updated", { id: currentProject.id, project: cloneProject(currentProject), meta: metaFromProject(currentProject) });
+  } catch (err) {
+    console.error(err);
+    setStatus("Não foi possível salvar. Tente novamente.", "error");
+  } finally {
+    busy = false;
+    updateFormState();
+  }
+}
+
+function handleInput(){
+  if (!currentProject) return;
+  markDirty(true);
+}
+
+function handleReset(){
+  if (!currentProject) return;
+  applyProjectToForm(currentProject);
+  markDirty(false);
+  setStatus("Alterações descartadas.");
+}
+
+function bindBus(){
+  if (busBound) return;
+  subscribe("marco:project-selected", ({ id, project }) => {
+    if (!id || !project) {
+      if (dirty && currentProject) {
+        setStatus("Seleção alterada. Alterações não salvas foram descartadas.", "warn");
+      } else {
+        setStatus("Selecione um evento para editar.");
+      }
+      currentProject = null;
+      dirty = false;
+      clearForm();
+      updateFormState();
+      return;
+    }
+    if (dirty && currentProject && currentProject.id !== id) {
+      const keep = confirm("Descartar alterações não salvas?");
+      if (!keep) {
+        publish("marco:request-project-select", { id: currentProject.id });
+        return;
+      }
+    }
+    currentProject = cloneProject(project);
+    applyProjectToForm(currentProject);
+    markDirty(false);
+    setStatus("Pronto para editar.", "ok");
+  });
+
+  subscribe("marco:project-updated", ({ id, project }) => {
+    if (!id || !project) return;
+    if (!currentProject || currentProject.id !== id) return;
+    currentProject = cloneProject(project);
+    if (!dirty) {
+      applyProjectToForm(currentProject);
+      setStatus("Dados atualizados.", "ok");
+    } else {
+      setStatus("Este evento foi alterado em outro local. Revise antes de salvar.", "warn");
+    }
+  });
+
+  busBound = true;
+}
+
+export function render(rootEl){
+  const root = document.createElement("div");
+  root.className = "gce-root";
+  const style = document.createElement("style");
+  style.textContent = css;
+  root.appendChild(style);
+  const host = document.createElement("div");
+  host.innerHTML = template;
+  root.appendChild(host);
+  rootEl.replaceChildren(root);
+
+  currentRoot = root;
+  formEl = root.querySelector("#evt-form");
+  saveBtn = root.querySelector("#btn-save");
+  resetBtn = root.querySelector("#btn-reset");
+  statusEl = root.querySelector("#gce-status");
+
+  bindBus();
+
+  formEl.addEventListener("submit", handleSubmit);
+  formEl.addEventListener("input", (e) => {
+    if (e.target.matches?.("[data-field]")) handleInput();
+  });
+  resetBtn.addEventListener("click", handleReset);
+
+  clearForm();
+  markDirty(false);
+  updateFormState();
+  return root;
+}
+
+export function mount(selector){
+  const el = document.querySelector(selector);
+  if(!el) throw new Error("Elemento não encontrado: " + selector);
+  return render(el);
+}

--- a/tools/gestao-de-convidados/nav_tabs.mjs
+++ b/tools/gestao-de-convidados/nav_tabs.mjs
@@ -1,0 +1,229 @@
+// tools/gestao-de-convidados/nav_tabs.mjs
+// Navegador principal de abas (Painel / Dados / Convidados / Mensagens / Relatórios).
+
+import { publish, subscribe } from "../../shared/marcoBus.js";
+
+const DEFAULT_TABS = [
+  { id: "painel", label: "Painel" },
+  { id: "dados-evento", label: "Dados do evento" },
+  { id: "convidados", label: "Convidados", badge: "convites" },
+  { id: "mensagens", label: "Mensagens", badge: "mensagens" },
+  { id: "relatorios", label: "Relatórios", badge: "relatorios" }
+];
+
+const css = `
+.gtn-root{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Arial;color:#111;line-height:1.45}
+.gtn-root *{box-sizing:border-box}
+.gtn-shell{border-bottom:1px solid #e5e7eb;background:#fff}
+.gtn-bar{display:flex;flex-wrap:wrap;gap:6px;padding:10px 0}
+.gtn-tab{appearance:none;border:1px solid transparent;background:transparent;padding:10px 16px;border-radius:999px;font-weight:600;cursor:pointer;position:relative;color:#111;transition:background .2s,color .2s,border .2s}
+.gtn-tab[aria-selected="true"]{background:#111;color:#fff;border-color:#111}
+.gtn-tab:not([aria-selected="true"]):hover{border-color:#111}
+.gtn-badge{display:inline-flex;align-items:center;justify-content:center;min-width:20px;padding:2px 6px;border-radius:999px;font-size:11px;margin-left:8px;background:rgba(17,17,17,.08);color:#111}
+.gtn-badge[hidden]{display:none}
+.gtn-info{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px;padding:12px 0;border-top:1px solid #f1f5f9}
+.gtn-current{min-width:240px}
+.gtn-name{font-size:18px;font-weight:800}
+.gtn-meta{display:flex;flex-wrap:wrap;gap:6px;font-size:12px;color:#6b7280;margin-top:4px}
+.gtn-pills{display:flex;flex-wrap:wrap;gap:8px}
+.gtn-pill{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;background:#f3f4f6;font-size:12px;color:#374151}
+.gtn-pill strong{font-size:14px}
+@media (max-width:640px){.gtn-bar{padding-bottom:0}.gtn-info{padding:14px 0 4px 0}}
+`;
+
+let currentRoot = null;
+let tabsConfig = DEFAULT_TABS;
+let activeTab = null;
+let busBound = false;
+let metrics = { convites: 0, pessoas: 0, mensagens: 0, relatorios: 0 };
+let currentMeta = { nome: "—", dataISO: "", horario: "", local: "", cidade: "", uf: "" };
+let currentProject = null;
+
+const fmtDate = (iso) => {
+  if (!iso) return "—";
+  const d = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString();
+};
+
+function getCounts(project){
+  if (!project) return { convites: 0, pessoas: 0 };
+  const convitesArr = Array.isArray(project.convites) ? project.convites : null;
+  if (convitesArr) {
+    const convites = convitesArr.length;
+    const pessoas = convitesArr.reduce((sum, invite) => {
+      if (typeof invite?.total === "number" && !Number.isNaN(invite.total)) return sum + invite.total;
+      const acomp = Array.isArray(invite?.acompanhantes) ? invite.acompanhantes.length : 0;
+      return sum + 1 + acomp;
+    }, 0);
+    return { convites, pessoas };
+  }
+  const lista = Array.isArray(project.lista) ? project.lista.length : 0;
+  return { convites: lista, pessoas: lista };
+}
+
+function updateBadges(){
+  if (!currentRoot) return;
+  tabsConfig.forEach(tab => {
+    if (!tab.badge) return;
+    const el = currentRoot.querySelector(`[data-badge-for="${tab.id}"]`);
+    if (!el) return;
+    const val = metrics[tab.badge] || 0;
+    if (val > 0) {
+      el.textContent = String(val);
+      el.hidden = false;
+    } else {
+      el.hidden = true;
+    }
+  });
+}
+
+function updateSummary(){
+  if (!currentRoot) return;
+  const { nome, dataISO, horario, local, cidade, uf } = currentMeta || {};
+  const nameEl = currentRoot.querySelector("#gtn-name");
+  const dateEl = currentRoot.querySelector("#gtn-date");
+  const localEl = currentRoot.querySelector("#gtn-local");
+  const convEl = currentRoot.querySelector("#gtn-convites");
+  const pesEl = currentRoot.querySelector("#gtn-pessoas");
+  const msgEl = currentRoot.querySelector("#gtn-msgs");
+  if (nameEl) nameEl.textContent = nome || "—";
+  if (dateEl) {
+    const datePieces = [fmtDate(dataISO), horario || "—"].filter(Boolean);
+    dateEl.textContent = datePieces.join(" • ") || "—";
+  }
+  if (localEl) {
+    const cityUF = [cidade, uf].filter(Boolean).join("/");
+    const loc = [local, cityUF].filter(Boolean).join(", ");
+    localEl.textContent = loc || "—";
+  }
+  if (convEl) convEl.textContent = String(metrics.convites || 0);
+  if (pesEl) pesEl.textContent = String(metrics.pessoas || 0);
+  if (msgEl) msgEl.textContent = String(metrics.mensagens || 0);
+  updateBadges();
+}
+
+function invokeAbas(tabId){
+  try {
+    if (typeof window !== "undefined" && typeof window.abas === "function") {
+      window.abas(tabId);
+    }
+  } catch (err) {
+    console.error("nav_tabs: falha ao chamar abas()", err);
+  }
+}
+
+function setActiveTab(tabId, { silent = false } = {}){
+  if (!currentRoot) return;
+  if (!tabsConfig.some(tab => tab.id === tabId)) return;
+  activeTab = tabId;
+  currentRoot.querySelectorAll("[data-tab]").forEach(btn => {
+    const isActive = btn.getAttribute("data-tab") === tabId;
+    btn.setAttribute("aria-selected", String(isActive));
+  });
+  if (!silent) {
+    publish("marco:tab-changed", { id: tabId });
+    invokeAbas(tabId);
+  }
+}
+
+function bindBus(){
+  if (busBound) return;
+  subscribe("marco:project-selected", ({ meta, project }) => {
+    currentProject = project || null;
+    currentMeta = meta || { nome: "—", dataISO: "", horario: "", local: "", cidade: "", uf: "" };
+    if (project) {
+      const counts = getCounts(project);
+      metrics.convites = counts.convites;
+      metrics.pessoas = counts.pessoas;
+      metrics.mensagens = Array.isArray(project.mensagens) ? project.mensagens.length : 0;
+      metrics.relatorios = Array.isArray(project.relatorios) ? project.relatorios.length : 0;
+    } else {
+      metrics = { convites: 0, pessoas: 0, mensagens: 0, relatorios: 0 };
+    }
+    updateSummary();
+  });
+
+  subscribe("marco:project-updated", ({ id, project, meta }) => {
+    if (!id) return;
+    if (project && currentProject && currentProject.id === id) {
+      currentProject = project;
+      currentMeta = meta || currentMeta;
+      const counts = getCounts(project);
+      metrics.convites = counts.convites;
+      metrics.pessoas = counts.pessoas;
+      metrics.mensagens = Array.isArray(project.mensagens) ? project.mensagens.length : 0;
+      metrics.relatorios = Array.isArray(project.relatorios) ? project.relatorios.length : 0;
+      updateSummary();
+    }
+  });
+
+  subscribe("marco:request-tab", ({ id }) => {
+    if (!id) return;
+    setActiveTab(id);
+  });
+
+  busBound = true;
+}
+
+export function render(rootEl, { tabs = DEFAULT_TABS, initial = null } = {}){
+  tabsConfig = Array.isArray(tabs) && tabs.length ? tabs : DEFAULT_TABS;
+  const root = document.createElement("div");
+  root.className = "gtn-root";
+  const style = document.createElement("style");
+  style.textContent = css;
+  root.appendChild(style);
+
+  const shell = document.createElement("div");
+  shell.className = "gtn-shell";
+
+  const nav = document.createElement("nav");
+  nav.className = "gtn-bar";
+  nav.setAttribute("role", "tablist");
+  nav.innerHTML = tabsConfig.map(tab => `
+    <button class="gtn-tab" type="button" role="tab" data-tab="${tab.id}" aria-selected="false">
+      <span>${tab.label}</span>
+      ${tab.badge ? `<span class="gtn-badge" data-badge-for="${tab.id}" hidden></span>` : ""}
+    </button>
+  `).join("");
+  shell.appendChild(nav);
+
+  const info = document.createElement("div");
+  info.className = "gtn-info";
+  info.innerHTML = `
+    <div class="gtn-current">
+      <div class="gtn-name" id="gtn-name">—</div>
+      <div class="gtn-meta"><span id="gtn-date">—</span><span>•</span><span id="gtn-local">—</span></div>
+    </div>
+    <div class="gtn-pills">
+      <span class="gtn-pill"><strong id="gtn-convites">0</strong> convites</span>
+      <span class="gtn-pill"><strong id="gtn-pessoas">0</strong> pessoas</span>
+      <span class="gtn-pill"><strong id="gtn-msgs">0</strong> agendamentos</span>
+    </div>
+  `;
+  shell.appendChild(info);
+
+  root.appendChild(shell);
+  rootEl.replaceChildren(root);
+  currentRoot = root;
+
+  bindBus();
+
+  nav.addEventListener("click", (e) => {
+    const btn = e.target.closest?.("[data-tab]");
+    if (!btn) return;
+    const id = btn.getAttribute("data-tab");
+    setActiveTab(id);
+  });
+
+  const initialTab = initial && tabsConfig.some(tab => tab.id === initial) ? initial : (tabsConfig[0]?.id || null);
+  if (initialTab) setActiveTab(initialTab, { silent: true });
+  updateSummary();
+  return root;
+}
+
+export function mount(selector, options){
+  const el = document.querySelector(selector);
+  if(!el) throw new Error("Elemento não encontrado: " + selector);
+  return render(el, options);
+}


### PR DESCRIPTION
## Summary
- add an app.html scaffolding page that mounts the Gestão de Convidados header, navigation tabs, and event editor together and wires window.abas
- expose a lightweight metrics sync in the demo shell so placeholder cards reflect the selected projeto
- simplify the shared ui.css to keep only neutral layout, responsiveness, and border helpers to avoid overriding host site styles

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8032784748320b3076a5a1e3776b9