### PR TITLE
Fix initial project creation when no events exist

### DIFF
--- a/embed/app_standalone.html
+++ b/embed/app_standalone.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Assistente Cerimonial — Gestão de Convites</title>
+    <meta
+      name="description"
+      content="Visualização standalone do Assistente Cerimonial — Gestão de Convites."
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+        background-color: #faf6f1;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        background: linear-gradient(180deg, #fdf4eb 0%, #fdfaf6 100%);
+        color: #2d2a32;
+      }
+
+      header {
+        padding: 2rem 1.5rem 1rem;
+        text-align: center;
+        background: transparent;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3vw, 2.4rem);
+        color: #f07b24;
+      }
+
+      header p {
+        margin: 0.5rem auto 0;
+        max-width: 52ch;
+        color: #5c5350;
+        line-height: 1.5;
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 0 1.5rem 3rem;
+      }
+
+      .ac-canvas {
+        width: min(1080px, 100%);
+        box-sizing: border-box;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem 1.5rem 3rem;
+        color: #7a726e;
+        font-size: 0.9rem;
+      }
+
+      footer a {
+        color: inherit;
+      }
+    </style>
+
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main/tools/gestao-de-convidados/app_header.mjs"
+    />
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main/shared/projectStore.js"
+    />
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main/shared/higienizarLista.mjs"
+    />
+  </head>
+  <body>
+    <header>
+      <h1>Assistente Cerimonial — Gestão de Convites</h1>
+      <p>
+        Visualize a primeira tela completa do aplicativo, com as abas e o painel
+        de convites carregados automaticamente a partir do CDN.
+      </p>
+    </header>
+
+    <main>
+      <div class="ac-canvas">
+        <div id="ac-root"></div>
+      </div>
+    </main>
+
+    <footer>
+      <small>
+        Dados salvos localmente no seu navegador. Você pode exportar/importar o
+        projeto quando quiser.
+      </small>
+    </footer>
+
+    <script type="module">
+      const CDN = 'https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main';
+      const SRC = `${CDN}/tools/gestao-de-convidados/app_header.mjs`;
+
+      async function boot() {
+        try {
+          const { render } = await import(SRC);
+          await render(document.getElementById('ac-root'));
+        } catch (error) {
+          console.warn('[AC] fallback cache-busting', error);
+          const { render } = await import(`${SRC}?t=${Date.now()}`);
+          await render(document.getElementById('ac-root'));
+        }
+      }
+
+      boot();
+    </script>
+
+    <noscript>Ative o JavaScript para usar a ferramenta.</noscript>
+  </body>
+</html>

--- a/shared/projectStore.js
+++ b/shared/projectStore.js
@@ -57,7 +57,13 @@ function ensureShape(p){
   p.cerimonialista ||= { nomeCompleto:"", telefone:"", redeSocial:"" };
 
   // Mantém endereco/anfitriao como OBJETOS (não strings)
-  p.evento ||= { nome:"", data:"", hora:"", local:"", endereco:{}, anfitriao:{} };
+  p.evento ||= {};
+  // Compatibilidade com versões anteriores que usavam "nome" como título
+  if (p.evento.nome && !p.evento.titulo) p.evento.titulo = p.evento.nome;
+  p.evento.titulo ||= "";
+  p.evento.data ||= "";
+  p.evento.hora ||= "";
+  p.evento.local ||= "";
   if (typeof p.evento.endereco !== "object" || p.evento.endereco === null) p.evento.endereco = {};
   if (typeof p.evento.anfitriao !== "object" || p.evento.anfitriao === null) p.evento.anfitriao = {};
 
@@ -68,7 +74,7 @@ function ensureShape(p){
   return p;
 }
 function toMeta(p){
-  return { id: p.id, nome: p.evento?.nome || "Sem nome", updatedAt: now() };
+  return { id: p.id, nome: p.evento?.titulo || p.evento?.nome || "Sem nome", updatedAt: now() };
 }
 
 // ---------- Cache do índice ----------
@@ -89,7 +95,7 @@ export async function createProject(data = {}){
     id,
     cerimonialista: data.cerimonialista || { nomeCompleto:"", telefone:"", redeSocial:"" },
     // aqui também garantimos objetos para endereco/anfitriao
-    evento: data.evento || { nome:"", data:"", hora:"", local:"", endereco:{}, anfitriao:{} },
+    evento: data.evento || { titulo:"", data:"", hora:"", local:"", endereco:{}, anfitriao:{} },
     lista: data.lista || [],
     tipos: data.tipos || [],
     modelos: data.modelos || {},
@@ -116,7 +122,7 @@ export async function updateProject(id, partial){
 
   const idx = indexCache || (await kvGet(INDEX_KEY)) || [];
   const i = idx.findIndex(x => x.id === id);
-  if (i >= 0) idx[i] = { ...idx[i], nome: next.evento?.nome || idx[i].nome, updatedAt: now() };
+  if (i >= 0) idx[i] = { ...idx[i], nome: next.evento?.titulo || next.evento?.nome || idx[i].nome, updatedAt: now() };
   indexCache = idx; await kvSet(INDEX_KEY, idx);
 
   return deep(next);

--- a/tools/gestao-de-convidados/app_header.mjs
+++ b/tools/gestao-de-convidados/app_header.mjs
@@ -3,7 +3,7 @@
 // - Shell + navegação
 // - Import dinâmico das views
 // - CSS mínimo namespaced (.ac-app) — tipografia herda do site
-import * as store from '/shared/projectStore.js';
+import * as store from '../../shared/projectStore.js';
 import { qs, on, mount, spinner, showToast, cssBase } from './ui/dom.mjs';
 
 const routes = {
@@ -99,15 +99,23 @@ function setActiveTab(tab) {
 }
 
 async function ensureProjectId() {
-  // Usa o primeiro projeto existente; caso não exista, cria um com mensagens/templates default.
+  // Usa o primeiro projeto existente; caso não exista, cria um inicial em branco.
   const list = await store.listProjects();
   if (list && list.length) {
     return list[0].id;
   }
-  const p = await store.createProject({
-    evento: { titulo: 'Meu Evento', local: '', data: '', hora: '' },
+  const { meta } = await store.createProject({
+    evento: {
+      titulo: 'Meu Evento',
+      local: '',
+      data: '',
+      hora: '',
+      endereco: { logradouro: '' },
+      anfitriao: { nome: '' },
+    },
   });
-  return p.id;
+  showToast('Projeto inicial criado. Preencha os dados do evento.', 'info');
+  return meta.id;
 }
 
 export { render };

--- a/tools/gestao-de-convidados/views/convites.mjs
+++ b/tools/gestao-de-convidados/views/convites.mjs
@@ -1,5 +1,5 @@
 // tools/gestao-de-convidados/views/convites.mjs
-import { higienizarLinha, higienizarLista } from '/shared/higienizarLista.mjs';
+import { higienizarLinha, higienizarLista } from '../../shared/higienizarLista.mjs';
 
 export async function render(root, ctx){
   const project = await ctx.store.getProject(ctx.projectId);


### PR DESCRIPTION
## Summary
- ensure project bootstrap returns the created project's id and seed data with a blank event
- normalize stored event shape to always include titulo/local/data/hora and map legacy nome values
- notify the user when an initial blank project is generated so they can fill in event details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d868d5d2a08320845c5c9202514c17