### PR TITLE
Redesign convite dashboard layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+

--- a/docs/gestao_convidados_vision.md
+++ b/docs/gestao_convidados_vision.md
@@ -1,0 +1,68 @@
+# Visão Técnica para o Aplicativo "Assistente Cerimonial"
+
+## Objetivo
+Entregar uma aplicação web modular que permita ao cerimonialista gerir eventos, convidados, convites, mensagens, agenda e relatórios em um fluxo coerente e responsivo, com suporte a operação offline parcial quando embutida no Elementor.
+
+## Stack Recomendada
+- **Base**: Aplicação front-end SPA em JavaScript moderno (ESM) hospedada em CDN.
+- **Framework**: Preact + Signals (leve e compatível com ambientes com restrições como Elementor) ou Lit para componentes Web nativos. Optar por Preact para melhor ecossistema.
+- **Estado**: Zustand ou Signals para store reativo. Persistência em `localStorage` com sincronização opcional via API REST (quando disponível).
+- **Build**: Vite para bundling, geração de módulos ESM e versão standalone (single HTML com assets embutidos via Rollup plugins).
+- **Estilização**: Tailwind (modo JIT) para agilidade + tokens customizados, gerando CSS purgado e inline no standalone.
+
+## Estrutura de Módulos
+1. **Shell Principal**
+   - Header com identificação do evento ativo e usuário.
+   - Tabs: Evento, Convidados, Convites, Mensagens & Agenda, Relatórios.
+   - Drawer lateral para navegação secundária e configurações.
+
+2. **Evento (Primeira Aba)**
+   - Formulário completo de dados do evento (nome, data, local, orçamento).
+   - Botão "Criar primeiro evento" exibido quando não houver eventos; cria rascunho e direciona ao formulário.
+   - Suporte a múltiplos eventos com seletor no header.
+
+3. **Convidados**
+   - Tabela com importação CSV e status.
+   - Filtros rápidos, bulk actions, status tracking.
+
+4. **Convites**
+   - Geração automática de convites (PDF/WhatsApp) com templates.
+   - Controle de envios e confirmações.
+
+5. **Mensagens & Agenda**
+   - Timeline de atividades com integração a notificações.
+   - Templates de mensagens reutilizáveis.
+
+6. **Relatórios**
+   - Dashboards com métricas (RSVP, orçamento, logística).
+   - Exportação para PDF.
+
+## Integrações e Persistência
+- **Shared Functions**: manter em `/shared` utilitários consumidos tanto pela versão CDN quanto pela standalone.
+- **API**: Interface REST (`/api/events`, `/api/guests`, etc.) opcional; fallback local garante funcionamento offline.
+- **Storage**: Estratégia `IndexedDB` (Dexie) para dados volumosos e sincronização quando online.
+
+## Fluxo de Desenvolvimento
+1. **Refactor** atual para módulos Preact + stores.
+2. **Implementar Estado Global**: eventos -> convidados -> convites.
+3. **Criar Seeds**: evento em branco ao iniciar; wizard para onboarding.
+4. **Testes**:
+   - Unitários com Vitest (stores, helpers).
+   - Componentes com Testing Library.
+   - E2E com Playwright em modo standalone.
+5. **Build Targets**:
+   - `standalone.html` com assets inline.
+   - `elementor.bundle.js` para embed (carrega via script único).
+6. **Automação**: GitHub Actions rodando lint, testes e build.
+
+## Plano de Entrega
+- **Sprint 1**: Setup build/tooling, conversão shell + aba Evento com criação inicial.
+- **Sprint 2**: Módulos Convidados/Convites com integração ao store.
+- **Sprint 3**: Mensagens & Agenda + Relatórios + exportações.
+- **Sprint 4**: Refinos UX, performance, acessibilidade, testes E2E completos.
+
+## Métricas de Sucesso
+- Carregamento inicial < 2s em conexão 4G.
+- Score Lighthouse > 90 em Performance, Accessibility, Best Practices.
+- 100% das ações críticas funcionais no modo offline (evento, convidado, convite).
+

--- a/embed/app_standalone.html
+++ b/embed/app_standalone.html
@@ -1,0 +1,1854 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Assistente Cerimonial — Gestão de Convites</title>
+    <meta
+      name="description"
+      content="Visualização standalone do Assistente Cerimonial — Gestão de Convites."
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+        background-color: #faf6f1;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        background: linear-gradient(180deg, #fdf4eb 0%, #fdfaf6 100%);
+        color: #2d2a32;
+      }
+
+      header {
+        padding: 2rem 1.5rem 1rem;
+        text-align: center;
+        background: transparent;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3vw, 2.4rem);
+        color: #f07b24;
+      }
+
+      header p {
+        margin: 0.5rem auto 0;
+        max-width: 52ch;
+        color: #5c5350;
+        line-height: 1.5;
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 0 1.5rem 3rem;
+      }
+
+      .ac-canvas {
+        width: min(1080px, 100%);
+        box-sizing: border-box;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem 1.5rem 3rem;
+        color: #7a726e;
+        font-size: 0.9rem;
+      }
+
+      footer a {
+        color: inherit;
+      }
+
+      /* ===== App styles (namespaced) ===== */
+      .ac-app {
+        background: #ffffff;
+        border-radius: 16px;
+        box-shadow: 0 16px 40px -24px rgba(36, 25, 22, 0.45);
+        padding: 24px;
+        box-sizing: border-box;
+        border: 1px solid rgba(240, 123, 36, 0.2);
+      }
+
+      .ac-app .ac-shell {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .ac-app .ac-header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: center;
+      }
+
+      .ac-app .ac-header h2 {
+        margin: 0;
+        font-size: 1.4rem;
+        color: #f07b24;
+      }
+
+      .ac-app .ac-tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .ac-app .ac-tabs a {
+        padding: 6px 12px;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        text-decoration: none;
+        color: inherit;
+        transition: all 0.2s ease;
+      }
+
+      .ac-app .ac-tabs a:hover {
+        border-color: rgba(240, 123, 36, 0.4);
+        background: rgba(240, 123, 36, 0.08);
+      }
+
+      .ac-app .ac-tabs a.active {
+        border-color: rgba(240, 123, 36, 0.9);
+        background: rgba(240, 123, 36, 0.12);
+      }
+
+      .ac-app .ac-status {
+        margin-left: auto;
+        font-size: 0.85rem;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: #fff3e8;
+        border: 1px solid rgba(240, 123, 36, 0.2);
+        color: #a44a09;
+      }
+
+      .ac-app .ac-section-block {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .ac-app .ac-grid-2 {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+      }
+
+      .ac-app .ac-grid-3 {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 16px;
+      }
+
+      .ac-app .ac-card {
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        border-radius: 14px;
+        padding: 18px;
+        background: #fff;
+        box-shadow: 0 6px 20px -18px rgba(16, 5, 2, 0.35);
+      }
+
+      .ac-app .ac-dashboard {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      .ac-app .ac-dashboard__top {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: stretch;
+        gap: 16px;
+      }
+
+      .ac-app .ac-status-grid {
+        flex: 2;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+      }
+
+      .ac-app .ac-status-card {
+        background: #fff9f4;
+        border: 1px solid rgba(240, 123, 36, 0.25);
+        border-radius: 16px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .ac-app .ac-status-label {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: rgba(94, 52, 10, 0.8);
+      }
+
+      .ac-app .ac-status-card strong {
+        font-size: 1.7rem;
+        color: #f07b24;
+        line-height: 1;
+      }
+
+      .ac-app .ac-status-card small {
+        color: rgba(0, 0, 0, 0.55);
+        font-size: 0.85rem;
+      }
+
+      .ac-app .ac-summary-card {
+        flex: 1;
+        min-width: 280px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .ac-app .ac-summary-card header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      .ac-app .ac-summary-card h4 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .ac-app .ac-summary-sub {
+        margin: 6px 0 0;
+        font-size: 0.95rem;
+        color: rgba(0, 0, 0, 0.65);
+      }
+
+      .ac-app .ac-summary-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 12px;
+        border-radius: 999px;
+        background: #fff3e6;
+        color: #b25b12;
+        font-size: 0.8rem;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      .ac-app .ac-summary-card dl {
+        margin: 0;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px 16px;
+        font-size: 0.95rem;
+      }
+
+      .ac-app .ac-summary-card dt {
+        font-weight: 600;
+        color: rgba(0, 0, 0, 0.58);
+      }
+
+      .ac-app .ac-summary-card dd {
+        margin: 0;
+      }
+
+      .ac-app .ac-form-card {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+
+      .ac-app .ac-form-card h4 {
+        margin: 0;
+      }
+
+      .ac-app .ac-form-card label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 0.95rem;
+      }
+
+      .ac-app .ac-form-inline {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .ac-app textarea,
+      .ac-app input,
+      .ac-app select {
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        font: inherit;
+      }
+
+      .ac-app textarea {
+        resize: vertical;
+      }
+
+      .ac-app button {
+        padding: 8px 12px;
+        border-radius: 8px;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        background: #fff;
+        cursor: pointer;
+        font: inherit;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      .ac-app button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 24px -20px rgba(0, 0, 0, 0.8);
+      }
+
+      .ac-app button.ac-primary {
+        background: linear-gradient(135deg, #f07b24, #ff9c4f);
+        color: #fff;
+        border: none;
+      }
+
+      .ac-app button.ac-danger {
+        background: #fff2f2;
+        border-color: rgba(208, 77, 77, 0.35);
+        color: #d04d4d;
+      }
+
+      .ac-app .ac-actions,
+      .ac-app .ac-form-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .ac-app .ac-form-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .ac-app .ac-table-wrap {
+        overflow-x: auto;
+        border-radius: 12px;
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        background: #fff;
+      }
+
+      .ac-app table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .ac-app th,
+      .ac-app td {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+        padding: 10px;
+        text-align: left;
+      }
+
+      .ac-app th {
+        background: #fff8f2;
+        font-weight: 600;
+      }
+
+      .ac-app .ac-actions-col {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .ac-app .ac-spinner {
+        padding: 24px;
+        text-align: center;
+        color: #a44a09;
+      }
+
+      .ac-app .ac-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25em 0.75em;
+        border-radius: 999px;
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        font-size: 0.82rem;
+        text-transform: capitalize;
+      }
+
+      .ac-app .ac-badge--pendente {
+        background: #fffbee;
+      }
+
+      .ac-app .ac-badge--confirmado_total {
+        background: #ebffe9;
+      }
+
+      .ac-app .ac-badge--confirmado_parcial {
+        background: #f3fff7;
+      }
+
+      .ac-app .ac-badge--ausente {
+        background: #fff0f0;
+      }
+
+      .ac-app .ac-drawer {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+      }
+
+      .ac-app .ac-drawer__overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.45);
+      }
+
+      .ac-app .ac-drawer__panel {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(520px, 100%);
+        background: #fff;
+        display: flex;
+        flex-direction: column;
+        box-shadow: -12px 0 32px -24px rgba(0, 0, 0, 0.6);
+      }
+
+      .ac-app .ac-drawer__header,
+      .ac-app .ac-drawer__footer {
+        padding: 16px;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .ac-app .ac-drawer__footer {
+        border-bottom: none;
+        border-top: 1px solid rgba(0, 0, 0, 0.06);
+        justify-content: flex-end;
+      }
+
+      .ac-app .ac-drawer__content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .ac-app .ac-fieldset {
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        border-radius: 12px;
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .ac-app .ac-rsvp {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .ac-app .ac-modelos {
+        display: grid;
+        gap: 12px;
+      }
+
+      .ac-app .ac-modelo {
+        border: 1px dashed rgba(240, 123, 36, 0.3);
+        border-radius: 10px;
+        padding: 12px;
+        background: #fff9f5;
+        display: grid;
+        gap: 6px;
+      }
+
+      .ac-app .ac-pre {
+        white-space: pre-wrap;
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        font-size: 0.9rem;
+        color: #40312d;
+      }
+
+      .ac-app .ac-muted {
+        opacity: 0.7;
+        font-size: 0.88rem;
+      }
+
+      @media (max-width: 960px) {
+        .ac-app .ac-grid-3 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (max-width: 860px) {
+        main {
+          padding-inline: 0.75rem;
+        }
+
+        .ac-app {
+          padding: 20px;
+        }
+
+        .ac-app .ac-grid-2,
+        .ac-app .ac-form-grid,
+        .ac-app .ac-grid-3,
+        .ac-app .ac-rsvp {
+          grid-template-columns: 1fr;
+        }
+
+        .ac-app .ac-form-inline {
+          grid-template-columns: 1fr;
+        }
+
+        .ac-app .ac-dashboard__top {
+          flex-direction: column;
+        }
+
+        .ac-app .ac-tabs {
+          width: 100%;
+        }
+
+        .ac-app .ac-status {
+          margin-left: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Assistente Cerimonial — Gestão de Convites</h1>
+      <p>
+        Visualize a primeira tela completa do aplicativo, com as abas e o painel
+        de convites carregados automaticamente a partir do CDN.
+      </p>
+    </header>
+
+    <main>
+      <div class="ac-canvas">
+        <div id="ac-root"></div>
+      </div>
+    </main>
+
+    <footer>
+      <small>
+        Dados salvos localmente no seu navegador. Você pode exportar/importar o
+        projeto quando quiser.
+      </small>
+    </footer>
+
+    <script type="module">
+      const CDN_SHARED = 'https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main/shared';
+
+      bootStandalone();
+
+      async function bootStandalone() {
+        const root = document.getElementById('ac-root');
+        if (!root) return;
+
+        updateRootStatus(root, 'Carregando módulos…');
+
+        try {
+          const [store, listaUtils] = await Promise.all([
+            import(`${CDN_SHARED}/projectStore.js`),
+            import(`${CDN_SHARED}/higienizarLista.mjs`),
+          ]);
+
+          const ctx = {
+            store,
+            higienizarLinha: listaUtils.higienizarLinha,
+            higienizarLista: listaUtils.higienizarLista,
+          };
+
+          await renderApp(root, ctx);
+        } catch (err) {
+          console.error('[AC] Falha ao carregar módulos compartilhados', err);
+          root.innerHTML = `<p>Não foi possível carregar os módulos compartilhados. Verifique a conexão.</p>`;
+        }
+      }
+
+      function updateRootStatus(root, message) {
+        root.innerHTML = `<div class="ac-app"><div class="ac-spinner">${message}</div></div>`;
+      }
+
+      async function renderApp(root, sharedCtx) {
+        const shell = document.createElement('div');
+        shell.className = 'ac-app';
+        shell.innerHTML = `
+          <div class="ac-shell">
+            <header class="ac-header">
+              <h2>Assistente Cerimonial — V5</h2>
+              <nav class="ac-tabs" aria-label="Seções do assistente">
+                <a href="#convites" data-tab="convites" class="active">Convites</a>
+                <a href="#evento" data-tab="evento">Evento</a>
+                <a href="#agenda" data-tab="agenda">Mensagens & Agenda</a>
+                <a href="#relatorio" data-tab="relatorio">Relatório</a>
+              </nav>
+              <div class="ac-status" id="ac-status">Carregado</div>
+            </header>
+            <main id="ac-main" aria-live="polite">${spinner()}</main>
+          </div>
+        `;
+
+        root.innerHTML = '';
+        root.appendChild(shell);
+
+        const main = shell.querySelector('#ac-main');
+        const statusEl = shell.querySelector('#ac-status');
+        const state = {
+          currentTab: 'convites',
+          currentDestroy: null,
+          projectId: null,
+        };
+
+        const setStatus = (msg, type = 'info') => {
+          if (!statusEl) return;
+          statusEl.textContent = msg;
+          statusEl.dataset.type = type;
+        };
+
+        const navigate = async (tab) => {
+          if (!views[tab]) {
+            console.warn('[AC] tab desconhecida', tab);
+            return;
+          }
+          state.currentTab = tab;
+          setActiveTab(shell, tab);
+          main.innerHTML = spinner();
+          setStatus(`Carregando ${tab}…`);
+
+          try {
+            if (!state.projectId) {
+              state.projectId = await ensureProjectId(sharedCtx.store, setStatus);
+            }
+
+            if (typeof state.currentDestroy === 'function') {
+              state.currentDestroy();
+              state.currentDestroy = null;
+            }
+
+            const viewCtx = {
+              store: sharedCtx.store,
+              higienizarLinha: sharedCtx.higienizarLinha,
+              higienizarLista: sharedCtx.higienizarLista,
+              projectId: state.projectId,
+              navigate,
+              setStatus,
+            };
+
+            const view = views[tab];
+            await view.render(main, viewCtx);
+            state.currentDestroy = view.destroy || null;
+            setStatus('Pronto');
+          } catch (error) {
+            console.error('[AC] erro ao navegar', error);
+            main.innerHTML = `<p>Falha ao carregar a tela. Veja o console para detalhes.</p>`;
+            setStatus('Erro ao carregar', 'error');
+          }
+        };
+
+        bindHeaderNav(shell, navigate);
+        window.addEventListener('hashchange', () => {
+          const tab = getTabFromHash();
+          if (tab) navigate(tab);
+        });
+
+        await sharedCtx.store.init?.();
+        const initialTab = getTabFromHash() || state.currentTab;
+        await navigate(initialTab);
+      }
+
+      function spinner() {
+        return '<div class="ac-spinner" role="status">Carregando…</div>';
+      }
+
+      function setActiveTab(shell, tab) {
+        const links = shell.querySelectorAll('.ac-tabs a[data-tab]');
+        links.forEach((a) => {
+          a.classList.toggle('active', a.dataset.tab === tab);
+        });
+      }
+
+      function bindHeaderNav(shell, navigate) {
+        shell.addEventListener('click', (evt) => {
+          const link = evt.target.closest('a[data-tab]');
+          if (!link) return;
+          evt.preventDefault();
+          const tab = link.dataset.tab;
+          history.replaceState(null, '', `#${tab}`);
+          navigate(tab);
+        });
+      }
+
+      function getTabFromHash() {
+        return location.hash ? location.hash.replace('#', '') : null;
+      }
+
+      async function ensureProjectId(store, setStatus) {
+        const list = await store.listProjects?.();
+        if (list && list.length) {
+          return list[0].id;
+        }
+        setStatus('Criando projeto inicial…');
+        const { meta } = await store.createProject({
+          evento: {
+            titulo: 'Meu Evento',
+            local: '',
+            data: '',
+            hora: '',
+            endereco: { logradouro: '' },
+            anfitriao: { nome: '' },
+          },
+        });
+        setStatus('Projeto inicial criado. Preencha os dados do evento.', 'info');
+        return meta.id;
+      }
+
+      const views = {
+        convites: {
+          async render(root, ctx) {
+            let project = await ctx.store.getProject(ctx.projectId);
+            let lista = Array.isArray(project?.lista) ? project.lista : [];
+
+            mountConviteDashboard(root, project, lista);
+
+            const tbody = root.querySelector('#ac-rows');
+            const drawerHost = root.querySelector('#drawer');
+            lista.forEach((item) => tbody.appendChild(renderConviteRow(item)));
+
+            const refs = collectConviteRefs(root);
+            updateConviteStats(refs, lista);
+            updateConviteSummary(refs, project);
+
+            root.querySelector('#ac-import').addEventListener('click', async () => {
+              const txt = root.querySelector('#ac-paste').value.trim();
+              if (!txt) return;
+
+              const res = txt.includes('\n')
+                ? ctx.higienizarLista(txt)
+                : { convidados: [ctx.higienizarLinha(txt)] };
+
+              const now = Date.now();
+              const novos = res.convidados.map((g) => ({
+                id: crypto.randomUUID(),
+                envio: { enviado: false, enviadoEm: null, modeloId: null },
+                rsvp: {
+                  status: 'pendente',
+                  confirmadosN: 0,
+                  confirmadosNomes: [],
+                  observacao: '',
+                  atualizadoEm: now,
+                },
+                ...g,
+              }));
+
+              const listaNova = [...lista, ...novos];
+              await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
+              lista = listaNova;
+              project.lista = listaNova;
+
+              novos.forEach((n) => tbody.appendChild(renderConviteRow(n)));
+              root.querySelector('#ac-paste').value = '';
+              updateConviteStats(refs, lista);
+              updateConviteSummary(refs, project);
+              ctx.setStatus?.(`${novos.length} convite(s) adicionados.`);
+            });
+
+            root.querySelector('#single-add').addEventListener('click', async () => {
+              const nome = root.querySelector('#single-nome').value.trim();
+              const tel = root.querySelector('#single-tel').value.trim();
+              if (!nome && !tel) return;
+
+              const item = ctx.higienizarLinha(`${nome} | ${tel}`);
+              const novo = {
+                id: crypto.randomUUID(),
+                envio: { enviado: false, enviadoEm: null, modeloId: null },
+                rsvp: {
+                  status: 'pendente',
+                  confirmadosN: 0,
+                  confirmadosNomes: [],
+                  observacao: '',
+                  atualizadoEm: Date.now(),
+                },
+                ...item,
+              };
+
+              const listaNova = [...lista, novo];
+              await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
+              lista = listaNova;
+              project.lista = listaNova;
+
+              tbody.appendChild(renderConviteRow(novo));
+              root.querySelector('#single-nome').value = '';
+              root.querySelector('#single-tel').value = '';
+              updateConviteStats(refs, lista);
+              updateConviteSummary(refs, project);
+              ctx.setStatus?.('Convite adicionado.');
+            });
+
+            tbody.addEventListener('click', async (evt) => {
+              const btn = evt.target.closest('button[data-action]');
+              if (!btn) return;
+
+              const tr = btn.closest('tr');
+              const id = tr.dataset.id;
+              const proj = await ctx.store.getProject(ctx.projectId);
+              const idx = (proj.lista || []).findIndex((x) => x.id === id);
+              if (idx < 0) return;
+              const item = proj.lista[idx];
+
+              if (btn.dataset.action === 'editar') {
+                openDrawer(drawerHost, item, async (next) => {
+                  proj.lista[idx] = next;
+                  const updated = await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
+                  lista = updated.lista || [];
+                  project.lista = lista;
+                  tr.replaceWith(renderConviteRow(next));
+                  updateConviteStats(refs, lista);
+                  updateConviteSummary(refs, project);
+                  ctx.setStatus?.('Convite atualizado.');
+                });
+              }
+
+              if (btn.dataset.action === 'confirmar') {
+                item.rsvp.confirmadosN = item.totalConvite;
+                item.rsvp.confirmadosNomes = [
+                  item.principal,
+                  ...(item.acompanhantesNomes || []),
+                ].filter(Boolean);
+                item.rsvp.status = 'confirmado_total';
+                item.rsvp.atualizadoEm = Date.now();
+                proj.lista[idx] = item;
+                const updated = await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
+                lista = updated.lista || [];
+                project.lista = lista;
+                tr.replaceWith(renderConviteRow(item));
+                updateConviteStats(refs, lista);
+                updateConviteSummary(refs, project);
+                ctx.setStatus?.('Convite confirmado.');
+              }
+
+              if (btn.dataset.action === 'ausente') {
+                item.rsvp.confirmadosN = 0;
+                item.rsvp.confirmadosNomes = [];
+                item.rsvp.status = 'ausente';
+                item.rsvp.atualizadoEm = Date.now();
+                proj.lista[idx] = item;
+                const updated = await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
+                lista = updated.lista || [];
+                project.lista = lista;
+                tr.replaceWith(renderConviteRow(item));
+                updateConviteStats(refs, lista);
+                updateConviteSummary(refs, project);
+                ctx.setStatus?.('Convite marcado como ausente.');
+              }
+
+              if (btn.dataset.action === 'enviar') {
+                item.envio.enviado = true;
+                item.envio.enviadoEm = Date.now();
+                proj.lista[idx] = item;
+                const updated = await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
+                lista = updated.lista || [];
+                project.lista = lista;
+                tr.replaceWith(renderConviteRow(item));
+                updateConviteStats(refs, lista);
+                updateConviteSummary(refs, project);
+                ctx.setStatus?.('Envio marcado.');
+              }
+
+              if (btn.dataset.action === 'excluir') {
+                if (!confirm('Excluir este convite?')) return;
+                proj.lista.splice(idx, 1);
+                const updated = await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
+                lista = updated.lista || [];
+                project.lista = lista;
+                tr.remove();
+                updateConviteStats(refs, lista);
+                updateConviteSummary(refs, project);
+                ctx.setStatus?.('Convite removido.');
+              }
+            });
+
+            bindConviteForms(root, ctx, refs, {
+              get: () => project,
+              set: (next) => {
+                project = next;
+              },
+            });
+          },
+          destroy() {},
+        },
+        evento: {
+          async render(root, ctx) {
+            const project = await ctx.store.getProject(ctx.projectId);
+            const ev = project?.evento || {};
+            root.innerHTML = `
+              <section class="ac-section-block">
+                <h3>Evento</h3>
+                <div class="ac-form-grid">
+                  <label>Título <input id="ev-titulo" value="${ev.titulo || ''}" placeholder="Ex.: Casamento Ana & João" /></label>
+                  <label>Data <input id="ev-data" type="date" value="${ev.data || ''}" /></label>
+                  <label>Hora <input id="ev-hora" type="time" value="${ev.hora || ''}" /></label>
+                  <label>Local <input id="ev-local" value="${ev.local || ''}" placeholder="Ex.: Espaço Jardim" /></label>
+                  <label>Endereço (opcional) <input id="ev-end" value="${(ev.endereco?.logradouro || '')}" placeholder="Rua, número..." /></label>
+                </div>
+                <div class="ac-actions">
+                  <button id="ev-salvar" class="ac-primary">Salvar evento</button>
+                </div>
+              </section>
+            `;
+
+            root.querySelector('#ev-salvar').addEventListener('click', async () => {
+              const next = {
+                titulo: root.querySelector('#ev-titulo').value.trim(),
+                data: root.querySelector('#ev-data').value,
+                hora: root.querySelector('#ev-hora').value,
+                local: root.querySelector('#ev-local').value.trim(),
+                endereco: { logradouro: root.querySelector('#ev-end').value.trim() },
+              };
+              await ctx.store.updateProject(ctx.projectId, { evento: next });
+              ctx.setStatus('Evento salvo.');
+              alert('Evento salvo!');
+            });
+          },
+          destroy() {},
+        },
+        agenda: {
+          async render(root, ctx) {
+            const project = await ctx.store.getProject(ctx.projectId);
+            if (!project.mensagens || !project.mensagens.modelos || project.mensagens.modelos.length === 0) {
+              await ctx.store.updateProject(ctx.projectId, { mensagens: { modelos: DEFAULT_TEMPLATES } });
+            }
+            const fresh = await ctx.store.getProject(ctx.projectId);
+            const modelos = fresh.mensagens.modelos;
+
+            root.innerHTML = `
+              <section class="ac-section-block">
+                <h3>Mensagens & Agenda</h3>
+                <div class="ac-grid-2">
+                  <div class="ac-card">
+                    <h4>Catálogo de modelos</h4>
+                    <div class="ac-modelos" id="ac-modelos"></div>
+                  </div>
+                  <div class="ac-card">
+                    <h4>Gerar agenda</h4>
+                    <label>Modelo
+                      <select id="modelo">${modelos.map((m) => `<option value="${m.id}">${m.titulo}</option>`).join('')}</select>
+                    </label>
+                    <label>Data/hora base do evento <input id="base-data" type="date" value="${fresh.evento?.data || ''}" /> <input id="base-hora" type="time" value="${fresh.evento?.hora || ''}" /></label>
+                    <label>Público
+                      <select id="publico">
+                        <option value="todos">Todos</option>
+                        <option value="somenteComTelefone">Somente com telefone</option>
+                        <option value="semTelefone">Sem telefone</option>
+                        <option value="pendente">Pendentes de RSVP</option>
+                        <option value="confirmado">Confirmados</option>
+                        <option value="ausente">Ausentes</option>
+                      </select>
+                    </label>
+                    <div class="ac-actions"><button id="btn-add" class="ac-primary">Adicionar à agenda</button></div>
+                  </div>
+                </div>
+
+                <div class="ac-table-wrap">
+                  <table class="ac-table">
+                    <thead><tr><th>Data/Hora</th><th>Modelo</th><th>Público</th><th>Estimado</th><th>Enviados</th><th>Status</th><th>Ações</th></tr></thead>
+                    <tbody id="tbody-agenda"></tbody>
+                  </table>
+                </div>
+              </section>
+            `;
+
+            const catalog = root.querySelector('#ac-modelos');
+            catalog.innerHTML = modelos
+              .map(
+                (m) => `
+                  <article class="ac-modelo">
+                    <h5>${m.titulo}</h5>
+                    <small class="ac-muted">${m.categoria}</small>
+                    <p class="ac-pre">${m.corpo}</p>
+                  </article>
+                `,
+              )
+              .join('');
+
+            const tbody = root.querySelector('#tbody-agenda');
+            (fresh.agenda || []).forEach((entry) => tbody.appendChild(renderAgendaRow(entry, modelos)));
+
+            root.querySelector('#btn-add').addEventListener('click', async () => {
+              const modeloId = root.querySelector('#modelo').value;
+              const modelo = modelos.find((m) => m.id === modeloId);
+              const baseData = root.querySelector('#base-data').value;
+              const baseHora = root.querySelector('#base-hora').value || '10:00';
+              if (!baseData) {
+                alert('Defina a data do evento na tela Evento.');
+                return;
+              }
+              const dtBase = new Date(`${baseData}T${baseHora}:00`);
+              const when = applyRule(dtBase, modelo.regraDataPadrao);
+              const publico = root.querySelector('#publico').value;
+              const estimado = estimatePublic(fresh.lista || [], publico);
+
+              const entry = {
+                id: crypto.randomUUID(),
+                dataHoraISO: when.toISOString(),
+                modeloId,
+                publico: { tipo: publico },
+                escopo: { tipo: 'em_lote', convidadoId: null },
+                preview: {
+                  exemploTexto: renderTemplate(modelo.corpo, sampleGuest(fresh.lista), fresh.evento),
+                },
+                metricas: { estimado, enviados: 0 },
+                status: 'planejado',
+                observacao: '',
+              };
+
+              const agenda = [...(fresh.agenda || []), entry];
+              await ctx.store.updateProject(ctx.projectId, { agenda });
+              tbody.appendChild(renderAgendaRow(entry, modelos));
+              ctx.setStatus('Entrada adicionada à agenda.');
+            });
+
+            tbody.addEventListener('click', async (evt) => {
+              const btn = evt.target.closest('button[data-action]');
+              if (!btn) return;
+              const tr = btn.closest('tr');
+              const id = tr.dataset.id;
+              const proj = await ctx.store.getProject(ctx.projectId);
+              const idx = (proj.agenda || []).findIndex((x) => x.id === id);
+              if (idx < 0) return;
+              const item = proj.agenda[idx];
+
+              if (btn.dataset.action === 'enviado') {
+                item.metricas.enviados = item.metricas.estimado;
+                item.status = 'enviado_manual';
+                proj.agenda[idx] = item;
+                await ctx.store.updateProject(ctx.projectId, { agenda: proj.agenda });
+                tr.replaceWith(renderAgendaRow(item, proj.mensagens.modelos));
+                ctx.setStatus('Linha marcada como enviada.');
+              }
+
+              if (btn.dataset.action === 'excluir') {
+                if (!confirm('Excluir esta linha da agenda?')) return;
+                proj.agenda.splice(idx, 1);
+                await ctx.store.updateProject(ctx.projectId, { agenda: proj.agenda });
+                tr.remove();
+                ctx.setStatus('Linha removida da agenda.');
+              }
+            });
+          },
+          destroy() {},
+        },
+        relatorio: {
+          async render(root, ctx) {
+            const project = await ctx.store.getProject(ctx.projectId);
+            root.innerHTML = `
+              <section class="ac-section-block">
+                <h3>Relatório (PDF)</h3>
+                <div class="ac-form-row">
+                  <label><input type="checkbox" id="sec-evento" checked /> Dados do evento</label>
+                  <label><input type="checkbox" id="sec-agenda" checked /> Agenda de mensagens</label>
+                  <label><input type="checkbox" id="sec-rsvp" checked /> Confirmações (RSVP)</label>
+                  <label><input type="checkbox" id="sec-lista" checked /> Lista de convites</label>
+                </div>
+                <div class="ac-actions"><button id="btn-pdf" class="ac-primary">Exportar PDF</button></div>
+                <p class="ac-muted">A exportação utiliza a caixa de impressão do navegador (Salvar como PDF).</p>
+              </section>
+            `;
+
+            root.querySelector('#btn-pdf').addEventListener('click', async () => {
+              const sections = {
+                evento: root.querySelector('#sec-evento').checked,
+                agenda: root.querySelector('#sec-agenda').checked,
+                rsvp: root.querySelector('#sec-rsvp').checked,
+                lista: root.querySelector('#sec-lista').checked,
+              };
+              const fresh = await ctx.store.getProject(ctx.projectId);
+              openPrint(sections, fresh);
+              ctx.setStatus('Relatório aberto para impressão.');
+            });
+          },
+          destroy() {},
+        },
+      };
+
+      const DEFAULT_TEMPLATES = [
+        {
+          id: 'save_the_date',
+          titulo: 'Save the Date',
+          categoria: 'pré-evento',
+          corpo: 'Olá {{convidado.principal}}, reserve a data: {{evento.data}} — {{evento.titulo}} em {{evento.local}}.',
+          variaveis: ['evento.titulo', 'evento.data', 'evento.local', 'convidado.principal'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: -30, hora: '10:00' },
+        },
+        {
+          id: 'convite',
+          titulo: 'Convite',
+          categoria: 'convite',
+          corpo: '{{convidado.principal}}, você está convidado para {{evento.titulo}} em {{evento.local}} dia {{evento.data}} às {{evento.hora}}.',
+          variaveis: ['evento.titulo', 'evento.data', 'evento.hora', 'evento.local', 'convidado.principal'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: -14, hora: '10:00' },
+        },
+        {
+          id: 'lembrete7',
+          titulo: 'Lembrete 7 dias',
+          categoria: 'lembrete',
+          corpo: 'Faltam 7 dias para {{evento.titulo}}. Confirme sua presença, {{convidado.principal}}.',
+          variaveis: ['evento.titulo', 'convidado.principal'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: -7, hora: '10:00' },
+        },
+        {
+          id: 'lembrete1',
+          titulo: 'Lembrete 1 dia',
+          categoria: 'lembrete',
+          corpo: 'É amanhã: {{evento.titulo}}! Nos vemos em {{evento.local}} às {{evento.hora}}.',
+          variaveis: ['evento.titulo', 'evento.local', 'evento.hora'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: -1, hora: '16:00' },
+        },
+        {
+          id: 'dia',
+          titulo: 'Dia do Evento',
+          categoria: 'lembrete',
+          corpo: 'Chegou o dia de {{evento.titulo}}. Boa festa!',
+          variaveis: ['evento.titulo'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: 0, hora: '08:00' },
+        },
+        {
+          id: 'agradecimento',
+          titulo: 'Agradecimento',
+          categoria: 'pós-evento',
+          corpo: 'Obrigado por fazer parte de {{evento.titulo}}! Foi especial ter você com a gente.',
+          variaveis: ['evento.titulo'],
+          regraDataPadrao: { tipo: 'relativo_evento', offsetDias: 1, hora: '10:00' },
+        },
+      ];
+
+      function mountConviteDashboard(root, project, lista) {
+        const ev = project?.evento || {};
+        const cer = project?.cerimonialista || {};
+        const anfitriao = ev?.anfitriao || {};
+
+        root.innerHTML = `
+          <section class="ac-section-block ac-dashboard">
+            <div class="ac-dashboard__top">
+              <div class="ac-status-grid">
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites cadastrados</span>
+                  <strong id="stat-total">${lista.length}</strong>
+                  <small>Todos os convites salvos</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites enviados</span>
+                  <strong id="stat-enviados">0</strong>
+                  <small>Mensagens marcadas como enviadas</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Pessoas confirmadas</span>
+                  <strong id="stat-confirmados">0</strong>
+                  <small>Total de convidados confirmados</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites pendentes</span>
+                  <strong id="stat-pendentes">0</strong>
+                  <small>Aguardando envio ou resposta</small>
+                </article>
+              </div>
+              <article class="ac-card ac-summary-card">
+                <header>
+                  <div>
+                    <h4 id="summary-title">${escapeHtml(ev.titulo || 'Defina o nome do evento')}</h4>
+                    <p class="ac-summary-sub" id="summary-date">${escapeHtml(formatEventDate(ev.data, ev.hora))}</p>
+                  </div>
+                  <span class="ac-summary-badge" id="summary-status">${escapeHtml(lista.length ? 'Em andamento' : 'Comece adicionando convites')}</span>
+                </header>
+                <dl>
+                  <div>
+                    <dt>Local</dt>
+                    <dd id="summary-local">${escapeHtml(ev.local || 'Informe o local')}</dd>
+                  </div>
+                  <div>
+                    <dt>Endereço</dt>
+                    <dd id="summary-endereco">${escapeHtml(formatEndereco(ev))}</dd>
+                  </div>
+                  <div>
+                    <dt>Organizador</dt>
+                    <dd id="summary-cerimonialista">${escapeHtml(cer.nomeCompleto || 'Cadastre o organizador')}</dd>
+                  </div>
+                  <div>
+                    <dt>Anfitrião</dt>
+                    <dd id="summary-anfitriao">${escapeHtml(anfitriao.nome || 'Cadastre o anfitrião')}</dd>
+                  </div>
+                </dl>
+                <p id="summary-resumo">${ev.resumo ? sanitizeText(ev.resumo) : '<span class=\"ac-muted\">Use os formulários abaixo para registrar o resumo do evento.</span>'}</p>
+              </article>
+            </div>
+          </section>
+          <section class="ac-section-block">
+            <div class="ac-grid-3">
+              <form class="ac-card ac-form-card" id="form-geral">
+                <h4>Dados gerais</h4>
+                <label>Nome do evento
+                  <input name="titulo" value="${escapeHtml(ev.titulo || '')}" placeholder="Ex.: Casamento Ana & João" />
+                </label>
+                <div class="ac-form-inline">
+                  <label>Data
+                    <input type="date" name="data" value="${escapeHtml(ev.data || '')}" />
+                  </label>
+                  <label>Hora
+                    <input type="time" name="hora" value="${escapeHtml(ev.hora || '')}" />
+                  </label>
+                </div>
+                <label>Local
+                  <input name="local" value="${escapeHtml(ev.local || '')}" placeholder="Espaço, salão, igreja…" />
+                </label>
+                <label>Endereço completo
+                  <input name="endereco" value="${escapeHtml(ev.endereco?.logradouro || '')}" placeholder="Rua, número, cidade" />
+                </label>
+                <label>Resumo do evento
+                  <textarea name="resumo" rows="3" placeholder="Breve descrição ou instruções.">${escapeHtml(ev.resumo || '')}</textarea>
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar dados gerais</button>
+                </div>
+              </form>
+              <form class="ac-card ac-form-card" id="form-organizador">
+                <h4>Dados do organizador</h4>
+                <label>Nome completo
+                  <input name="nome" value="${escapeHtml(cer.nomeCompleto || '')}" placeholder="Quem coordena o evento" />
+                </label>
+                <label>Telefone / WhatsApp
+                  <input name="telefone" value="${escapeHtml(cer.telefone || '')}" placeholder="(00) 90000-0000" />
+                </label>
+                <label>Redes sociais ou e-mail
+                  <input name="redeSocial" value="${escapeHtml(cer.redeSocial || '')}" placeholder="@usuario ou e-mail" />
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar organizador</button>
+                </div>
+              </form>
+              <form class="ac-card ac-form-card" id="form-anfitriao">
+                <h4>Dados do anfitrião</h4>
+                <label>Nome dos anfitriões
+                  <input name="nome" value="${escapeHtml(anfitriao.nome || '')}" placeholder="Responsáveis pelo evento" />
+                </label>
+                <label>Contato principal
+                  <input name="contato" value="${escapeHtml(anfitriao.contato || '')}" placeholder="Telefone ou e-mail" />
+                </label>
+                <label>Observações
+                  <textarea name="observacao" rows="3" placeholder="Notas importantes para a recepção.">${escapeHtml(anfitriao.observacao || '')}</textarea>
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar anfitrião</button>
+                </div>
+              </form>
+            </div>
+          </section>
+          <section class="ac-section-block">
+            <h3>Convites</h3>
+            <div class="ac-grid-2">
+              <div class="ac-card">
+                <h4>Adicionar vários (colar)</h4>
+                <textarea id="ac-paste" rows="4" placeholder="Uma linha por convite: Nome(s) | Telefone"></textarea>
+                <div class="ac-actions"><button id="ac-import" class="ac-primary">Higienizar &amp; Adicionar</button></div>
+              </div>
+              <div class="ac-card">
+                <h4>Adicionar um</h4>
+                <div class="ac-form-row">
+                  <input id="single-nome" placeholder="Nome(s)" />
+                  <input id="single-tel" placeholder="Telefone" />
+                  <button id="single-add">Adicionar</button>
+                </div>
+              </div>
+            </div>
+            <div class="ac-table-wrap">
+              <table class="ac-table">
+                <thead>
+                  <tr>
+                    <th>Convidado</th><th>Telefone</th><th>Total</th>
+                    <th>Enviado?</th><th>Enviado em</th>
+                    <th>RSVP</th><th>Confirmados</th><th>Ações</th>
+                  </tr>
+                </thead>
+                <tbody id="ac-rows"></tbody>
+              </table>
+            </div>
+          </section>
+          <div id="drawer" class="ac-drawer" hidden></div>
+        `;
+      }
+
+      function updateConviteStats(refs, lista) {
+        const stats = computeConviteStats(lista);
+        if (refs.stats.total) refs.stats.total.textContent = stats.total;
+        if (refs.stats.enviados) refs.stats.enviados.textContent = stats.enviados;
+        if (refs.stats.confirmados) refs.stats.confirmados.textContent = stats.confirmados;
+        if (refs.stats.pendentes) refs.stats.pendentes.textContent = stats.pendentes;
+      }
+
+      function computeConviteStats(lista) {
+        const stats = { total: lista.length, enviados: 0, confirmados: 0, pendentes: 0 };
+        lista.forEach((item) => {
+          if (item?.envio?.enviado) stats.enviados += 1;
+          if (typeof item?.rsvp?.confirmadosN === 'number') stats.confirmados += item.rsvp.confirmadosN;
+          if (!item?.envio?.enviado || (item?.rsvp?.status || 'pendente') === 'pendente') stats.pendentes += 1;
+        });
+        return stats;
+      }
+
+      function updateConviteSummary(refs, project) {
+        const ev = project?.evento || {};
+        const cer = project?.cerimonialista || {};
+        const anfitriao = ev?.anfitriao || {};
+        const lista = Array.isArray(project?.lista) ? project.lista : [];
+
+        if (refs.summary.title) refs.summary.title.textContent = ev.titulo || 'Defina o nome do evento';
+        if (refs.summary.date) refs.summary.date.textContent = formatEventDate(ev.data, ev.hora);
+        if (refs.summary.status) refs.summary.status.textContent = lista.length ? 'Em andamento' : 'Comece adicionando convites';
+        if (refs.summary.local) refs.summary.local.textContent = ev.local || 'Informe o local';
+        if (refs.summary.endereco) refs.summary.endereco.textContent = formatEndereco(ev);
+        if (refs.summary.cerimonialista) refs.summary.cerimonialista.textContent = cer.nomeCompleto || 'Cadastre o organizador';
+        if (refs.summary.anfitriao) refs.summary.anfitriao.textContent = anfitriao.nome || 'Cadastre o anfitrião';
+        if (refs.summary.resumo) {
+          refs.summary.resumo.innerHTML = ev.resumo
+            ? sanitizeText(ev.resumo)
+            : '<span class="ac-muted">Use os formulários abaixo para registrar o resumo do evento.</span>';
+        }
+      }
+
+      function bindConviteForms(root, ctx, refs, bridge) {
+        const formGeral = root.querySelector('#form-geral');
+        const formOrganizador = root.querySelector('#form-organizador');
+        const formAnfitriao = root.querySelector('#form-anfitriao');
+
+        if (formGeral) {
+          formGeral.addEventListener('submit', async (evt) => {
+            evt.preventDefault();
+            const data = new FormData(formGeral);
+            const project = bridge.get();
+            const nextEvento = {
+              ...project.evento,
+              titulo: (data.get('titulo') || '').trim(),
+              data: data.get('data') || '',
+              hora: data.get('hora') || '',
+              local: (data.get('local') || '').trim(),
+              resumo: (data.get('resumo') || '').trim(),
+              endereco: {
+                ...(project.evento?.endereco || {}),
+                logradouro: (data.get('endereco') || '').trim(),
+              },
+            };
+
+            const updated = await ctx.store.updateProject(ctx.projectId, { evento: nextEvento });
+            bridge.set(updated);
+            updateConviteSummary(refs, updated);
+            ctx.setStatus?.('Dados gerais atualizados.');
+          });
+        }
+
+        if (formOrganizador) {
+          formOrganizador.addEventListener('submit', async (evt) => {
+            evt.preventDefault();
+            const data = new FormData(formOrganizador);
+            const project = bridge.get();
+            const nextCer = {
+              ...project.cerimonialista,
+              nomeCompleto: (data.get('nome') || '').trim(),
+              telefone: (data.get('telefone') || '').trim(),
+              redeSocial: (data.get('redeSocial') || '').trim(),
+            };
+
+            const updated = await ctx.store.updateProject(ctx.projectId, { cerimonialista: nextCer });
+            bridge.set(updated);
+            updateConviteSummary(refs, updated);
+            ctx.setStatus?.('Organizador atualizado.');
+          });
+        }
+
+        if (formAnfitriao) {
+          formAnfitriao.addEventListener('submit', async (evt) => {
+            evt.preventDefault();
+            const data = new FormData(formAnfitriao);
+            const project = bridge.get();
+            const nextHost = {
+              ...project.evento?.anfitriao,
+              nome: (data.get('nome') || '').trim(),
+              contato: (data.get('contato') || '').trim(),
+              observacao: (data.get('observacao') || '').trim(),
+            };
+
+            const updated = await ctx.store.updateProject(ctx.projectId, {
+              evento: {
+                ...project.evento,
+                anfitriao: nextHost,
+              },
+            });
+            bridge.set(updated);
+            updateConviteSummary(refs, updated);
+            ctx.setStatus?.('Dados do anfitrião atualizados.');
+          });
+        }
+      }
+
+      function escapeHtml(value) {
+        return String(value ?? '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      function sanitizeText(value) {
+        return escapeHtml(value).replace(/\r?\n/g, '<br/>');
+      }
+
+      function formatEventDate(dateStr, timeStr) {
+        if (!dateStr && !timeStr) return 'Defina data e horário';
+        let dateLabel = 'Defina a data';
+        if (dateStr) {
+          const parts = dateStr.split('-').map(Number);
+          if (parts.length >= 3) {
+            const [y, m, d] = parts;
+            const date = new Date(Date.UTC(y, m - 1, d));
+            dateLabel = new Intl.DateTimeFormat('pt-BR', {
+              weekday: 'long',
+              day: '2-digit',
+              month: 'long',
+            }).format(date);
+          } else {
+            dateLabel = dateStr;
+          }
+        }
+        const timeLabel = timeStr ? `${timeStr}h` : 'Horário a definir';
+        return `${dateLabel} · ${timeLabel}`;
+      }
+
+      function formatEndereco(ev) {
+        const end = ev?.endereco || {};
+        if (end.logradouro) return end.logradouro;
+        return 'Endereço a definir';
+      }
+
+      function mountConviteDashboard(root, project, lista) {
+        const ev = project?.evento || {};
+        const cer = project?.cerimonialista || {};
+        const anfitriao = ev?.anfitriao || {};
+
+        root.innerHTML = `
+          <section class="ac-section-block ac-dashboard">
+            <div class="ac-dashboard__top">
+              <div class="ac-status-grid">
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites cadastrados</span>
+                  <strong id="stat-total">${lista.length}</strong>
+                  <small>Todos os convites salvos</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites enviados</span>
+                  <strong id="stat-enviados">0</strong>
+                  <small>Mensagens marcadas como enviadas</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Pessoas confirmadas</span>
+                  <strong id="stat-confirmados">0</strong>
+                  <small>Total de convidados confirmados</small>
+                </article>
+                <article class="ac-status-card">
+                  <span class="ac-status-label">Convites pendentes</span>
+                  <strong id="stat-pendentes">0</strong>
+                  <small>Aguardando envio ou resposta</small>
+                </article>
+              </div>
+              <article class="ac-card ac-summary-card">
+                <header>
+                  <div>
+                    <h4 id="summary-title">${escapeHtml(ev.titulo || 'Defina o nome do evento')}</h4>
+                    <p class="ac-summary-sub" id="summary-date">${escapeHtml(formatEventDate(ev.data, ev.hora))}</p>
+                  </div>
+                  <span class="ac-summary-badge" id="summary-status">${escapeHtml(lista.length ? 'Em andamento' : 'Comece adicionando convites')}</span>
+                </header>
+                <dl>
+                  <div>
+                    <dt>Local</dt>
+                    <dd id="summary-local">${escapeHtml(ev.local || 'Informe o local')}</dd>
+                  </div>
+                  <div>
+                    <dt>Endereço</dt>
+                    <dd id="summary-endereco">${escapeHtml(formatEndereco(ev))}</dd>
+                  </div>
+                  <div>
+                    <dt>Organizador</dt>
+                    <dd id="summary-cerimonialista">${escapeHtml(cer.nomeCompleto || 'Cadastre o organizador')}</dd>
+                  </div>
+                  <div>
+                    <dt>Anfitrião</dt>
+                    <dd id="summary-anfitriao">${escapeHtml(anfitriao.nome || 'Cadastre o anfitrião')}</dd>
+                  </div>
+                </dl>
+                <p id="summary-resumo">${
+                  ev.resumo
+                    ? sanitizeText(ev.resumo)
+                    : '<span class="ac-muted">Use os formulários abaixo para registrar o resumo do evento.</span>'
+                }</p>
+              </article>
+            </div>
+          </section>
+          <section class="ac-section-block">
+            <div class="ac-grid-3">
+              <form class="ac-card ac-form-card" id="form-geral">
+                <h4>Dados gerais</h4>
+                <label>Nome do evento
+                  <input name="titulo" value="${escapeHtml(ev.titulo || '')}" placeholder="Ex.: Casamento Ana & João" />
+                </label>
+                <div class="ac-form-inline">
+                  <label>Data
+                    <input type="date" name="data" value="${escapeHtml(ev.data || '')}" />
+                  </label>
+                  <label>Hora
+                    <input type="time" name="hora" value="${escapeHtml(ev.hora || '')}" />
+                  </label>
+                </div>
+                <label>Local
+                  <input name="local" value="${escapeHtml(ev.local || '')}" placeholder="Espaço, salão, igreja…" />
+                </label>
+                <label>Endereço completo
+                  <input name="endereco" value="${escapeHtml(ev.endereco?.logradouro || '')}" placeholder="Rua, número, cidade" />
+                </label>
+                <label>Resumo do evento
+                  <textarea name="resumo" rows="3" placeholder="Breve descrição ou instruções.">${escapeHtml(ev.resumo || '')}</textarea>
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar dados gerais</button>
+                </div>
+              </form>
+              <form class="ac-card ac-form-card" id="form-organizador">
+                <h4>Dados do organizador</h4>
+                <label>Nome completo
+                  <input name="nome" value="${escapeHtml(cer.nomeCompleto || '')}" placeholder="Quem coordena o evento" />
+                </label>
+                <label>Telefone / WhatsApp
+                  <input name="telefone" value="${escapeHtml(cer.telefone || '')}" placeholder="(00) 90000-0000" />
+                </label>
+                <label>Redes sociais ou e-mail
+                  <input name="redeSocial" value="${escapeHtml(cer.redeSocial || '')}" placeholder="@usuario ou e-mail" />
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar organizador</button>
+                </div>
+              </form>
+              <form class="ac-card ac-form-card" id="form-anfitriao">
+                <h4>Dados do anfitrião</h4>
+                <label>Nome dos anfitriões
+                  <input name="nome" value="${escapeHtml(anfitriao.nome || '')}" placeholder="Responsáveis pelo evento" />
+                </label>
+                <label>Contato principal
+                  <input name="contato" value="${escapeHtml(anfitriao.contato || '')}" placeholder="Telefone ou e-mail" />
+                </label>
+                <label>Observações
+                  <textarea name="observacao" rows="3" placeholder="Notas importantes para a recepção.">${escapeHtml(anfitriao.observacao || '')}</textarea>
+                </label>
+                <div class="ac-actions">
+                  <button type="submit" class="ac-primary">Salvar anfitrião</button>
+                </div>
+              </form>
+            </div>
+          </section>
+          <section class="ac-section-block">
+            <h3>Convites</h3>
+            <div class="ac-grid-2">
+              <div class="ac-card">
+                <h4>Adicionar vários (colar)</h4>
+                <textarea id="ac-paste" rows="4" placeholder="Uma linha por convite: Nome(s) | Telefone"></textarea>
+                <div class="ac-actions"><button id="ac-import" class="ac-primary">Higienizar &amp; Adicionar</button></div>
+              </div>
+              <div class="ac-card">
+                <h4>Adicionar um</h4>
+                <div class="ac-form-row">
+                  <input id="single-nome" placeholder="Nome(s)" />
+                  <input id="single-tel" placeholder="Telefone" />
+                  <button id="single-add">Adicionar</button>
+                </div>
+              </div>
+            </div>
+            <div class="ac-table-wrap">
+              <table class="ac-table">
+                <thead>
+                  <tr>
+                    <th>Convidado</th><th>Telefone</th><th>Total</th>
+                    <th>Enviado?</th><th>Enviado em</th>
+                    <th>RSVP</th><th>Confirmados</th><th>Ações</th>
+                  </tr>
+                </thead>
+                <tbody id="ac-rows"></tbody>
+              </table>
+            </div>
+          </section>
+          <div id="drawer" class="ac-drawer" hidden></div>
+        `;
+      }
+
+      function collectConviteRefs(root) {
+        return {
+          stats: {
+            total: root.querySelector('#stat-total'),
+            enviados: root.querySelector('#stat-enviados'),
+            confirmados: root.querySelector('#stat-confirmados'),
+            pendentes: root.querySelector('#stat-pendentes'),
+          },
+          summary: {
+            title: root.querySelector('#summary-title'),
+            date: root.querySelector('#summary-date'),
+            status: root.querySelector('#summary-status'),
+            local: root.querySelector('#summary-local'),
+            endereco: root.querySelector('#summary-endereco'),
+            cerimonialista: root.querySelector('#summary-cerimonialista'),
+            anfitriao: root.querySelector('#summary-anfitriao'),
+            resumo: root.querySelector('#summary-resumo'),
+          },
+        };
+      }
+
+      function renderConviteRow(item) {
+        const tr = document.createElement('tr');
+        tr.dataset.id = item.id;
+        const enviadoEm = item.envio?.enviadoEm
+          ? new Date(item.envio.enviadoEm).toLocaleString()
+          : '-';
+        const rsvp = item.rsvp?.status || 'pendente';
+        const conf = item.rsvp?.confirmadosN ?? 0;
+        tr.innerHTML = `
+          <td>${escapeHtml(item.nome || '')}</td>
+          <td>${escapeHtml(item.telefoneFormatado || item.telefone || '-')}</td>
+          <td>${escapeHtml(item.totalConvite ?? '')}</td>
+          <td>${item.envio?.enviado ? 'Sim' : 'Não'}</td>
+          <td>${escapeHtml(enviadoEm)}</td>
+          <td><span class="ac-badge ac-badge--${escapeHtml(rsvp)}">${escapeHtml(rsvp.replace('_', ' '))}</span></td>
+          <td>${escapeHtml(`${conf}/${item.totalConvite}`)}</td>
+          <td class="ac-actions-col">
+            <button data-action="editar">Editar</button>
+            <button data-action="confirmar">Confirmar todos</button>
+            <button data-action="ausente">Ausente</button>
+            <button data-action="enviar">Marcar enviado</button>
+            <button data-action="excluir" class="ac-danger">Excluir</button>
+          </td>
+        `;
+        return tr;
+      }
+
+      function openDrawer(host, item, onSave) {
+        host.hidden = false;
+        const nomes = [item.principal, ...(item.acompanhantesNomes || [])].filter(Boolean);
+        const checks =
+          nomes
+            .map((n) => {
+              const checked = item.rsvp?.confirmadosNomes?.includes(n) ? 'checked' : '';
+              const safe = escapeHtml(n);
+              return `<label><input type="checkbox" data-name="${safe}" ${checked}/> ${safe}</label>`;
+            })
+            .join('') || '<em>Sem nomes de acompanhantes — use o seletor numérico.</em>';
+        const numOptions = Array.from({ length: item.totalConvite + 1 }, (_, i) => {
+          const selected = i === (item.rsvp?.confirmadosN ?? 0) ? 'selected' : '';
+          return `<option value="${i}" ${selected}>${i}</option>`;
+        }).join('');
+        host.innerHTML = `
+          <div class="ac-drawer__overlay"></div>
+          <div class="ac-drawer__panel">
+            <header class="ac-drawer__header">
+              <h4>Editar convite</h4>
+              <button id="close">×</button>
+            </header>
+            <div class="ac-drawer__content">
+              <div class="ac-form-grid">
+                <label>Nome(s) <input id="f-nome" value="${escapeHtml(item.nome || '')}"/></label>
+                <label>Telefone <input id="f-tel" value="${escapeHtml(item.telefone || '')}" placeholder="Ex.: +55 41 99999-0000"/></label>
+                <label>Total do convite <input id="f-total" type="number" min="1" value="${escapeHtml(item.totalConvite || 1)}"/></label>
+              </div>
+              <fieldset class="ac-fieldset">
+                <legend>RSVP</legend>
+                <div class="ac-rsvp">
+                  <div class="ac-rsvp__names">${checks}</div>
+                  <div class="ac-rsvp__count">
+                    <label>Confirmados (número)
+                      <select id="f-conf">${numOptions}</select>
+                    </label>
+                  </div>
+                  <label>Observação <input id="f-obs" value="${escapeHtml(item.rsvp?.observacao || '')}"/></label>
+                </div>
+              </fieldset>
+              <fieldset class="ac-fieldset">
+                <legend>Envio</legend>
+                <label><input type="checkbox" id="f-enviado" ${item.envio?.enviado ? 'checked' : ''}/> Mensagem enviada</label>
+                <label>Modelo <input id="f-modelo" value="${escapeHtml(item.envio?.modeloId || '')}" placeholder="Opcional: id do modelo"/></label>
+              </fieldset>
+            </div>
+            <footer class="ac-drawer__footer">
+              <button id="save" class="ac-primary">Salvar alterações</button>
+              <button id="cancel">Cancelar</button>
+            </footer>
+          </div>
+        `;
+
+        const close = () => {
+          host.hidden = true;
+          host.innerHTML = '';
+        };
+
+        host.querySelector('#cancel').addEventListener('click', close);
+        host.querySelector('#close').addEventListener('click', close);
+        host.querySelector('.ac-drawer__overlay').addEventListener('click', close);
+        host.querySelector('#save').addEventListener('click', async () => {
+          const next = {
+            ...item,
+            nome: host.querySelector('#f-nome').value.trim(),
+            telefone: host.querySelector('#f-tel').value.trim(),
+            totalConvite: Number(host.querySelector('#f-total').value) || item.totalConvite,
+            rsvp: {
+              ...item.rsvp,
+              confirmadosN: Number(host.querySelector('#f-conf').value) || 0,
+              confirmadosNomes: Array.from(host.querySelectorAll('input[data-name]:checked')).map((c) => c.dataset.name),
+              observacao: host.querySelector('#f-obs').value.trim(),
+              status: deriveDrawerStatus(item, host),
+              atualizadoEm: Date.now(),
+            },
+            envio: {
+              ...item.envio,
+              enviado: host.querySelector('#f-enviado').checked,
+              enviadoEm: host.querySelector('#f-enviado').checked ? Date.now() : item.envio?.enviadoEm || null,
+              modeloId: host.querySelector('#f-modelo').value.trim() || null,
+            },
+          };
+          close();
+          await onSave(next);
+        });
+      }
+
+      function deriveDrawerStatus(item, host) {
+        const enviado = host.querySelector('#f-enviado').checked;
+        const confirmados = Number(host.querySelector('#f-conf').value) || 0;
+        if (confirmados >= item.totalConvite) return 'confirmado_total';
+        if (confirmados > 0) return 'confirmado_parcial';
+        if (enviado) return 'aguardando_resposta';
+        return 'pendente';
+      }
+
+      function renderAgendaRow(entry, modelos) {
+        const tr = document.createElement('tr');
+        tr.dataset.id = entry.id;
+        const modelo = modelos.find((m) => m.id === entry.modeloId);
+        tr.innerHTML = `
+          <td>${new Date(entry.dataHoraISO).toLocaleString()}</td>
+          <td>${modelo ? modelo.titulo : entry.modeloId}</td>
+          <td>${entry.publico?.tipo}</td>
+          <td>${entry.metricas?.estimado ?? 0}</td>
+          <td>${entry.metricas?.enviados ?? 0}</td>
+          <td>${entry.status}</td>
+          <td class="ac-actions-col">
+            <button data-action="enviado">Marcar enviados</button>
+            <button data-action="excluir" class="ac-danger">Excluir</button>
+          </td>
+        `;
+        return tr;
+      }
+
+      function estimatePublic(lista, tipo) {
+        const hasPhone = (g) => !!(g.telefone || g.telefoneFormatado);
+        if (tipo === 'todos') return lista.length;
+        if (tipo === 'somenteComTelefone') return lista.filter(hasPhone).length;
+        if (tipo === 'semTelefone') return lista.filter((g) => !hasPhone(g)).length;
+        if (tipo === 'pendente') return lista.filter((g) => g.rsvp?.status === 'pendente').length;
+        if (tipo === 'confirmado') return lista.filter((g) => ['confirmado_total', 'confirmado_parcial'].includes(g.rsvp?.status)).length;
+        if (tipo === 'ausente') return lista.filter((g) => g.rsvp?.status === 'ausente').length;
+        return 0;
+      }
+
+      function applyRule(base, regra) {
+        const d = new Date(base);
+        if (regra?.tipo === 'relativo_evento') {
+          d.setDate(d.getDate() + (regra.offsetDias || 0));
+          const [h, m] = (regra.hora || '10:00').split(':');
+          d.setHours(parseInt(h, 10), parseInt(m, 10), 0, 0);
+        }
+        return d;
+      }
+
+      function sampleGuest(lista) {
+        return lista && lista.length ? lista[0] : { principal: 'Convidado', telefoneFormatado: '' };
+      }
+
+      function renderTemplate(tpl, convidado, evento) {
+        return tpl.replace(/\{\{\s*([\w\.]+)\s*\}\}/g, (_, key) => {
+          const [root, prop] = key.split('.');
+          if (root === 'convidado') return convidado?.[prop] ?? '';
+          if (root === 'evento') return evento?.[prop] ?? '';
+          return '';
+        });
+      }
+
+      function openPrint(sections, project) {
+        const w = window.open('', '_blank');
+        if (!w) return;
+        const css = `
+          body{font-family:inherit;color:inherit;padding:24px;line-height:1.4}
+          h1,h2,h3{margin:.2em 0}
+          table{border-collapse:collapse;width:100%}th,td{border:1px solid #ccc;padding:6px;text-align:left}
+          small{opacity:.7}
+          .muted{opacity:.7}
+          .section{margin:16px 0}
+        `;
+        w.document.write('<!doctype html><html><head><meta charset="utf-8"><title>Relatório</title><style>' + css + '</style></head><body>');
+        if (sections.evento) {
+          const ev = project.evento || {};
+          w.document.write(`<section class="section"><h2>Dados do evento</h2>
+            <p><b>Título:</b> ${ev.titulo || '-'}<br/>
+            <b>Data:</b> ${ev.data || '-'} &nbsp; <b>Hora:</b> ${ev.hora || '-'}<br/>
+            <b>Local:</b> ${ev.local || '-'}</p></section>`);
+        }
+        if (sections.agenda) {
+          const agenda = project.agenda || [];
+          w.document.write('<section class="section"><h2>Agenda de mensagens</h2><table><thead><tr><th>Data/Hora</th><th>Modelo</th><th>Público</th><th>Estimado</th><th>Enviados</th><th>Status</th></tr></thead><tbody>');
+          agenda.forEach((a) => {
+            w.document.write(`<tr><td>${new Date(a.dataHoraISO).toLocaleString()}</td><td>${a.modeloId}</td><td>${a.publico?.tipo || ''}</td><td>${a.metricas?.estimado ?? 0}</td><td>${a.metricas?.enviados ?? 0}</td><td>${a.status}</td></tr>`);
+          });
+          w.document.write('</tbody></table></section>');
+        }
+        if (sections.rsvp) {
+          const lista = project.lista || [];
+          w.document.write('<section class="section"><h2>Confirmações (RSVP)</h2><table><thead><tr><th>Convite</th><th>Total</th><th>Status</th><th>Confirmados</th><th>Telefone</th></tr></thead><tbody>');
+          lista.forEach((g) => {
+            w.document.write(`<tr><td>${g.nome}</td><td>${g.totalConvite}</td><td>${g.rsvp?.status || 'pendente'}</td><td>${g.rsvp?.confirmadosN ?? 0}</td><td>${g.telefoneFormatado || g.telefone || '-'}</td></tr>`);
+          });
+          w.document.write('</tbody></table></section>');
+        }
+        if (sections.lista) {
+          const lista = project.lista || [];
+          w.document.write('<section class="section"><h2>Lista de convites</h2><table><thead><tr><th>Convite</th><th>Principal</th><th>Acompanhantes</th><th>Telefone</th></tr></thead><tbody>');
+          lista.forEach((g) => {
+            w.document.write(`<tr><td>${g.nome}</td><td>${g.principal || ''}</td><td>${(g.acompanhantesNomes || []).join(', ')}</td><td>${g.telefoneFormatado || g.telefone || '-'}</td></tr>`);
+          });
+          w.document.write('</tbody></table></section>');
+        }
+        w.document.write('<hr/><small class="muted">Gerado pelo Assistente Cerimonial — V5</small>');
+        w.document.write('</body></html>');
+        w.document.close();
+        w.focus();
+        w.print();
+      }
+    </script>
+
+    <noscript>Ative o JavaScript para usar a ferramenta.</noscript>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "projeto-marco",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "projeto-marco",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "fake-indexeddb": "^6.2.2"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz",
+      "integrity": "sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "projeto-marco",
+  "version": "1.0.0",
+  "description": "Assistente Cerimonial utilities",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "fake-indexeddb": "^6.2.2"
+  }
+}

--- a/tests/projectStore.test.js
+++ b/tests/projectStore.test.js
@@ -1,0 +1,93 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
+
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+const MODULE_PATH = resolve('shared/projectStore.js');
+let importCounter = 0;
+let factory;
+
+async function freshStore() {
+  const url = new URL(`${pathToFileURL(MODULE_PATH).href}?v=${importCounter++}`);
+  return import(url);
+}
+
+function deleteDatabase(name) {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
+
+beforeEach(async () => {
+  factory = new FDBFactory();
+  globalThis.indexedDB = factory;
+  await deleteDatabase('marco_db');
+});
+
+afterEach(async () => {
+  await deleteDatabase('marco_db');
+  if (factory && typeof factory.close === 'function') {
+    factory.close();
+  }
+  factory = undefined;
+});
+
+test('createProject seeds a blank event and updates the in-memory index', async () => {
+  const store = await freshStore();
+  await store.init();
+  const { meta, payload } = await store.createProject();
+
+  assert.equal(payload.evento.titulo, '');
+  assert.equal(payload.evento.anfitriao.nome, '');
+  assert.equal(payload.cerimonialista.nomeCompleto, '');
+  assert.equal(store.listProjects().length, 1);
+  assert.equal(store.listProjects()[0].id, meta.id);
+});
+
+test('updateProject normalizes legacy name field and refreshes the index timestamp', async () => {
+  const store = await freshStore();
+  await store.init();
+  const { meta } = await store.createProject({ evento: { nome: 'Casamento Ana & Bruno' } });
+  const before = store.listProjects()[0].updatedAt;
+
+  await new Promise((resolve) => setTimeout(resolve, 2));
+  const updated = await store.updateProject(meta.id, { evento: { resumo: 'Cerimônia ao ar livre' } });
+
+  assert.equal(updated.evento.titulo, 'Casamento Ana & Bruno');
+  const [entry] = store.listProjects();
+  assert.equal(entry.id, meta.id);
+  assert.ok(entry.updatedAt >= before, 'updatedAt should advance after update');
+});
+
+test('importProject persists provided data and returns the stored payload', async () => {
+  const store = await freshStore();
+  await store.init();
+  const mockData = {
+    cerimonialista: { nomeCompleto: 'Luiza Cerimonial', telefone: '(11) 99999-9999', redeSocial: '@luiza' },
+    evento: {
+      titulo: 'Formatura 2025',
+      data: '2025-02-15',
+      hora: '20:00',
+      local: 'Espaço Jardins',
+      resumo: 'Celebração dos formandos de 2025',
+      anfitriao: { nome: 'Colégio Horizonte', contato: 'contato@horizonte.com', observacao: 'Chegar 1h antes' }
+    },
+    lista: [{ id: 'a1', nomeCompleto: 'Convidado 1', status: 'pendente' }]
+  };
+
+  const { meta, payload } = await store.importProject(mockData);
+  assert.equal(payload.evento.titulo, 'Formatura 2025');
+  const stored = await store.getProject(meta.id);
+  assert.equal(stored.evento.titulo, 'Formatura 2025');
+  assert.equal(stored.evento.anfitriao.nome, 'Colégio Horizonte');
+  assert.deepEqual(stored.lista, mockData.lista);
+});

--- a/tools/gestao-de-convidados/app_header.mjs
+++ b/tools/gestao-de-convidados/app_header.mjs
@@ -3,7 +3,7 @@
 // - Shell + navegação
 // - Import dinâmico das views
 // - CSS mínimo namespaced (.ac-app) — tipografia herda do site
-import * as store from '/shared/projectStore.js';
+import * as store from '../../shared/projectStore.js';
 import { qs, on, mount, spinner, showToast, cssBase } from './ui/dom.mjs';
 
 const routes = {
@@ -99,15 +99,23 @@ function setActiveTab(tab) {
 }
 
 async function ensureProjectId() {
-  // Usa o primeiro projeto existente; caso não exista, cria um com mensagens/templates default.
+  // Usa o primeiro projeto existente; caso não exista, cria um inicial em branco.
   const list = await store.listProjects();
   if (list && list.length) {
     return list[0].id;
   }
-  const p = await store.createProject({
-    evento: { titulo: 'Meu Evento', local: '', data: '', hora: '' },
+  const { meta } = await store.createProject({
+    evento: {
+      titulo: 'Meu Evento',
+      local: '',
+      data: '',
+      hora: '',
+      endereco: { logradouro: '' },
+      anfitriao: { nome: '' },
+    },
   });
-  return p.id;
+  showToast('Projeto inicial criado. Preencha os dados do evento.', 'info');
+  return meta.id;
 }
 
 export { render };

--- a/tools/gestao-de-convidados/ui/dom.mjs
+++ b/tools/gestao-de-convidados/ui/dom.mjs
@@ -29,7 +29,8 @@ export function cssBase(){
   .ac-app button.ac-danger{background:#fff5f5;border-color:#ffbdbd}
   .ac-app .ac-spinner{padding:16px}
   .ac-app .ac-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-  .ac-app .ac-card{border:1px solid rgba(0,0,0,.1);border-radius:8px;padding:12px}
+  .ac-app .ac-grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+  .ac-app .ac-card{border:1px solid rgba(0,0,0,.1);border-radius:12px;padding:16px;background:#fff}
   .ac-app .ac-form-row{display:flex;gap:8px;align-items:center}
   .ac-app .ac-form-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
   .ac-app .ac-section-block{margin-block:12px}
@@ -42,6 +43,25 @@ export function cssBase(){
   .ac-app .ac-badge--confirmado_total{background:#eaffea}
   .ac-app .ac-badge--confirmado_parcial{background:#f0fff8}
   .ac-app .ac-badge--ausente{background:#ffeeee}
+  .ac-app .ac-dashboard{display:flex;flex-direction:column;gap:16px}
+  .ac-app .ac-dashboard__top{display:flex;flex-wrap:wrap;gap:16px;align-items:stretch}
+  .ac-app .ac-status-grid{flex:2;display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}
+  .ac-app .ac-status-card{background:#fff9f4;border:1px solid rgba(240,123,36,.25);border-radius:14px;padding:14px;display:flex;flex-direction:column;gap:6px}
+  .ac-app .ac-status-card strong{font-size:1.7em;color:#f07b24;line-height:1}
+  .ac-app .ac-status-card small{font-size:.85em;color:rgba(0,0,0,.6)}
+  .ac-app .ac-status-label{font-size:.9em;font-weight:600;color:rgba(0,0,0,.65)}
+  .ac-app .ac-summary-card{flex:1;min-width:260px;display:flex;flex-direction:column;gap:8px}
+  .ac-app .ac-summary-card header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
+  .ac-app .ac-summary-card h4{margin:0;font-size:1.1em}
+  .ac-app .ac-summary-sub{margin:4px 0 0;font-size:.95em;color:rgba(0,0,0,.65)}
+  .ac-app .ac-summary-badge{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:#fff3e6;color:#b25b12;font-size:.8em;font-weight:600}
+  .ac-app .ac-summary-card dl{margin:0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px 12px;font-size:.94em}
+  .ac-app .ac-summary-card dt{font-weight:600;color:rgba(0,0,0,.55)}
+  .ac-app .ac-summary-card dd{margin:0}
+  .ac-app .ac-form-card{display:flex;flex-direction:column;gap:12px}
+  .ac-app .ac-form-card h4{margin:0}
+  .ac-app .ac-form-card label{display:flex;flex-direction:column;gap:4px;font-size:.95em}
+  .ac-app .ac-form-inline{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
   /* Drawer */
   .ac-app .ac-drawer{position:fixed;inset:0;z-index:9999}
   .ac-app .ac-drawer__overlay{position:absolute;inset:0;background:rgba(0,0,0,.4)}
@@ -51,6 +71,8 @@ export function cssBase(){
   .ac-app .ac-drawer__footer{padding:12px;border-top:1px solid rgba(0,0,0,.1);display:flex;gap:8px;justify-content:flex-end}
   .ac-app .ac-fieldset{border:1px solid rgba(0,0,0,.1);border-radius:8px;padding:8px;margin-top:8px}
   .ac-app .ac-rsvp{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+  @media (max-width: 960px){ .ac-app .ac-grid-3{grid-template-columns:repeat(2,1fr)} }
   @media (max-width: 860px){ .ac-app .ac-grid-2{grid-template-columns:1fr} .ac-app .ac-form-grid{grid-template-columns:1fr} .ac-app .ac-rsvp{grid-template-columns:1fr} }
+  @media (max-width: 720px){ .ac-app .ac-dashboard__top{flex-direction:column} .ac-app .ac-grid-3{grid-template-columns:1fr} .ac-app .ac-form-inline{grid-template-columns:1fr} }
   `;
 }

--- a/tools/gestao-de-convidados/views/convites.mjs
+++ b/tools/gestao-de-convidados/views/convites.mjs
@@ -1,23 +1,321 @@
 // tools/gestao-de-convidados/views/convites.mjs
-import { higienizarLinha, higienizarLista } from '/shared/higienizarLista.mjs';
+import { higienizarLinha, higienizarLista } from '../../shared/higienizarLista.mjs';
 
-export async function render(root, ctx){
-  const project = await ctx.store.getProject(ctx.projectId);
-  const lista = Array.isArray(project.lista) ? project.lista : [];
+export async function render(root, ctx) {
+  let project = await ctx.store.getProject(ctx.projectId);
+  let lista = Array.isArray(project?.lista) ? project.lista : [];
+
+  mountDashboard(root, project, lista);
+
+  const tbody = root.querySelector('#ac-rows');
+  const drawerHost = root.querySelector('#drawer');
+  lista.forEach((item) => tbody.appendChild(row(item)));
+
+  const refs = collectRefs(root);
+  updateStats(refs, lista);
+  updateSummary(refs, project);
+
+  root.querySelector('#ac-import').addEventListener('click', async () => {
+    const txt = root.querySelector('#ac-paste').value.trim();
+    if (!txt) return;
+
+    const res = txt.includes('\n')
+      ? higienizarLista(txt)
+      : { convidados: [higienizarLinha(txt)] };
+
+    const now = Date.now();
+    const novos = res.convidados.map((g) => ({
+      id: crypto.randomUUID(),
+      envio: { enviado: false, enviadoEm: null, modeloId: null },
+      rsvp: {
+        status: 'pendente',
+        confirmadosN: 0,
+        confirmadosNomes: [],
+        observacao: '',
+        atualizadoEm: now,
+      },
+      ...g,
+    }));
+
+    const listaNova = [...lista, ...novos];
+    await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
+    lista = listaNova;
+    project.lista = listaNova;
+
+    novos.forEach((n) => tbody.appendChild(row(n)));
+    root.querySelector('#ac-paste').value = '';
+    updateStats(refs, lista);
+    updateSummary(refs, project);
+    notify(ctx, `${novos.length} convite(s) adicionados.`);
+  });
+
+  root.querySelector('#single-add').addEventListener('click', async () => {
+    const nome = root.querySelector('#single-nome').value.trim();
+    const tel = root.querySelector('#single-tel').value.trim();
+    if (!nome && !tel) return;
+
+    const item = higienizarLinha(`${nome} | ${tel}`);
+    const novo = {
+      id: crypto.randomUUID(),
+      envio: { enviado: false, enviadoEm: null, modeloId: null },
+      rsvp: {
+        status: 'pendente',
+        confirmadosN: 0,
+        confirmadosNomes: [],
+        observacao: '',
+        atualizadoEm: Date.now(),
+      },
+      ...item,
+    };
+
+    const listaNova = [...lista, novo];
+    await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
+    lista = listaNova;
+    project.lista = listaNova;
+
+    tbody.appendChild(row(novo));
+    root.querySelector('#single-nome').value = '';
+    root.querySelector('#single-tel').value = '';
+    updateStats(refs, lista);
+    updateSummary(refs, project);
+    notify(ctx, 'Convite adicionado.');
+  });
+
+  tbody.addEventListener('click', async (evt) => {
+    const btn = evt.target.closest('button[data-action]');
+    if (!btn) return;
+
+    const tr = btn.closest('tr');
+    const id = tr.dataset.id;
+    const proj = await ctx.store.getProject(ctx.projectId);
+    const idx = (proj.lista || []).findIndex((x) => x.id === id);
+    if (idx < 0) return;
+    const item = proj.lista[idx];
+
+    if (btn.dataset.action === 'editar') {
+      openDrawer(drawerHost, item, async (next) => {
+        proj.lista[idx] = next;
+        const updated = await ctx.store.updateProject(ctx.projectId, {
+          lista: proj.lista,
+        });
+        lista = updated.lista || [];
+        project.lista = lista;
+        tr.replaceWith(row(next));
+        updateStats(refs, lista);
+        updateSummary(refs, project);
+        notify(ctx, 'Convite atualizado.');
+      });
+    }
+
+    if (btn.dataset.action === 'confirmar') {
+      item.rsvp.confirmadosN = item.totalConvite;
+      item.rsvp.confirmadosNomes = [
+        item.principal,
+        ...(item.acompanhantesNomes || []),
+      ].filter(Boolean);
+      item.rsvp.status = 'confirmado_total';
+      item.rsvp.atualizadoEm = Date.now();
+      proj.lista[idx] = item;
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        lista: proj.lista,
+      });
+      lista = updated.lista || [];
+      project.lista = lista;
+      tr.replaceWith(row(item));
+      updateStats(refs, lista);
+      updateSummary(refs, project);
+      notify(ctx, 'Convite confirmado.');
+    }
+
+    if (btn.dataset.action === 'ausente') {
+      item.rsvp.confirmadosN = 0;
+      item.rsvp.confirmadosNomes = [];
+      item.rsvp.status = 'ausente';
+      item.rsvp.atualizadoEm = Date.now();
+      proj.lista[idx] = item;
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        lista: proj.lista,
+      });
+      lista = updated.lista || [];
+      project.lista = lista;
+      tr.replaceWith(row(item));
+      updateStats(refs, lista);
+      updateSummary(refs, project);
+      notify(ctx, 'Convite marcado como ausente.');
+    }
+
+    if (btn.dataset.action === 'enviar') {
+      item.envio.enviado = true;
+      item.envio.enviadoEm = Date.now();
+      proj.lista[idx] = item;
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        lista: proj.lista,
+      });
+      lista = updated.lista || [];
+      project.lista = lista;
+      tr.replaceWith(row(item));
+      updateStats(refs, lista);
+      updateSummary(refs, project);
+      notify(ctx, 'Envio marcado.');
+    }
+
+    if (btn.dataset.action === 'excluir') {
+      if (!confirm('Excluir este convite?')) return;
+      proj.lista.splice(idx, 1);
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        lista: proj.lista,
+      });
+      lista = updated.lista || [];
+      project.lista = lista;
+      tr.remove();
+      updateStats(refs, lista);
+      updateSummary(refs, project);
+      notify(ctx, 'Convite removido.');
+    }
+  });
+
+  bindForms(root, ctx, refs, () => project);
+}
+
+function notify(ctx, msg) {
+  if (typeof ctx.setStatus === 'function') {
+    ctx.setStatus(msg);
+  }
+}
+
+function mountDashboard(root, project, lista) {
+  const ev = project?.evento || {};
+  const cer = project?.cerimonialista || {};
+  const anfitriao = ev?.anfitriao || {};
+
   root.innerHTML = `
+    <section class="ac-section-block ac-dashboard">
+      <div class="ac-dashboard__top">
+        <div class="ac-status-grid">
+          <article class="ac-status-card">
+            <span class="ac-status-label">Convites cadastrados</span>
+            <strong id="stat-total">${lista.length}</strong>
+            <small>Todos os convites salvos</small>
+          </article>
+          <article class="ac-status-card">
+            <span class="ac-status-label">Convites enviados</span>
+            <strong id="stat-enviados">0</strong>
+            <small>Mensagens marcadas como enviadas</small>
+          </article>
+          <article class="ac-status-card">
+            <span class="ac-status-label">Pessoas confirmadas</span>
+            <strong id="stat-confirmados">0</strong>
+            <small>Total de convidados confirmados</small>
+          </article>
+          <article class="ac-status-card">
+            <span class="ac-status-label">Convites pendentes</span>
+            <strong id="stat-pendentes">0</strong>
+            <small>Aguardando envio ou resposta</small>
+          </article>
+        </div>
+        <article class="ac-card ac-summary-card">
+          <header>
+            <div>
+              <h4 id="summary-title">${ev.titulo || 'Defina o nome do evento'}</h4>
+              <p class="ac-summary-sub" id="summary-date">${formatDate(ev.data, ev.hora)}</p>
+            </div>
+            <span class="ac-summary-badge" id="summary-status">${lista.length ? 'Em andamento' : 'Comece adicionando convites'}</span>
+          </header>
+          <dl>
+            <div>
+              <dt>Local</dt>
+              <dd id="summary-local">${ev.local || 'Informe o local'}</dd>
+            </div>
+            <div>
+              <dt>Endereço</dt>
+              <dd id="summary-endereco">${formatEndereco(ev)}</dd>
+            </div>
+            <div>
+              <dt>Organizador</dt>
+              <dd id="summary-cerimonialista">${cer.nomeCompleto || 'Cadastre o organizador'}</dd>
+            </div>
+            <div>
+              <dt>Anfitrião</dt>
+              <dd id="summary-anfitriao">${anfitriao.nome || 'Cadastre o anfitrião'}</dd>
+            </div>
+          </dl>
+          <p id="summary-resumo">${ev.resumo ? sanitize(ev.resumo) : '<span class="ac-muted">Use os formulários abaixo para registrar o resumo do evento.</span>'}</p>
+        </article>
+      </div>
+    </section>
+    <section class="ac-section-block">
+      <div class="ac-grid-3">
+        <form class="ac-card ac-form-card" id="form-geral">
+          <h4>Dados gerais</h4>
+          <label>Nome do evento
+            <input name="titulo" value="${ev.titulo || ''}" placeholder="Ex.: Casamento Ana & João" />
+          </label>
+          <div class="ac-form-inline">
+            <label>Data
+              <input type="date" name="data" value="${ev.data || ''}" />
+            </label>
+            <label>Hora
+              <input type="time" name="hora" value="${ev.hora || ''}" />
+            </label>
+          </div>
+          <label>Local
+            <input name="local" value="${ev.local || ''}" placeholder="Espaço, salão, igreja…" />
+          </label>
+          <label>Endereço completo
+            <input name="endereco" value="${ev.endereco?.logradouro || ''}" placeholder="Rua, número, cidade" />
+          </label>
+          <label>Resumo do evento
+            <textarea name="resumo" rows="3" placeholder="Breve descrição ou instruções.">${ev.resumo || ''}</textarea>
+          </label>
+          <div class="ac-actions">
+            <button type="submit" class="ac-primary">Salvar dados gerais</button>
+          </div>
+        </form>
+        <form class="ac-card ac-form-card" id="form-organizador">
+          <h4>Dados do organizador</h4>
+          <label>Nome completo
+            <input name="nome" value="${cer.nomeCompleto || ''}" placeholder="Quem coordena o evento" />
+          </label>
+          <label>Telefone / WhatsApp
+            <input name="telefone" value="${cer.telefone || ''}" placeholder="(00) 90000-0000" />
+          </label>
+          <label>Redes sociais ou e-mail
+            <input name="redeSocial" value="${cer.redeSocial || ''}" placeholder="@usuario ou e-mail" />
+          </label>
+          <div class="ac-actions">
+            <button type="submit" class="ac-primary">Salvar organizador</button>
+          </div>
+        </form>
+        <form class="ac-card ac-form-card" id="form-anfitriao">
+          <h4>Dados do anfitrião</h4>
+          <label>Nome dos anfitriões
+            <input name="nome" value="${anfitriao.nome || ''}" placeholder="Responsáveis pelo evento" />
+          </label>
+          <label>Contato principal
+            <input name="contato" value="${anfitriao.contato || ''}" placeholder="Telefone ou e-mail" />
+          </label>
+          <label>Observações
+            <textarea name="observacao" rows="3" placeholder="Notas importantes para a recepção.">${anfitriao.observacao || ''}</textarea>
+          </label>
+          <div class="ac-actions">
+            <button type="submit" class="ac-primary">Salvar anfitrião</button>
+          </div>
+        </form>
+      </div>
+    </section>
     <section class="ac-section-block">
       <h3>Convites</h3>
       <div class="ac-grid-2">
         <div class="ac-card">
           <h4>Adicionar vários (colar)</h4>
           <textarea id="ac-paste" rows="4" placeholder="Uma linha por convite: Nome(s) | Telefone"></textarea>
-          <div class="ac-actions"><button id="ac-import">Higienizar & Adicionar</button></div>
+          <div class="ac-actions"><button id="ac-import" class="ac-primary">Higienizar &amp; Adicionar</button></div>
         </div>
         <div class="ac-card">
           <h4>Adicionar um</h4>
           <div class="ac-form-row">
-            <input id="single-nome" placeholder="Nome(s)"/>
-            <input id="single-tel" placeholder="Telefone"/>
+            <input id="single-nome" placeholder="Nome(s)" />
+            <input id="single-tel" placeholder="Telefone" />
             <button id="single-add">Adicionar</button>
           </div>
         </div>
@@ -37,102 +335,200 @@ export async function render(root, ctx){
     </section>
     <div id="drawer" class="ac-drawer" hidden></div>
   `;
-  const tbody = root.querySelector('#ac-rows');
-  lista.forEach(item => tbody.appendChild(row(item)));
-
-  root.querySelector('#ac-import').addEventListener('click', async () => {
-    const txt = root.querySelector('#ac-paste').value.trim();
-    if(!txt) return;
-    const res = txt.includes('\n') ? higienizarLista(txt) : { convidados: [ higienizarLinha(txt) ] };
-    const p = await ctx.store.getProject(ctx.projectId);
-    const now = Date.now();
-    const novos = res.convidados.map(g => ({
-      id: crypto.randomUUID(),
-      envio: { enviado:false, enviadoEm:null, modeloId:null },
-      rsvp: { status:'pendente', confirmadosN:0, confirmadosNomes:[], observacao:'', atualizadoEm:now },
-      ...g
-    }));
-    const listaNova = [...(p.lista||[]), ...novos];
-    await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
-    novos.forEach(n => tbody.appendChild(row(n)));
-    root.querySelector('#ac-paste').value='';
-  });
-
-  root.querySelector('#single-add').addEventListener('click', async () => {
-    const nome = root.querySelector('#single-nome').value.trim();
-    const tel  = root.querySelector('#single-tel').value.trim();
-    if(!nome && !tel) return;
-    const item = higienizarLinha(`${nome} | ${tel}`);
-    const p = await ctx.store.getProject(ctx.projectId);
-    const novo = {
-      id: crypto.randomUUID(),
-      envio: { enviado:false, enviadoEm:null, modeloId:null },
-      rsvp: { status:'pendente', confirmadosN:0, confirmadosNomes:[], observacao:'', atualizadoEm:Date.now() },
-      ...item
-    };
-    const listaNova = [...(p.lista||[]), novo];
-    await ctx.store.updateProject(ctx.projectId, { lista: listaNova });
-    tbody.appendChild(row(novo));
-    root.querySelector('#single-nome').value='';
-    root.querySelector('#single-tel').value='';
-  });
-
-  // Delegação de eventos na tabela
-  tbody.addEventListener('click', async (e)=>{
-    const btn = e.target.closest('button[data-action]');
-    if(!btn) return;
-    const tr = btn.closest('tr');
-    const id = tr.dataset.id;
-    const proj = await ctx.store.getProject(ctx.projectId);
-    const idx = (proj.lista||[]).findIndex(x => x.id === id);
-    if (idx < 0) return;
-    const item = proj.lista[idx];
-
-    if (btn.dataset.action === 'editar'){
-      openDrawer(root.querySelector('#drawer'), item, async (next)=>{
-        proj.lista[idx] = next;
-        await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
-        tr.replaceWith(row(next));
-      });
-    }
-    if (btn.dataset.action === 'confirmar'){
-      item.rsvp.confirmadosN = item.totalConvite;
-      item.rsvp.confirmadosNomes = [item.principal, ...(item.acompanhantesNomes||[])].filter(Boolean);
-      item.rsvp.status = 'confirmado_total';
-      item.rsvp.atualizadoEm = Date.now();
-      proj.lista[idx] = item;
-      await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
-      tr.replaceWith(row(item));
-    }
-    if (btn.dataset.action === 'ausente'){
-      item.rsvp.confirmadosN = 0;
-      item.rsvp.confirmadosNomes = [];
-      item.rsvp.status = 'ausente';
-      item.rsvp.atualizadoEm = Date.now();
-      proj.lista[idx] = item;
-      await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
-      tr.replaceWith(row(item));
-    }
-    if (btn.dataset.action === 'enviar'){
-      item.envio.enviado = true;
-      item.envio.enviadoEm = Date.now();
-      proj.lista[idx] = item;
-      await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
-      tr.replaceWith(row(item));
-    }
-    if (btn.dataset.action === 'excluir'){
-      if (!confirm('Excluir este convite?')) return;
-      proj.lista.splice(idx,1);
-      await ctx.store.updateProject(ctx.projectId, { lista: proj.lista });
-      tr.remove();
-    }
-  });
 }
 
-function row(item){
+function collectRefs(root) {
+  return {
+    stats: {
+      total: root.querySelector('#stat-total'),
+      enviados: root.querySelector('#stat-enviados'),
+      confirmados: root.querySelector('#stat-confirmados'),
+      pendentes: root.querySelector('#stat-pendentes'),
+    },
+    summary: {
+      title: root.querySelector('#summary-title'),
+      date: root.querySelector('#summary-date'),
+      status: root.querySelector('#summary-status'),
+      local: root.querySelector('#summary-local'),
+      endereco: root.querySelector('#summary-endereco'),
+      cerimonialista: root.querySelector('#summary-cerimonialista'),
+      anfitriao: root.querySelector('#summary-anfitriao'),
+      resumo: root.querySelector('#summary-resumo'),
+    },
+  };
+}
+
+function updateStats(refs, lista) {
+  const stats = computeStats(lista);
+  if (refs.stats.total) refs.stats.total.textContent = stats.total;
+  if (refs.stats.enviados) refs.stats.enviados.textContent = stats.enviados;
+  if (refs.stats.confirmados) refs.stats.confirmados.textContent = stats.confirmados;
+  if (refs.stats.pendentes) refs.stats.pendentes.textContent = stats.pendentes;
+}
+
+function computeStats(lista) {
+  const stats = {
+    total: lista.length,
+    enviados: 0,
+    confirmados: 0,
+    pendentes: 0,
+  };
+
+  lista.forEach((item) => {
+    if (item?.envio?.enviado) stats.enviados += 1;
+    if (typeof item?.rsvp?.confirmadosN === 'number') {
+      stats.confirmados += item.rsvp.confirmadosN;
+    }
+    if (!item?.envio?.enviado || (item?.rsvp?.status || 'pendente') === 'pendente') {
+      stats.pendentes += 1;
+    }
+  });
+
+  return stats;
+}
+
+function updateSummary(refs, project) {
+  const ev = project?.evento || {};
+  const cer = project?.cerimonialista || {};
+  const anfitriao = ev?.anfitriao || {};
+
+  if (refs.summary.title) refs.summary.title.textContent = ev.titulo || 'Defina o nome do evento';
+  if (refs.summary.date) refs.summary.date.textContent = formatDate(ev.data, ev.hora);
+
+  const lista = Array.isArray(project?.lista) ? project.lista : [];
+  if (refs.summary.status) {
+    refs.summary.status.textContent = lista.length ? 'Em andamento' : 'Comece adicionando convites';
+  }
+
+  if (refs.summary.local) refs.summary.local.textContent = ev.local || 'Informe o local';
+  if (refs.summary.endereco) refs.summary.endereco.textContent = formatEndereco(ev);
+  if (refs.summary.cerimonialista) refs.summary.cerimonialista.textContent = cer.nomeCompleto || 'Cadastre o organizador';
+  if (refs.summary.anfitriao) refs.summary.anfitriao.textContent = anfitriao.nome || 'Cadastre o anfitrião';
+  if (refs.summary.resumo) {
+    refs.summary.resumo.innerHTML = ev.resumo
+      ? sanitize(ev.resumo)
+      : '<span class="ac-muted">Use os formulários abaixo para registrar o resumo do evento.</span>';
+  }
+}
+
+function bindForms(root, ctx, refs, projectGetter) {
+  const formGeral = root.querySelector('#form-geral');
+  const formOrganizador = root.querySelector('#form-organizador');
+  const formAnfitriao = root.querySelector('#form-anfitriao');
+
+  if (formGeral) {
+    formGeral.addEventListener('submit', async (evt) => {
+      evt.preventDefault();
+      const data = new FormData(formGeral);
+      const project = projectGetter();
+      const nextEvento = {
+        ...project.evento,
+        titulo: (data.get('titulo') || '').trim(),
+        data: data.get('data') || '',
+        hora: data.get('hora') || '',
+        local: (data.get('local') || '').trim(),
+        resumo: (data.get('resumo') || '').trim(),
+        endereco: {
+          ...(project.evento?.endereco || {}),
+          logradouro: (data.get('endereco') || '').trim(),
+        },
+      };
+
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        evento: nextEvento,
+      });
+      Object.assign(project, updated);
+      updateSummary(refs, updated);
+      notify(ctx, 'Dados gerais atualizados.');
+    });
+  }
+
+  if (formOrganizador) {
+    formOrganizador.addEventListener('submit', async (evt) => {
+      evt.preventDefault();
+      const data = new FormData(formOrganizador);
+      const project = projectGetter();
+      const nextCer = {
+        ...project.cerimonialista,
+        nomeCompleto: (data.get('nome') || '').trim(),
+        telefone: (data.get('telefone') || '').trim(),
+        redeSocial: (data.get('redeSocial') || '').trim(),
+      };
+
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        cerimonialista: nextCer,
+      });
+      Object.assign(project, updated);
+      updateSummary(refs, updated);
+      notify(ctx, 'Organizador atualizado.');
+    });
+  }
+
+  if (formAnfitriao) {
+    formAnfitriao.addEventListener('submit', async (evt) => {
+      evt.preventDefault();
+      const data = new FormData(formAnfitriao);
+      const project = projectGetter();
+      const nextHost = {
+        ...project.evento?.anfitriao,
+        nome: (data.get('nome') || '').trim(),
+        contato: (data.get('contato') || '').trim(),
+        observacao: (data.get('observacao') || '').trim(),
+      };
+
+      const updated = await ctx.store.updateProject(ctx.projectId, {
+        evento: {
+          ...project.evento,
+          anfitriao: nextHost,
+        },
+      });
+      Object.assign(project, updated);
+      updateSummary(refs, updated);
+      notify(ctx, 'Dados do anfitrião atualizados.');
+    });
+  }
+}
+
+function formatDate(dateStr, timeStr) {
+  if (!dateStr && !timeStr) return 'Defina data e horário';
+  let dateLabel = 'Defina a data';
+  if (dateStr) {
+    const parts = dateStr.split('-').map(Number);
+    if (parts.length >= 3) {
+      const [y, m, d] = parts;
+      const date = new Date(Date.UTC(y, m - 1, d));
+      dateLabel = new Intl.DateTimeFormat('pt-BR', {
+        weekday: 'long',
+        day: '2-digit',
+        month: 'long',
+      }).format(date);
+    } else {
+      dateLabel = dateStr;
+    }
+  }
+
+  const timeLabel = timeStr ? `${timeStr}h` : 'Horário a definir';
+  return `${dateLabel} · ${timeLabel}`;
+}
+
+function formatEndereco(ev) {
+  const end = ev?.endereco || {};
+  if (end.logradouro) return end.logradouro;
+  return 'Endereço a definir';
+}
+
+function sanitize(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML.replace(/\n/g, '<br/>');
+}
+
+function row(item) {
   const tr = document.createElement('tr');
   tr.dataset.id = item.id;
-  const enviadoEm = item.envio?.enviadoEm ? new Date(item.envio.enviadoEm).toLocaleString() : '-';
+  const enviadoEm = item.envio?.enviadoEm
+    ? new Date(item.envio.enviadoEm).toLocaleString()
+    : '-';
   const rsvp = item.rsvp?.status || 'pendente';
   const conf = item.rsvp?.confirmadosN ?? 0;
   tr.innerHTML = `
@@ -141,7 +537,7 @@ function row(item){
     <td>${item.totalConvite}</td>
     <td>${item.envio?.enviado ? 'Sim' : 'Não'}</td>
     <td>${enviadoEm}</td>
-    <td><span class="ac-badge ac-badge--${rsvp}">${rsvp.replace('_',' ')}</span></td>
+    <td><span class="ac-badge ac-badge--${rsvp}">${rsvp.replace('_', ' ')}</span></td>
     <td>${conf}/${item.totalConvite}</td>
     <td class="ac-actions-col">
       <button data-action="editar">Editar</button>
@@ -154,14 +550,19 @@ function row(item){
   return tr;
 }
 
-function openDrawer(host, item, onSave){
+function openDrawer(host, item, onSave) {
   host.hidden = false;
-  const nomes = [item.principal, ...(item.acompanhantesNomes||[])].filter(Boolean);
-  const checks = nomes.map(n => {
-    const checked = item.rsvp.confirmadosNomes?.includes(n) ? 'checked' : '';
-    return `<label><input type="checkbox" data-name="${n}" ${checked}/> ${n}</label>`;
-  }).join('') || '<em>Sem nomes de acompanhantes — use o seletor numérico.</em>';
-  const numOptions = Array.from({length:item.totalConvite+1}, (_,i)=>`<option value="${i}" ${i===item.rsvp.confirmadosN?'selected':''}>${i}</option>`).join('');
+  const nomes = [item.principal, ...(item.acompanhantesNomes || [])].filter(Boolean);
+  const checks = nomes
+    .map((n) => {
+      const checked = item.rsvp.confirmadosNomes?.includes(n) ? 'checked' : '';
+      return `<label><input type="checkbox" data-name="${n}" ${checked}/> ${n}</label>`;
+    })
+    .join('') || '<em>Sem nomes de acompanhantes — use o seletor numérico.</em>';
+  const numOptions = Array.from(
+    { length: item.totalConvite + 1 },
+    (_, i) => `<option value="${i}" ${i === item.rsvp.confirmadosN ? 'selected' : ''}>${i}</option>`
+  ).join('');
   host.innerHTML = `
     <div class="ac-drawer__overlay"></div>
     <div class="ac-drawer__panel">
@@ -184,13 +585,13 @@ function openDrawer(host, item, onSave){
                 <select id="f-conf">${numOptions}</select>
               </label>
             </div>
-            <label>Observação <input id="f-obs" value="${item.rsvp?.observacao||''}"/></label>
+            <label>Observação <input id="f-obs" value="${item.rsvp?.observacao || ''}"/></label>
           </div>
         </fieldset>
         <fieldset class="ac-fieldset">
           <legend>Envio</legend>
-          <label><input type="checkbox" id="f-enviado" ${item.envio?.enviado?'checked':''}/> Mensagem enviada</label>
-          <label>Modelo <input id="f-modelo" value="${item.envio?.modeloId||''}" placeholder="Opcional: id do modelo"/></label>
+          <label><input type="checkbox" id="f-enviado" ${item.envio?.enviado ? 'checked' : ''}/> Mensagem enviada</label>
+          <label>Modelo <input id="f-modelo" value="${item.envio?.modeloId || ''}" placeholder="Opcional: id do modelo"/></label>
         </fieldset>
       </div>
       <footer class="ac-drawer__footer">
@@ -199,32 +600,46 @@ function openDrawer(host, item, onSave){
       </footer>
     </div>
   `;
-  const close = ()=>{ host.hidden = true; host.innerHTML=''; };
-  host.querySelector('#close').onclick = close;
-  host.querySelector('.ac-drawer__overlay').onclick = close;
-  host.querySelector('#cancel').onclick = close;
-  host.querySelector('#save').onclick = async ()=>{
-    const next = structuredClone(item);
-    next.nome = host.querySelector('#f-nome').value.trim() || item.nome;
-    next.telefone = host.querySelector('#f-tel').value.trim() || item.telefone;
-    next.totalConvite = Math.max(1, parseInt(host.querySelector('#f-total').value||item.totalConvite,10));
-    // RSVP via nomes marcados (quando houver) OU seletor numérico
-    const marked = Array.from(host.querySelectorAll('.ac-rsvp__names input[type=checkbox]:checked')).map(i=>i.dataset.name);
-    const confByNames = marked.length > 0;
-    next.rsvp = next.rsvp || {};
-    next.rsvp.confirmadosNomes = confByNames ? marked : [];
-    next.rsvp.confirmadosN = confByNames ? marked.length : parseInt(host.querySelector('#f-conf').value,10);
-    next.rsvp.status = next.rsvp.confirmadosN === 0 ? 'ausente' : (next.rsvp.confirmadosN === next.totalConvite ? 'confirmado_total' : 'confirmado_parcial');
-    next.rsvp.observacao = host.querySelector('#f-obs').value.trim();
-    next.rsvp.atualizadoEm = Date.now();
-    // Envio
-    next.envio = next.envio || {};
-    next.envio.enviado = host.querySelector('#f-enviado').checked;
-    next.envio.enviadoEm = next.envio.enviado ? (next.envio.enviadoEm || Date.now()) : null;
-    next.envio.modeloId = host.querySelector('#f-modelo').value.trim() || null;
-    await onSave(next);
-    close();
+
+  const close = () => {
+    host.hidden = true;
+    host.innerHTML = '';
   };
+
+  host.querySelector('#cancel').addEventListener('click', close);
+  host.querySelector('#close').addEventListener('click', close);
+  host.querySelector('.ac-drawer__overlay').addEventListener('click', close);
+  host.querySelector('#save').addEventListener('click', async () => {
+    const next = {
+      ...item,
+      nome: host.querySelector('#f-nome').value.trim(),
+      telefone: host.querySelector('#f-tel').value.trim(),
+      totalConvite: Number(host.querySelector('#f-total').value) || item.totalConvite,
+      rsvp: {
+        ...item.rsvp,
+        confirmadosN: Number(host.querySelector('#f-conf').value) || 0,
+        confirmadosNomes: Array.from(host.querySelectorAll('input[data-name]:checked')).map((c) => c.dataset.name),
+        observacao: host.querySelector('#f-obs').value.trim(),
+        status: deriveStatus(item, host),
+        atualizadoEm: Date.now(),
+      },
+      envio: {
+        ...item.envio,
+        enviado: host.querySelector('#f-enviado').checked,
+        enviadoEm: host.querySelector('#f-enviado').checked ? Date.now() : null,
+        modeloId: host.querySelector('#f-modelo').value.trim() || null,
+      },
+    };
+    close();
+    await onSave(next);
+  });
 }
 
-export function destroy(){} 
+function deriveStatus(item, host) {
+  const enviado = host.querySelector('#f-enviado').checked;
+  const confirmados = Number(host.querySelector('#f-conf').value) || 0;
+  if (confirmados >= item.totalConvite) return 'confirmado_total';
+  if (confirmados > 0) return 'confirmado_parcial';
+  if (enviado) return 'aguardando_resposta';
+  return 'pendente';
+}


### PR DESCRIPTION
## Summary
- redesign the standalone convite dashboard to include event summary cards, organizer and host forms, and inline sanitization helpers
- expand shared dashboard styles for status metrics and three-column forms used by both embed and module views
- enhance the convites module to hydrate stats/summary consistently and persist organizer/host details in the project store

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d868d5d2a08320845c5c9202514c17