### PR TITLE
Unifica CSS compartilhado em app.css

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -4,12 +4,20 @@
 Este documento fornece um rápido resumo para quem automatiza tarefas neste repositório, descrevendo práticas recomendadas e pontos de atenção ao modificar os módulos compartilhados do projeto.
 
 ## Diretrizes Gerais
-- 
+- Priorize o reaproveitamento de módulos em `tools/shared/`. Promova qualquer lógica recorrente encontrada em `tools/unique/` e documente a migração.
+- Ao modificar `apps/eventos.html`, garanta que o carregamento use `loadSharedModule`/`loadSharedModules` e que novos widgets sejam registrados via `miniAppSync`.
+- Sempre que criar ou alterar miniapps, atualize `docs/arquitetura.md`, `readme.md` e `log.md` com o motivo, uso futuro e instruções de montagem.
+- Evite `<style>` inline: carregue a base visual com `ensureSharedStyle('styles/app.css')` e promova utilitários visuais para `tools/shared/styles/`.
 
 ## Convenções de Estilo
-- 
+- Nomeie arquivos JavaScript em `tools/shared/miniapps/` como `vN.mjs`, mantendo versionamento explícito.
+- Prefira imports relativos ao loader (`loadSharedModule('core/projectStore.js')`) em vez de caminhos absolutos.
+- Documente funções exportadas com comentários focados no *porquê* da decisão.
 
 ## Checklist Rápido
-1. 
+1. Revisar `apps/eventos.html` para confirmar que o miniapp desejado está registrado com `ensureMiniApp`.
+2. Atualizar README(s) relevantes com instruções de uso e dependências.
+3. Registrar a alteração em `log.md`, incluindo objetivo, impacto e próximos passos.
+4. Validar manualmente o fluxo "clique no lápis → painel → persistência" após qualquer mudança em miniapps.
 
 Seguir estas orientações ajuda a manter o código consistente e facilita o trabalho colaborativo entre agentes e desenvolvedores humanos.

--- a/agent.md
+++ b/agent.md
@@ -8,6 +8,7 @@ Este documento fornece um rápido resumo para quem automatiza tarefas neste repo
 - Ao modificar `apps/eventos.html`, garanta que o carregamento use `loadSharedModule`/`loadSharedModules` e que novos widgets sejam registrados via `miniAppSync`.
 - Sempre que criar ou alterar miniapps, atualize `docs/arquitetura.md`, `readme.md` e `log.md` com o motivo, uso futuro e instruções de montagem.
 - Evite `<style>` inline: carregue a base visual com `ensureSharedStyle('styles/app.css')` e promova utilitários visuais para `tools/shared/styles/`.
+- Durante implantações em WordPress/Elementor, garanta que o loader saiba qual branch consumir configurando `window.__MARCO_BRANCH__` (ou `configureSharedRuntime({ branch })`) antes de montar os miniapps.
 
 ## Convenções de Estilo
 - Nomeie arquivos JavaScript em `tools/shared/miniapps/` como `vN.mjs`, mantendo versionamento explícito.

--- a/apps/eventos.html
+++ b/apps/eventos.html
@@ -307,6 +307,8 @@
   </main>
 
   <script type="module">
+    // Para testar um branch específico durante a implantação, defina
+    // `window.__MARCO_BRANCH__` ou adicione `?branch=` à URL antes de carregar este módulo.
     import { loadSharedModule, ensureSharedStyle } from '../tools/shared/runtime/loader.mjs';
 
     await ensureSharedStyle('styles/app.css', { key: 'ac-shared-styles' });

--- a/apps/eventos.html
+++ b/apps/eventos.html
@@ -4,31 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Gerenciar Eventos — AC (v2) + Mini‑Apps Fornecedores & Convidados</title>
-  <!-- Estilos locais, mínimos e escopados -->
-  <style>
-    /* ===== KPIs / MiniApps ===== */
-    #cardIndicadores .mini.kpi{position:relative;display:flex;flex-direction:column;justify-content:center;min-height:150px}
-    #cardIndicadores .mini.kpi .label{font-weight:600;margin-bottom:8px;display:flex;align-items:center;justify-content:flex-start}
-    #cardIndicadores .mini.kpi .label .title{color:#0b65c2}
-    /* h3 nos títulos dos KPIs para padronizar com os badges acima */
-    #cardIndicadores .mini.kpi .label h3{margin:0 48px 2px 0;font-size:14px;line-height:1.2;color:#0b65c2;display:flex;align-items:center}
-    /* Destaque laranja quando o mini-app estiver expandido */
-    #cardIndicadores .mini.kpi.active{border-color:#ffa245;background:#fff7ed;box-shadow:0 0 0 1px #ffa245 inset}
-    #cardIndicadores #secTarefas[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-    #cardIndicadores #secFornecedores[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-    #cardIndicadores #secConvidados[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-    #cardIndicadores .mini.kpi .actions{position:absolute;top:10px;right:10px}
-    #cardIndicadores .mini.kpi .edit-btn{border:1px solid #cccccc;background:#ffffff;border-radius:10px;padding:4px 8px;cursor:pointer;line-height:1}
-
-    #cardIndicadores .progress.progress--lg .progress__track{height:10px;border-radius:6px;background:#eef2f6}
-    #cardIndicadores .progress.progress--lg .progress__bar{height:10px;border-radius:6px;background:#0b65c2;transition:width .25s ease}
-    #cardIndicadores .hbar-legend{display:flex;justify-content:space-between;gap:8px;margin-top:8px;font-size:.875rem;color:#555}
-    #cardIndicadores .progress--segments .progress__track{display:flex;gap:2px;align-items:center}
-    #cardIndicadores .progress--segments .seg{height:10px;border-radius:4px;background:#0b65c2;flex:0 0 auto}
-    #cardIndicadores .muted{opacity:.75}
-    #cardIndicadores details>summary{display:none}
-    @media (max-width:640px){#cardIndicadores .mini.kpi{min-height:140px}}
-  </style>
 </head>
 <body>
   <main class="ac">
@@ -42,19 +17,19 @@
             <div class="small muted" id="updatedWrap">Atualizado: <span id="updatedAt">—</span></div>
           </div>
 
-          <div class="select-block" style="margin-left:auto">
-            <label class="small" for="switchEvent">Selecionar evento</label>
-            <select id="switchEvent"></select>
+        <div class="select-block push-end">
+          <label class="small" for="switchEvent">Selecionar evento</label>
+          <select id="switchEvent"></select>
 
-            <div class="row" style="align-items:center">
-              <button id="btnNew" class="btn btn--ghost" type="button">Novo</button>
-              <button id="btnDelete" class="btn btn--ghost danger" type="button">Excluir</button>
-              <!-- Pílulas de status ALINHADAS ao lado dos botões -->
-              <span id="chipReady"  class="pill pillok" style="margin-left:8px">Pronto</span>
-              <span id="chipDirty"  class="pill pillwarn"   style="display:none;margin-left:8px">Edição não salva</span>
-              <span id="chipSaving" class="pill pillsaving" style="display:none;margin-left:8px">Salvando…</span>
-            </div>
+          <div class="row row--center status-stack">
+            <button id="btnNew" class="btn btn--ghost" type="button">Novo</button>
+            <button id="btnDelete" class="btn btn--ghost danger" type="button">Excluir</button>
+            <!-- Pílulas de status ALINHADAS ao lado dos botões -->
+            <span id="chipReady"  class="pill pillok pill--status">Pronto</span>
+            <span id="chipDirty"  class="pill pillwarn pill--status">Edição não salva</span>
+            <span id="chipSaving" class="pill pillsaving pill--status">Salvando…</span>
           </div>
+        </div>
         </div>
 
         <!-- BADGES -->
@@ -282,7 +257,7 @@
           <div class="mini kpi" id="kpi_tasks">
             <div class="label"><h3 class="title" id="kpi_task_title">Tarefas</h3></div>
             <div class="actions"><button class="edit-btn" data-open="#secTarefas" aria-label="Editar tarefas" title="Abrir painel de tarefas">✎</button></div>
-            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_task_bar" class="progress__bar" style="width:0%"></div></div></div>
+            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_task_bar" class="progress__bar"></div></div></div>
             <div class="hbar-legend"><span id="kpi_task_lbl1">0 concluídas — 0%</span><span id="kpi_task_lbl2">Total: 0</span></div>
           </div>
 
@@ -290,7 +265,7 @@
           <div class="mini kpi" id="kpi_for">
             <div class="label"><h3 class="title" id="kpi_for_title">Fornecedores</h3></div>
             <div class="actions"><button class="edit-btn" data-open="#secFornecedores" aria-label="Editar fornecedores" title="Abrir painel de fornecedores">✎</button></div>
-            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_for_bar" class="progress__bar" style="width:0%"></div></div></div>
+            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_for_bar" class="progress__bar"></div></div></div>
             <div class="hbar-legend"><span id="kpi_for_lbl1">R$ 0,00 pagos — 0%</span><span id="kpi_for_lbl2">Total: R$ 0,00</span></div>
           </div>
 
@@ -298,7 +273,7 @@
           <div class="mini kpi" id="kpi_guests">
             <div class="label"><h3 class="title" id="kpi_guest_title">Convidados &amp; Convites</h3></div>
             <div class="actions"><button class="edit-btn" data-open="#secConvidados" aria-label="Editar convidados" title="Abrir painel de convidados">✎</button></div>
-            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_guest_bar" class="progress__bar" style="width:0%"></div></div></div>
+            <div class="progress progress--lg"><div class="progress__track"><div id="kpi_guest_bar" class="progress__bar"></div></div></div>
             <div class="hbar-legend"><span id="kpi_guest_lbl1">0 confirmados — 0%</span><span id="kpi_guest_lbl2">Total: 0</span></div>
             <div class="progress progress--lg progress--segments" aria-label="Distribuição por mesas/grupos"><div class="progress__track" id="kpi_guest_bands"></div></div>
             <div class="small muted" id="kpi_guest_legend"></div>
@@ -314,17 +289,17 @@
         </div>
 
         <!-- ===== MiniApp Tarefas ===== -->
-        <details id="secTarefas"><summary>Tarefas</summary>
+        <details id="secTarefas" data-highlight="orange"><summary>Tarefas</summary>
           <div class="details-wrap"><div id="tasks_host"></div><div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div></div>
         </details>
 
         <!-- ===== MiniApp Fornecedores ===== -->
-        <details id="secFornecedores"><summary>Fornecedores</summary>
+        <details id="secFornecedores" data-highlight="orange"><summary>Fornecedores</summary>
           <div class="details-wrap"><div id="fornecedores_host"></div><div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div></div>
         </details>
 
         <!-- ===== MiniApp Convidados ===== -->
-        <details id="secConvidados"><summary>Convidados</summary>
+        <details id="secConvidados" data-highlight="orange"><summary>Convidados</summary>
           <div class="details-wrap"><div id="guests_host"></div><div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div></div>
         </details>
       </section>
@@ -332,35 +307,33 @@
   </main>
 
   <script type="module">
-    // ====================== Shared Modules ======================
-    const PATH_BUS    = "/shared/marcoBus.js";
-    const PATH_STORE  = "/shared/projectStore.js";
-    const PATH_CORE   = "/shared/acEventsCore.v2.mjs";
-    const PATH_TASKS  = "/shared/acTasks.v1.mjs";            // MiniApp tarefas
-    const PATH_FORNEC = "/shared/acFornecedores.v1.mjs";      // MiniApp fornecedores (shared)
-    const PATH_GUESTS = "/shared/acConvidados.v1.mjs";        // MiniApp convidados (shared)
+    import { loadSharedModule, ensureSharedStyle } from '../tools/shared/runtime/loader.mjs';
 
-    const CANDIDATES = [
-      "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main", // githack primeiro
-      "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main"
-    ];
-    async function tryImport(url){
-      try{ return await import(url); }
-      catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } }
-    }
-    async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+    await ensureSharedStyle('styles/app.css', { key: 'ac-shared-styles' });
 
-    const store     = await loadShared(PATH_STORE);
-    const bus       = await loadShared(PATH_BUS);
-    const ac        = await loadShared(PATH_CORE);
-    const tasksMod  = await loadShared(PATH_TASKS);
-    const fornMod   = await loadShared(PATH_FORNEC);
-    const guestsMod = await loadShared(PATH_GUESTS);
+    const store     = await loadSharedModule('core/projectStore.js');
+    const bus       = await loadSharedModule('core/marcoBus.js');
+    const ac        = await loadSharedModule('core/eventsCore.v2.mjs');
+    const tasksMod  = await loadSharedModule('miniapps/tarefas/v1.mjs');
+    const fornMod   = await loadSharedModule('miniapps/fornecedores/v1.mjs');
+    const guestsMod = await loadSharedModule('miniapps/convidados/v1.mjs');
+    const miniSync  = await loadSharedModule('core/miniAppSync.mjs');
+
     await store?.init?.();
+
+    const { createMiniAppSync } = miniSync;
 
     // ====================== Estado & helpers ======================
     const AUTO_SAVE_MS = 700;
     const state = { currentId:null, project:null, metas:[], dirty:false, saving:false, timer:null };
+    const miniApps = createMiniAppSync({ ac, store, bus, getCurrentId: () => state.currentId });
+    miniApps.register('#tasks_host', tasksMod, { mountKey: 'mountTasksMiniApp' });
+    miniApps.register('#fornecedores_host', fornMod, { mountKey: 'mountFornecedoresMiniApp' });
+    miniApps.register('#guests_host', guestsMod, { mountKey: 'mountConvidadosMiniApp' });
+    ['#tasks_host','#fornecedores_host','#guests_host'].forEach(sel => {
+      const host = document.querySelector(sel);
+      if (host?.dataset?.mounted) delete host.dataset.mounted;
+    });
     const $  = (s)=> document.querySelector(s);
     const $$ = (s)=> [...document.querySelectorAll(s)];
 
@@ -398,6 +371,7 @@
       chipDirty.style.display = (state.dirty && !state.saving)? 'inline-block':'none';
       chipSaving.style.display= state.saving? 'inline-block':'none';
     }
+    renderStatus();
     function setDirty(v){ state.dirty=!!v; renderStatus(); }
     function setSaving(v){ state.saving=!!v; renderStatus(); }
 
@@ -591,28 +565,9 @@
 
     function publishCurrent(){ if(state.currentId) bus.publish('ac:open-event',{ id: state.currentId, from:'eventos' }); }
 
-    function mountTasksIfNeeded(){
-      const host = document.querySelector('#tasks_host');
-      if(host && !host?.dataset?.mounted && tasksMod?.mountTasksMiniApp){
-        tasksMod.mountTasksMiniApp(host, { ac, store, bus, getCurrentId: ()=> state.currentId });
-        host.dataset.mounted = '1';
-      }
-    }
-
-    function mountFornecedoresIfNeeded(){
-      const host = document.querySelector('#fornecedores_host');
-      if(host && !host.dataset.mounted && fornMod?.mountFornecedoresMiniApp){
-        fornMod.mountFornecedoresMiniApp(host, { ac, store, bus, getCurrentId: ()=> state.currentId });
-        host.dataset.mounted = '1';
-      }
-    }
-    function mountConvidadosIfNeeded(){
-      const host = document.querySelector('#guests_host');
-      if(host && !host.dataset.mounted && guestsMod?.mountConvidadosMiniApp){
-        guestsMod.mountConvidadosMiniApp(host, { ac, store, bus, getCurrentId: ()=> state.currentId });
-        host.dataset.mounted = '1';
-      }
-    }
+    function mountTasksIfNeeded(){ miniApps.ensure('#tasks_host'); }
+    function mountFornecedoresIfNeeded(){ miniApps.ensure('#fornecedores_host'); }
+    function mountConvidadosIfNeeded(){ miniApps.ensure('#guests_host'); }
 
     async function loadCurrent(id){
       state.currentId=id||state.currentId;

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,74 @@
+# Arquitetura do Projeto Marco
+
+## Ciclo de Vida `mount…MiniApp`
+1. **Bootstrap**: o app orquestrador carrega o layout base, resolve permissões via `ac` (Access Control) e registra listeners globais no `marcoBus`.
+2. **Inicialização do estado**: o `projectStore` é instanciado com o `getCurrentId`, garantindo que o contexto do evento/cliente atual esteja disponível antes do render.
+3. **Montagem de widgets**: a função `mount<Evento>MiniApp` (ou variações equivalentes) injeta dependências (`ac`, `store`, `bus`) e monta widgets compartilhados conforme a configuração do fluxo.
+4. **Execução ativa**: durante o uso, os widgets publicam e escutam eventos via `bus`, sincronizando persistência e UI. O `store` reage a cada atualização e mantém o snapshot coeso.
+5. **Desmontagem/cleanup**: ao trocar de contexto, o app cancela subscriptions do `bus`, persiste alterações pendentes e libera referências do `store` para evitar vazamentos.
+
+## Dependências Necessárias
+- **`ac`**: módulo de controle de acesso, responsável por liberar ou bloquear funcionalidades a partir do perfil do executivo.
+- **`store` (`projectStore`)**: fonte da verdade, provê `getState`, `setState` e eventos de mudança para widgets.
+- **`bus` (`marcoBus`)**: barramento de eventos baseado em publish/subscribe usado para comunicação cross-widget.
+- **`getCurrentId`**: utilitário que retorna o identificador ativo (evento, convidado ou equipe), garantindo consistência na inicialização.
+
+Todos os miniapps devem receber essas dependências como parâmetros explícitos para facilitar testes e permitir mocks durante pipelines de QA.
+
+## Metodologia de UX Executiva
+1. **Ponto de entrada consistente**: o ícone de lápis abre sempre o mesmo painel lateral (`EditorPanel`) a partir de um evento `editor:open`. Os apps publicam o payload `{ id: getCurrentId(), source: <miniapp> }`, permitindo que widgets compartilhem a experiência de edição.
+2. **Layout previsível**: o painel lateral possui largura fixa de 420px, com header contendo breadcrumbs (`ac.getCurrentRole() → evento atual`) e botões `Salvar`/`Cancelar`. Campos obrigatórios aparecem com label alinhada à esquerda e descrição auxiliar de 12px logo abaixo.
+3. **Sequência de interação**:
+   - O app orquestrador dispara `miniapp:ready` após montar os widgets.
+   - Ao clicar no lápis, um widget publica `editor:open`; o painel consome esse evento e solicita ao `store` o snapshot atual via `getState`.
+   - Alterações são mantidas em um `draftState` local até que o usuário clique em `Salvar`, quando então emitimos `editor:commit` e atualizamos o `projectStore`.
+   - O fechamento do painel emite `editor:close`, que deve limpar listeners e restaurar foco para o card original.
+4. **Posicionamento e espaçamento**: cards principais utilizam grid de 12 colunas com gutters de 16px. Ações primárias permanecem no canto inferior direito do card, enquanto ações secundárias ficam no menu `…` ou ao lado do título. Use a paleta `MarcoBlue 600` para CTA primário e `MarcoGray 400` para textos auxiliares.
+
+## Diretrizes para `shared` e `unique`
+- **`tools/shared/`**: catálogo público com widgets e integrações reutilizáveis. Concentre aqui componentes que espelham capacidades comuns (Google Calendar, Marco Banzo, notificações padrão) e que possam ser versionados sem depender de um app específico.
+- **`tools/unique/`**: espaço controlado para módulos pontuais ou confidenciais. Utilize-o para conectores raros, fluxos de clientes específicos ou funcionalidades que não devem poluir o catálogo compartilhado.
+- Sempre que uma implementação em `unique` demonstrar valor recorrente, promova-a para `shared`, garantindo documentação de migração e redução de duplicidades.
+
+### Organização de `tools/shared/`
+- **`core/`**: infraestrutura de runtime (IndexedDB `projectStore`, `marcoBus`, utilitários `eventsCore`, `miniAppSync`).
+- **`miniapps/`**: widgets executivos versionados por domínio (`tarefas/v1.mjs`, `fornecedores/v1.mjs`, `convidados/v1.mjs`, `mensagens/v1.mjs`).
+- **`styles/`**: camada visual unificada (`app.css`) que cobre layout do app de Eventos, utilitários de miniapps e catálogo de convites.
+- **`utils/`**: utilitários comuns (DOM, IDs, formatação BR, parsing de listas/convites).
+- **`runtime/`**: loader público que resolve módulos locais ou das CDNs oficiais.
+
+### Base comum de carregamento
+- O arquivo `tools/shared/runtime/loader.mjs` centraliza o algoritmo de import dinâmico. Ele tenta carregar primeiro dos caminhos locais (`../`, `./`, `/tools/shared/`) e, em seguida, das CDNs públicas (`rawcdn.githack` e `jsDelivr`).
+- Os orquestradores devem preferir `loadSharedModule('<subpasta/arquivo>')` para resolver dependências compartilhadas, evitando que cada app replique listas de URLs ou tratamentos de fallback.
+- O loader exporta também `loadSharedModules([...])`, útil para resolver pacotes em paralelo durante o bootstrap e manter o tempo de montagem previsível, e `ensureSharedStyle('styles/app.css')` para injetar a folha de estilo compartilhada sem duplicar `<style>` inline.
+- Ao promover um módulo de `unique` para `shared`, lembre-se de atualizar o README do app orquestrador para apontar para o caminho canônico em `tools/shared/`.
+- Para coordenar a montagem única dos widgets, utilize `core/miniAppSync.mjs`, que expõe `ensureMiniApp` e `createMiniAppSync` e substitui flags manuais em `dataset`.
+
+### Fluxo para registrar um miniapp no `apps/eventos.html`
+1. **Importação**: adicione no bloco de bootstrap a chamada `await loadSharedModules(['core/miniAppSync.mjs', 'miniapps/<domínio>/vN.mjs'])`.
+2. **Sincronizador**: instancie `const { ensureMiniApp, createMiniAppSync } = sharedMiniAppSync;` (ou equivalente) e inicialize `const sync = createMiniAppSync({ ac, store, bus, getCurrentId });`.
+3. **Registro**: use `sync.ensureMiniApp('<domínio>', () => mount<Domínio>MiniApp({ ac, store, bus, getCurrentId }));` dentro do `DOMContentLoaded` para garantir montagem única e idempotente.
+4. **Eventos**: valide que o miniapp publica `miniapp:ready` após a montagem, dispara `editor:open` ao abrir o painel e consome `editor:close` para limpar o estado temporário.
+5. **Telemetria/documentação**: registre o domínio e a versão do miniapp na seção "Miniapps conectados" do README do app e adicione uma linha no `log.md` com a data e o racional da integração.
+
+### Checklist de documentação após cada entrega
+- Atualize este guia sempre que surgir uma nova dependência obrigatória ou alteração na sequência de eventos.
+- Revise o README raiz com instruções de uso para o novo miniapp e referências às ferramentas em `tools/shared/`.
+- Garanta que `agent.md` liste qualquer atenção extra para automação (ex.: scripts de build, padrões de nome).
+- Acrescente ao `log.md` uma entrada descrevendo o objetivo, o motivo da mudança e como reutilizar o resultado em futuras entregas.
+
+## Guidelines de Estilo e Nomenclatura
+- Prefira nomes de arquivos no formato `kebab-case` para HTML/CSS e `camelCase` para módulos JavaScript.
+- Funções de montagem devem seguir o padrão `mount<Contexto>MiniApp`, mantendo o `<Contexto>` alinhado ao domínio (ex.: `mountEventosMiniApp`).
+- Widgets compartilhados expõem APIs em português claro, com verbos no infinitivo (`abrirConvite`, `sincronizarAgenda`).
+- Comentários devem indicar o motivo da decisão arquitetural, evitando descrever o óbvio.
+- Cada novo módulo precisa declarar suas dependências no topo e exportar uma função `setup` quando houver inicialização externa.
+
+## Processo para Novos Miniapps
+1. **Descoberta**: alinhar com a equipe de negócios o objetivo do miniapp e mapear quais widgets compartilhados já suprem o fluxo.
+2. **Design técnico**: documentar no README da pasta do app quais eventos serão publicados/consumidos e quais dependências (`ac`, `store`, `bus`) são necessárias.
+3. **Implementação**: iniciar pelo esqueleto `mount<Contexto>MiniApp`, conectar widgets compartilhados e só então criar módulos `unique` caso ainda existam lacunas.
+4. **Validação**: executar o checklist de UX (clique no lápis → painel → salvamento) e registrar testes manuais no `log.md`.
+5. **Lançamento**: abrir PR descrevendo o comportamento, dependências e quaisquer ajustes no catálogo compartilhado, mantendo rastreabilidade para evoluções futuras.
+
+Seguir esta metodologia garante que qualquer pessoa consiga replicar a experiência do cliente e expandir o ecossistema rumo à versão 3.0 executiva.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -41,6 +41,7 @@ Todos os miniapps devem receber essas dependências como parâmetros explícitos
 - O arquivo `tools/shared/runtime/loader.mjs` centraliza o algoritmo de import dinâmico. Ele tenta carregar primeiro dos caminhos locais (`../`, `./`, `/tools/shared/`) e, em seguida, das CDNs públicas (`rawcdn.githack` e `jsDelivr`).
 - Os orquestradores devem preferir `loadSharedModule('<subpasta/arquivo>')` para resolver dependências compartilhadas, evitando que cada app replique listas de URLs ou tratamentos de fallback.
 - O loader exporta também `loadSharedModules([...])`, útil para resolver pacotes em paralelo durante o bootstrap e manter o tempo de montagem previsível, e `ensureSharedStyle('styles/app.css')` para injetar a folha de estilo compartilhada sem duplicar `<style>` inline.
+- Durante implantações em um branch específico, informe o alvo via query string (`?branch=`/`?marco-branch=`), variável global (`window.__MARCO_BRANCH__`) ou atributo `data-marco-branch` no `<script type="module">`. O helper `configureSharedRuntime({ branch: 'feature-x' })` também pode ser chamado logo após importar o loader para fixar o branch em ambientes gerenciados.
 - Ao promover um módulo de `unique` para `shared`, lembre-se de atualizar o README do app orquestrador para apontar para o caminho canônico em `tools/shared/`.
 - Para coordenar a montagem única dos widgets, utilize `core/miniAppSync.mjs`, que expõe `ensureMiniApp` e `createMiniAppSync` e substitui flags manuais em `dataset`.
 

--- a/log.md
+++ b/log.md
@@ -1,4 +1,28 @@
 # Histórico do Projeto
 
+## 2025-10-10
+- Unificação do CSS compartilhado em `styles/app.css`, substituindo as três folhas anteriores. `apps/eventos.html` agora carrega uma única folha via `ensureSharedStyle('styles/app.css')`, e a documentação (README, arquitetura, agent, catálogo de shared) foi atualizada para orientar novos miniapps a reutilizar essa base responsiva.
+
+## 2025-10-09
+- Consolidada a camada de estilos compartilhados: loader passou a expor `ensureSharedStyles`, `apps/eventos.html` carrega `miniapps.css`, `eventos-dashboard.css` e `convidados.css`, e os miniapps de tarefas/fornecedores foram atualizados para consumir classes comuns, eliminando `<style>` inline.
+
+## 2025-10-08
+- Consolidada a documentação operacional: README principal agora inclui passo a passo para plugar novos miniapps no app de Eventos, `docs/arquitetura.md` detalha o fluxo no HTML e o checklist pós-entrega, `agent.md` orienta automações futuras e os READMEs de `shared`/`unique` explicam quando e como utilizar cada catálogo.
+
+## 2025-10-07
+- Estruturado `tools/shared/` em camadas (`core/`, `miniapps/`, `utils/`, `runtime/`), extraindo utilitários de formatação/DOM e incorporando o `core/miniAppSync.mjs` ao app de eventos. Atualizados README, guia de arquitetura e histórico para refletir a base comum.
+
+## 2025-10-06
+- Reorganização do código base: promoção dos miniapps de eventos, tarefas, fornecedores, convidados e mensagens para `tools/shared/`, criação do loader comum `runtimeLoader.mjs` e ajuste do app de eventos para consumir a nova infraestrutura.
+
+## 2025-10-05
+- Documentada a metodologia de UX e construção de miniapps (padrão do painel de edição, sequência de eventos e checklist de entrega) para orientar futuras integrações.
+
+## 2025-10-04
+- Esclarecida a separação entre `tools/shared/` (catálogo público) e `tools/unique/` (módulos pontuais), reforçando diretrizes na documentação arquitetural.
+
+## 2025-10-03
+- Documentação expandida para orientar a evolução rumo à versão 3.0 executiva: README revisado, guia de arquitetura com ciclo de vida `mount…MiniApp` e diretrizes de estilo.
+
 ## 2025-10-02
 - Adicionados arquivos de README e log para facilitar a documentação das atividades.

--- a/log.md
+++ b/log.md
@@ -1,5 +1,8 @@
 # Histórico do Projeto
 
+## 2025-10-11
+- Loader do shared agora aceita configuração de branch durante implantações (query string, variável global ou `configureSharedRuntime`). Documentação geral, guia arquitetural, agent e README do catálogo foram atualizados com o passo a passo para apontar o app de Eventos ao branch em homologação.
+
 ## 2025-10-10
 - Unificação do CSS compartilhado em `styles/app.css`, substituindo as três folhas anteriores. `apps/eventos.html` agora carrega uma única folha via `ensureSharedStyle('styles/app.css')`, e a documentação (README, arquitetura, agent, catálogo de shared) foi atualizada para orientar novos miniapps a reutilizar essa base responsiva.
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,55 @@
 # Projeto Marco
 
-Este repositório...
+## Objetivo do Projeto
+O Projeto Marco consolida diferentes miniaplicativos executivos em uma plataforma única para planejamento, convites e acompanhamento de eventos corporativos. A proposta é oferecer uma camada comum de serviços (autenticação, agenda compartilhada e notificações) enquanto permite que cada equipe entregue funcionalidades especializadas de forma independente.
+
+## Visão Modular
+### Apps como orquestradores
+Os diretórios em `apps/` abrigam micro front-ends que atuam como orquestradores da experiência. Cada app carrega widgets, inicializa o estado compartilhado e publica eventos relevantes para o restante do ecossistema.
+
+### Widgets compartilháveis
+Componentes reutilizáveis vivem em `tools/shared/`, diretório público que espelha integrações comuns (ex.: conectores com Google, componentes de agenda, notificações) e garante que qualquer app consuma os mesmos blocos sem divergências. Esses widgets expõem APIs leves baseadas em propriedades e eventos, de modo que o mesmo componente possa ser montado em diferentes fluxos sem duplicação de lógica.
+
+```
+tools/shared/
+  core/        → infraestrutura (projectStore, marcoBus, eventsCore, miniAppSync)
+  miniapps/    → widgets executivos versionados (`tarefas/`, `fornecedores/`, `convidados/`, `mensagens/`)
+  styles/      → camada visual unificada (`app.css`) que cobre layout geral, KPIs e catálogos
+  utils/       → utilitários de DOM, formatação BR, IDs e parsing de listas/convites
+  runtime/     → loader responsável por resolver módulos locais ou CDN (`runtime/loader.mjs`)
+```
+
+As folhas de estilo são carregadas dinamicamente pelo loader via `ensureSharedStyle('styles/app.css')`, evitando CSS inline nos apps orquestradores. Sempre que um miniapp expuser um layout novo, promova as regras para `tools/shared/styles/` e documente quais arquivos devem ser importados no bootstrap.
+
+> **MiniAppSync** (`core/miniAppSync.mjs`): utilitário que garante montagem única de cada miniapp e concentra regras de sincronização (`ensureMiniApp`, `createMiniAppSync`). Ele evita que apps orquestradores repliquem lógica de dataset/flag manual e mantém a coesão do ecossistema.
+
+### Camada de persistência, event bus e módulos específicos
+A infraestrutura de dados é garantida pelo barramento de eventos (`core/marcoBus.js`) e pelo `core/projectStore.js`, enquanto módulos especializados residem em `tools/unique/`. Use `unique` para implementar integrações pontuais ou lógicas que não devam poluir o catálogo compartilhado — por exemplo, fluxos exclusivos de um app parceiro ou credenciais sensíveis. A persistência ocorre via adaptadores que falam com serviços corporativos e armazenam o estado atual no `projectStore`, enquanto o event bus propaga mudanças para manter os apps sincronizados. O carregamento padrão passa por `runtime/loader.mjs`, que resolve qualquer módulo compartilhado via `loadSharedModule('<subpasta/arquivo>')`.
+
+## Metodologia de Entrega e Experiência
+1. **Invariantes de UX executiva**: sempre que o usuário clicar no ícone de lápis, abra o painel lateral de edição padrão à direita, com cabeçalho informando o contexto atual (`getCurrentId`) e ações claras de salvar/cancelar. Respeite espaçamentos de 24px entre blocos e textos com tipografia corporativa `MarcoSans`.
+2. **Orquestração previsível**: cada app registra no `marcoBus` os mesmos eventos de ciclo de vida (`miniapp:ready`, `editor:open`, `editor:close`). Widgets devem reagir a esses eventos para manter uma experiência consistente mesmo quando são reutilizados em outros fluxos.
+3. **Gestão de estado disciplinada**: antes de liberar qualquer ação interativa, recupere o estado do `projectStore` e injete dependências via `mount<Contexto>MiniApp`. Alterações devem ser commitadas no store antes de emitir eventos de confirmação para garantir sincronia entre apps irmãos.
+4. **Checklist para novos miniapps**:
+   - Mapear os widgets necessários em `tools/shared/`; somente crie itens em `tools/unique/` se a lógica for realmente pontual.
+   - Definir quais eventos o miniapp publica/consome e registrá-los na documentação para evitar colisões.
+   - Implementar testes manuais cobrindo o fluxo de edição (click no lápis → painel → persistência) antes de solicitar revisão.
+   - Documentar no `log.md` a evolução e quaisquer exceções adotadas.
+
+Seguir essa metodologia garante que a equipe replique o mesmo modo de trabalhar ao evoluir o aplicativo atual ou criar novos módulos integrados ao repositório.
+
+## Como plugar um novo miniapp no app de Eventos
+1. **Mapeie as dependências**: confirme que o widget a ser criado já possui utilitários em `tools/shared/`. Caso contrário, extraia funções comuns para `utils/` antes de iniciar a implementação.
+2. **Configure o bootstrap**: em `apps/eventos.html`, utilize `loadSharedModule` para importar `core/miniAppSync.mjs`, o miniapp desejado em `miniapps/<domínio>/vN.mjs` e quaisquer helpers adicionais.
+3. **Monte com `miniAppSync`**: crie um sincronizador via `createMiniAppSync({ bus, store, ac, getCurrentId })` e registre o miniapp com `ensureMiniApp('<domínio>', () => mount<Domínio>MiniApp({ ac, store, bus, getCurrentId }))`. Garanta o carregamento de `ensureSharedStyle('styles/app.css')` antes de montar o widget para eliminar dependências de CSS inline.
+4. **Siga o checklist de UX**: valide a abertura do painel de edição via evento `editor:open`, a persistência no `projectStore` e a publicação dos eventos `miniapp:ready` e `editor:close`.
+5. **Documente a entrega**: registre no `log.md` o miniapp publicado, atualize `docs/arquitetura.md` com qualquer regra adicional e descreva no PR como o widget reaproveita o catálogo compartilhado.
+
+Para casos excepcionalmente específicos, crie o módulo em `tools/unique/` seguindo as regras descritas naquele README e registre o motivo na documentação.
+
+## Build e Testes
+1. **Instalação de dependências**: assegure-se de utilizar Node.js 18+ e execute `npm install` na raiz assim que o `package.json` estiver disponível. Até lá, os protótipos podem ser servidos com `npx serve apps` para desenvolvimento local.
+2. **Build**: utilize `npm run build` para gerar artefatos otimizados quando os pipelines forem configurados. Para protótipos estáticos, exporte a pasta `apps/` diretamente.
+3. **Testes**: adote `npm test` e `npm run lint` como comandos padrão. Enquanto os testes automatizados não forem implementados, execute validações manuais abrindo `apps/eventos.html` no navegador e verificando os fluxos críticos.
+
+Manter essa rotina garante que as entregas evoluam de protótipos para uma versão 3.0 pronta para consumo executivo.

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,15 @@ Seguir essa metodologia garante que a equipe replique o mesmo modo de trabalhar 
 
 Para casos excepcionalmente específicos, crie o módulo em `tools/unique/` seguindo as regras descritas naquele README e registre o motivo na documentação.
 
+## Implantação apontando para um branch específico
+Durante homologações e implantações parciais em WordPress/Elementor, o loader precisa resolver os módulos diretamente do branch ativo para que CSS e miniapps reflitam as alterações em andamento. A partir de `tools/shared/runtime/loader.mjs` é possível informar o branch de três maneiras:
+
+1. **Query string** – acrescente `?branch=<nome-do-branch>` (ou `?marco-branch=`) ao URL que hospeda o aplicativo. O loader captura esse parâmetro automaticamente.
+2. **Variável global** – antes de carregar o loader, defina `window.__MARCO_BRANCH__ = '<nome-do-branch>';`. Esse padrão funciona bem em widgets Elementor onde controlamos um bloco `<script>` inicial.
+3. **Atributo no `<script>`** – ao importar o loader via `<script type="module" data-marco-branch="<nome>">`, o atributo `data-marco-branch` será lido como fonte da verdade.
+
+Caso nenhum mecanismo seja informado, o branch padrão continua sendo `main`. Utilize sempre o mesmo branch para folha de estilo e módulos JavaScript a fim de evitar versões desencontradas durante a implantação.
+
 ## Build e Testes
 1. **Instalação de dependências**: assegure-se de utilizar Node.js 18+ e execute `npm install` na raiz assim que o `package.json` estiver disponível. Até lá, os protótipos podem ser servidos com `npx serve apps` para desenvolvimento local.
 2. **Build**: utilize `npm run build` para gerar artefatos otimizados quando os pipelines forem configurados. Para protótipos estáticos, exporte a pasta `apps/` diretamente.

--- a/tools/shared/README.md
+++ b/tools/shared/README.md
@@ -1,0 +1,24 @@
+# Catálogo `tools/shared/`
+
+Este diretório concentra os módulos reutilizáveis do Projeto Marco, organizados em cinco camadas:
+
+- **`core/`** – infraestrutura compartilhada: `projectStore` (IndexedDB), `marcoBus` (event bus), `eventsCore` (helpers de domínio) e `miniAppSync` (montagem única de miniapps).
+- **`miniapps/`** – widgets executivos versionados. Cada subpasta contém um módulo `vN.mjs` com a função `mount…MiniApp` correspondente.
+- **`styles/`** – folha de estilo unificada `app.css` cobrindo layout do orquestrador, utilitários de miniapps e catálogo de convites.
+- **`utils/`** – funções utilitárias independentes (DOM, IDs, formatação BR, parsing de convites/listas).
+- **`runtime/`** – loader padrão (`runtime/loader.mjs`) consumido pelos apps orquestradores via `loadSharedModule('<subpasta/arquivo>')`.
+
+## Convenções rápidas
+- Prefira `loadSharedModule('core/projectStore.js')` (ou caminhos equivalentes) para resolver dependências. O loader tenta caminhos locais e, em fallback, as CDNs oficiais (`rawcdn.githack`, `jsDelivr`).
+- Miniapps devem depender apenas de `ac`, `store`, `bus` e `getCurrentId`, recebidos como parâmetros de `mount…MiniApp`.
+- Use `core/miniAppSync.mjs` (`createMiniAppSync` / `ensureMiniApp`) para evitar flags manuais (`dataset.mounted`) ao montar widgets a partir dos apps em `apps/`.
+- Qualquer duplicação encontrada em novos miniapps deve ser extraída para `utils/` e reaproveitada.
+- Registre no cabeçalho do módulo (`/** Miniapp Eventos v1 */`) o motivo da existência e o contexto de uso para facilitar futuras promoções ou refactors.
+
+## Como consumir a partir de `apps/eventos.html`
+1. Carregue o loader: `const { loadSharedModules } = await import('../tools/shared/runtime/loader.mjs');` (ou caminho equivalente quando servido via CDN).
+2. Resolva as dependências necessárias `const [{ createMiniAppSync }, { mountTarefasMiniApp }] = await loadSharedModules(['core/miniAppSync.mjs', 'miniapps/tarefas/v1.mjs']);` (troque o domínio conforme o miniapp desejado).
+3. Instancie o sincronizador `const sync = createMiniAppSync({ ac, store, bus, getCurrentId });` e monte `sync.ensureMiniApp('tarefas', () => mountTarefasMiniApp({ ac, store, bus, getCurrentId }));`.
+4. Caso precise da base visual, importe-a via loader (`ensureSharedStyle('styles/app.css')`) e mantenha a chamada declarada na documentação do miniapp.
+
+Sempre que um novo miniapp for conectado, atualize este arquivo com links para sua subpasta e descreva quais utilitários do catálogo ele utiliza.

--- a/tools/shared/README.md
+++ b/tools/shared/README.md
@@ -10,6 +10,7 @@ Este diretório concentra os módulos reutilizáveis do Projeto Marco, organizad
 
 ## Convenções rápidas
 - Prefira `loadSharedModule('core/projectStore.js')` (ou caminhos equivalentes) para resolver dependências. O loader tenta caminhos locais e, em fallback, as CDNs oficiais (`rawcdn.githack`, `jsDelivr`).
+- Para implantações que apontam para um branch diferente de `main`, defina `window.__MARCO_BRANCH__ = '<branch>'` antes de carregar o loader, acrescente `?branch=<branch>` na URL do host ou invoque `configureSharedRuntime({ branch: '<branch>' })` após importar `runtime/loader.mjs`.
 - Miniapps devem depender apenas de `ac`, `store`, `bus` e `getCurrentId`, recebidos como parâmetros de `mount…MiniApp`.
 - Use `core/miniAppSync.mjs` (`createMiniAppSync` / `ensureMiniApp`) para evitar flags manuais (`dataset.mounted`) ao montar widgets a partir dos apps em `apps/`.
 - Qualquer duplicação encontrada em novos miniapps deve ser extraída para `utils/` e reaproveitada.

--- a/tools/shared/core/eventsCore.v2.mjs
+++ b/tools/shared/core/eventsCore.v2.mjs
@@ -1,5 +1,5 @@
 // ===============================
-// /shared/acEventsCore.v2.mjs
+// tools/shared/core/eventsCore.v2.mjs
 // ===============================
 // AC Eventos Core v2 — helpers + KPIs centralizados (atualizado)
 // Mantém compatibilidade com v1 e amplia KPIs de tarefas com breakdown de status

--- a/tools/shared/core/marcoBus.js
+++ b/tools/shared/core/marcoBus.js
@@ -1,4 +1,4 @@
-// shared/marcoBus.js
+// tools/shared/core/marcoBus.js
 // Event bus simples para coordenação entre widgets (mesma aba e multi-abas).
 
 const bc = ('BroadcastChannel' in self) ? new BroadcastChannel('marco-bus') : null;

--- a/tools/shared/core/miniAppSync.mjs
+++ b/tools/shared/core/miniAppSync.mjs
@@ -1,0 +1,83 @@
+// tools/shared/core/miniAppSync.mjs
+// Utilidades para montar miniapps compartilhados garantindo montagem única por host.
+
+const DEFAULT_MOUNT_KEYS = [
+  'mountMiniApp',
+  'mount',
+  'default',
+  'mountTasksMiniApp',
+  'mountFornecedoresMiniApp',
+  'mountConvidadosMiniApp',
+  'mountMensagensMiniApp'
+];
+
+export function resolveMount(moduleExports, explicitKey){
+  if (!moduleExports) return null;
+  if (explicitKey && typeof moduleExports[explicitKey] === 'function') {
+    return moduleExports[explicitKey];
+  }
+  if (typeof moduleExports === 'function') return moduleExports;
+  for (const key of DEFAULT_MOUNT_KEYS) {
+    if (typeof moduleExports[key] === 'function') return moduleExports[key];
+  }
+  return null;
+}
+
+export function ensureMiniApp(host, moduleExports, { mountKey, deps = {}, flag = 'mounted', beforeMount, afterMount } = {}) {
+  if (!host) throw new Error('[miniAppSync] host inválido');
+  if (!moduleExports) throw new Error('[miniAppSync] módulo ausente');
+  const attr = `miniapp${flag}`;
+  if (host.dataset && host.dataset[attr]) return false;
+  const mountFn = resolveMount(moduleExports, mountKey);
+  if (typeof mountFn !== 'function') {
+    throw new Error('[miniAppSync] não foi possível resolver função de montagem');
+  }
+  if (typeof beforeMount === 'function') beforeMount(host);
+  mountFn(host, deps);
+  if (host.dataset) host.dataset[attr] = '1';
+  if (typeof afterMount === 'function') afterMount(host);
+  return true;
+}
+
+export function createMiniAppSync(defaultDeps = {}) {
+  const registry = new Map();
+
+  function register(selector, moduleExports, options = {}) {
+    registry.set(selector, { moduleExports, options });
+  }
+
+  function ensure(selector, moduleExportsOverride, extraOptions = {}) {
+    const entry = registry.get(selector);
+    if (!entry && !moduleExportsOverride) return false;
+    const host = document.querySelector(selector);
+    if (!host) return false;
+    const moduleExports = moduleExportsOverride || entry?.moduleExports;
+    if (!moduleExports) return false;
+    const entryOptions = entry?.options || {};
+    const mergedDeps = { ...defaultDeps, ...(entryOptions.deps || {}), ...(extraOptions.deps || {}) };
+    const mountOptions = { ...entryOptions, ...extraOptions, deps: mergedDeps };
+    return ensureMiniApp(host, moduleExports, mountOptions);
+  }
+
+  function mountAll(overrides = {}) {
+    let mounted = 0;
+    for (const [selector, entry] of registry.entries()) {
+      const host = document.querySelector(selector);
+      if (!host) continue;
+      const moduleExports = overrides[selector] || entry.moduleExports;
+      if (!moduleExports) continue;
+      const mergedDeps = { ...defaultDeps, ...(entry.options?.deps || {}) };
+      if (ensureMiniApp(host, moduleExports, { ...entry.options, deps: mergedDeps })) {
+        mounted += 1;
+      }
+    }
+    return mounted;
+  }
+
+  function reset(selector, flag = 'mounted') {
+    const host = typeof selector === 'string' ? document.querySelector(selector) : selector;
+    if (host?.dataset) delete host.dataset[`miniapp${flag}`];
+  }
+
+  return { register, ensure, mountAll, reset };
+}

--- a/tools/shared/core/projectStore.js
+++ b/tools/shared/core/projectStore.js
@@ -1,4 +1,4 @@
-// shared/projectStore.js (v2)
+// tools/shared/core/projectStore.js (v2)
 // IndexedDB para múltiplos eventos, com migração, persistência e utilidades.
 // Fontes & boas práticas:
 // - MDN Using IndexedDB / API: transações, onupgradeneeded, versionchange, erros

--- a/tools/shared/miniapps/fornecedores/v1.mjs
+++ b/tools/shared/miniapps/fornecedores/v1.mjs
@@ -1,5 +1,11 @@
 // ===============================
-// /shared/acFornecedores.v1.mjs
+import { uid as makeUid } from '../../utils/ids.mjs';
+import { el, clear, ensureHost } from '../../utils/dom.mjs';
+import { formatMoneyBR, parseCurrencyBR, formatDateBR, toISODate, maskPhoneBR } from '../../utils/br.mjs';
+import { getProject, updateProject } from '../../utils/store.mjs';
+
+// ===============================
+// tools/shared/miniapps/fornecedores/v1.mjs
 // ===============================
 // MiniApp Fornecedores — v1 (documento único)
 // - Colunas: Fornecedor, Contato, Telefone, Categoria, Entrega (BR), Valor, Pago, Status, Ações
@@ -10,8 +16,10 @@
 // - Autosave imediato via projectStore + marcoBus
 //
 // API de uso:
-// import * as ac from '/shared/acEventsCore.v2.mjs';
-// import { mountFornecedoresMiniApp } from '/shared/acFornecedores.v1.mjs';
+// import { loadSharedModule } from '../tools/shared/runtime/loader.mjs';
+//
+// const ac = await loadSharedModule('core/eventsCore.v2.mjs');
+// const { mountFornecedoresMiniApp } = await loadSharedModule('miniapps/fornecedores/v1.mjs');
 //
 // mountFornecedoresMiniApp(rootElement, {
 //   ac,
@@ -21,32 +29,7 @@
 // });
 
 // ---------- Utils básicos ----------
-const uid = (p='f')=> p + Math.random().toString(36).slice(2,10);
-
-function el(tag, attrs={}, children=[]){
-  const n = document.createElement(tag);
-  Object.entries(attrs||{}).forEach(([k,v])=>{
-    if(k==='className') n.className=v;
-    else if(k==='dataset') Object.assign(n.dataset,v);
-    else if(k in n) n[k]=v;
-    else n.setAttribute(k,v);
-  });
-  (children||[]).forEach(c=> n.appendChild(typeof c==='string'? document.createTextNode(c) : c));
-  return n;
-}
-function clear(node){ while(node && node.firstChild) node.removeChild(node.firstChild); }
-
-// ---------- Persistência utilitária ----------
-async function getProject(store, id){ return id? await store.getProject?.(id) : null; }
-async function updateProject(store, id, mut){
-  if(!id) return null;
-  const current = await getProject(store, id) || {};
-  const next = JSON.parse(JSON.stringify(current));
-  mut(next);
-  next.updatedAt = Date.now();
-  await store.updateProject?.(id, next);
-  return await getProject(store, id);
-}
+const nextId = () => makeUid('supplier');
 
 // ---------- Normalização ----------
 const normalizeStatus = (s)=>{
@@ -68,24 +51,14 @@ const computeStatus = (it)=>{
   return normalizeStatus(it?.status) || (v>0? 'contratado' : 'planejado');
 };
 
-const toISO = (d)=>{ // aceita 'YYYY-MM-DD' ou 'DD/MM/AAAA'
-  if(!d) return '';
-  const s = String(d).trim();
-  if(/\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0,10);
-  const m = s.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
-  if(m){ const [_,dd,mm,yy]=m; return `${yy.padStart(4,'0')}-${mm.padStart(2,'0')}-${dd.padStart(2,'0')}`; }
-  const dt = new Date(s); if(!Number.isNaN(+dt)) return dt.toISOString().slice(0,10);
-  return '';
-};
-
 function normFornecedor(it={}){
   const base = {
-    id: it.id || uid(),
+    id: it.id || nextId(),
     fornecedor: it.fornecedor ?? it.nome ?? it.title ?? '',
     contato: it.contato ?? '',
     telefone: it.telefone ?? it.phone ?? '',
     categoria: it.categoria ?? it.tipo ?? '',
-    dataEntrega: toISO(it.dataEntrega || it.entrega || it.date || ''), // persistimos ISO
+    dataEntrega: toISODate(it.dataEntrega || it.entrega || it.date || ''), // persistimos ISO
     valor: Number(it.valor ?? it.total ?? 0) || 0,
     pago: Number(it.pago ?? it.valorPago ?? 0) || 0,
     notas: it.notas ?? it.obs ?? it.notes ?? ''
@@ -94,21 +67,37 @@ function normFornecedor(it={}){
   return base;
 }
 
-// ---------- Formatação BR ----------
-function fmtBRDate(ac, iso){
-  if(!iso) return '';
-  try{ return ac?.format?.fmtDateBR ? ac.format.fmtDateBR(iso) : iso.split('-').reverse().join('/'); }
-  catch{ return iso.split('-').reverse().join('/'); }
+function formatMoney(ac, value){
+  try{
+    return ac?.format?.money ? ac.format.money(Number(value) || 0) : formatMoneyBR(value);
+  }catch{
+    return formatMoneyBR(value);
+  }
 }
-function parseBRL(str){ // "1.234,56" -> 1234.56 (Number)
-  const s = String(str||'').replace(/[^\d,.-]/g,'').replace(/\./g,'').replace(',', '.');
-  const n = parseFloat(s); return Number.isFinite(n) ? n : 0;
+
+function parseMoneyValue(ac, raw){
+  try{
+    return ac?.format?.parseCurrencyBR ? ac.format.parseCurrencyBR(raw) : parseCurrencyBR(raw);
+  }catch{
+    return parseCurrencyBR(raw);
+  }
 }
-function fmtBRL(ac, n){ try{ return ac?.format?.money ? ac.format.money(Number(n)||0) : (Number(n)||0).toLocaleString('pt-BR',{style:'currency',currency:'BRL'}); } catch{ return `R$ ${(Number(n)||0).toFixed(2)}`; } }
-function maskTelBR(v){
-  let s = String(v||'').replace(/\D/g,'').slice(0,11);
-  if(s.length<=10) return s.replace(/(\d{0,2})(\d{0,4})(\d{0,4}).*/, (m,a,b,c)=> (a?`(${a}`:'') + (a&&a.length===2?') ':'') + (b||'') + (c?`-${c}`:'') );
-  return s.replace(/(\d{0,2})(\d{0,5})(\d{0,4}).*/, (m,a,b,c)=> (a?`(${a}`:'') + (a&&a.length===2?') ':'') + (b||'') + (c?`-${c}`:'') );
+
+function formatDate(ac, value){
+  if(!value) return '';
+  try{
+    return ac?.format?.fmtDateBR ? ac.format.fmtDateBR(value) : formatDateBR(value);
+  }catch{
+    return formatDateBR(value);
+  }
+}
+
+function maskPhoneValue(ac, value){
+  try{
+    return ac?.format?.maskPhone ? ac.format.maskPhone(value) : maskPhoneBR(value);
+  }catch{
+    return maskPhoneBR(value);
+  }
 }
 
 // ---------- UI helpers ----------
@@ -130,10 +119,10 @@ function kpiRow(ac, list){
   const total = list.reduce((a,b)=> a + (Number(b.valor)||0), 0);
   const pago  = list.reduce((a,b)=> a + (Number(b.pago)||0), 0);
   const pct = total>0 ? Math.round((pago/total)*100) : 0;
-  return el('div',{className:'row',style:'gap:.75rem;align-items:center;margin:6px 0'},[
-    el('strong',{textContent:`${fmtBRL(ac, pago)} pagos — ${pct}%`}),
+  return el('div',{className:'row row--center row--gap-md row--tight miniapp__legend'},[
+    el('strong',{textContent:`${formatMoney(ac, pago)} pagos — ${pct}%`}),
     el('span',{textContent:'•'}),
-    el('span',{textContent:`Total: ${fmtBRL(ac, total)}`, className:'muted'})
+    el('span',{textContent:`Total: ${formatMoney(ac, total)}`, className:'muted'})
   ]);
 }
 
@@ -141,24 +130,25 @@ function progress(ac, list){
   const total = list.reduce((a,b)=> a + (Number(b.valor)||0), 0);
   const pago  = list.reduce((a,b)=> a + (Number(b.pago)||0), 0);
   const pct = total>0 ? Math.round((pago/total)*100) : 0;
-  const track = el('div',{className:'progress__track',style:'height:10px;border-radius:6px;background:#eef2f6;overflow:hidden'});
-  const bar = el('div',{className:'progress__bar',style:`height:10px;border-radius:6px;background:#0b65c2;width:${pct}%;transition:width .25s ease`});
+  const track = el('div',{className:'miniapp__progress-track'});
+  const bar = el('div',{className:'miniapp__progress-bar'});
+  bar.style.width = `${pct}%`;
   track.appendChild(bar);
   return track;
 }
 
 // ---------- Editor expandido ----------
 function editorRow(ac, item, onChange){
-  const wrap = el('div',{className:'editor'});
+  const wrap = el('div',{className:'miniapp__editor'});
 
-  const inFornecedor = el('input',{type:'text',value:item.fornecedor||'',placeholder:'Fornecedor',style:'flex:1'});
-  const inContato    = el('input',{type:'text',value:item.contato||'',placeholder:'Contato',style:'flex:1'});
-  const inTel        = el('input',{type:'text',value:item.telefone||'',placeholder:'Telefone',style:'width:180px'});
-  const inCat        = el('input',{type:'text',value:item.categoria||'',placeholder:'Categoria',style:'width:160px'});
-  const inEnt        = el('input',{type:'date',value:(item.dataEntrega||'').slice(0,10),style:'width:160px'});
-  const inVal        = el('input',{type:'text',value:fmtBRL(ac, item.valor||0),style:'width:140px'});
-  const inPago       = el('input',{type:'text',value:fmtBRL(ac, item.pago||0),style:'width:140px'});
-  const inStatus     = el('select',{},[
+  const inFornecedor = el('input',{type:'text',value:item.fornecedor||'',placeholder:'Fornecedor',className:'miniapp__input miniapp__input--flex'});
+  const inContato    = el('input',{type:'text',value:item.contato||'',placeholder:'Contato',className:'miniapp__input miniapp__input--flex'});
+  const inTel        = el('input',{type:'text',value:item.telefone||'',placeholder:'Telefone',className:'miniapp__input w-180'});
+  const inCat        = el('input',{type:'text',value:item.categoria||'',placeholder:'Categoria',className:'miniapp__input w-160'});
+  const inEnt        = el('input',{type:'date',value:(item.dataEntrega||'').slice(0,10),className:'miniapp__input w-160'});
+  const inVal        = el('input',{type:'text',value:formatMoney(ac, item.valor||0),className:'miniapp__input w-140'});
+  const inPago       = el('input',{type:'text',value:formatMoney(ac, item.pago||0),className:'miniapp__input w-140'});
+  const inStatus     = el('select',{className:'miniapp__select w-160'},[
     el('option',{value:'planejado',textContent:'Planejado'}),
     el('option',{value:'contratado',textContent:'Contratado'}),
     el('option',{value:'parcial',textContent:'Pago parcial'}),
@@ -166,24 +156,24 @@ function editorRow(ac, item, onChange){
     el('option',{value:'cancelado',textContent:'Cancelado'})
   ]);
   inStatus.value = computeStatus(item);
-  const inNotas = el('textarea',{value:item.notas||'',placeholder:'Anotações',rows:3,style:'width:100%;resize:vertical'});
+  const inNotas = el('textarea',{value:item.notas||'',placeholder:'Anotações',rows:3,className:'miniapp__textarea'});
 
-  inTel.addEventListener('input', ()=>{ inTel.value = maskTelBR(inTel.value); });
+  inTel.addEventListener('input', ()=>{ inTel.value = maskPhoneValue(ac, inTel.value); });
   const syncMoney = (inp, key)=>{
-    inp.addEventListener('blur', ()=>{ const num = parseBRL(inp.value); inp.value = fmtBRL(ac, num); onChange({[key]: num}); });
-    inp.addEventListener('change', ()=>{ const num = parseBRL(inp.value); onChange({[key]: num}); });
+    inp.addEventListener('blur', ()=>{ const num = parseMoneyValue(ac, inp.value); inp.value = formatMoney(ac, num); onChange({[key]: num}); });
+    inp.addEventListener('change', ()=>{ const num = parseMoneyValue(ac, inp.value); onChange({[key]: num}); });
   };
   syncMoney(inVal,'valor'); syncMoney(inPago,'pago');
 
   inFornecedor.addEventListener('change', ()=> onChange({fornecedor: inFornecedor.value}));
   inContato.addEventListener('change',    ()=> onChange({contato: inContato.value}));
-  inTel.addEventListener('change',        ()=> onChange({telefone: inTel.value}));
+  inTel.addEventListener('change',        ()=>{ inTel.value = maskPhoneValue(ac, inTel.value); onChange({telefone: inTel.value}); });
   inCat.addEventListener('change',        ()=> onChange({categoria: inCat.value}));
   inEnt.addEventListener('change',        ()=> onChange({dataEntrega: inEnt.value}));
   inStatus.addEventListener('change',     ()=> onChange({status: inStatus.value}));
   inNotas.addEventListener('change',      ()=> onChange({notas: inNotas.value}));
 
-  const grid = el('div',{className:'grid'},[
+  const grid = el('div',{className:'miniapp__grid'},[
     labeled('Fornecedor', inFornecedor),
     labeled('Contato', inContato),
     labeled('Telefone', inTel),
@@ -203,53 +193,31 @@ function labeled(lbl, input, opts={}){
     el('span',{className:'small',textContent:lbl}),
     input
   ]);
-  if(opts.full) w.style.gridColumn = '1 / -1';
+  if(opts.full) w.classList.add('fld--full');
   return w;
 }
 
 // ---------- Montagem principal ----------
 export function mountFornecedoresMiniApp(root, { ac, store, bus, getCurrentId }){
-  if(!root) throw new Error('root inválido');
+  const host = ensureHost(root);
+  host.classList.add('miniapp','miniapp--fornecedores');
 
-  // Estilos mínimos e escopados para o mini-app
-  const style = el('style',{},[document.createTextNode(`
-    .for-mini{font-size:14px}
-    .for-mini .row{display:flex;gap:.5rem}
-    .for-mini .muted{opacity:.75}
-    .for-mini table{width:100%;border-collapse:separate;border-spacing:0 8px;margin-top:8px}
-    .for-mini thead th{padding:8px 10px;font-size:12px;color:#555;border-bottom:0;background:transparent;text-align:left}
-    .for-mini td{background:#fff;border:1px solid #e5e9f2;border-left-width:0;border-right-width:0;padding:8px 10px}
-    .for-mini tr{box-shadow:0 1px 0 rgba(0,0,0,.03)}
-    .for-mini .menu details{position:relative}
-    .for-mini .menu summary{list-style:none;cursor:pointer;padding:4px 8px;border:1px solid #d0d7e2;border-radius:8px;background:#fff}
-    .for-mini .menu summary::-webkit-details-marker{display:none}
-    .for-mini .menu[open] summary{box-shadow:0 0 0 1px #0b65c2 inset}
-    .for-mini .menu .pop{position:absolute;right:0;top:32px;background:#fff;border:1px solid #d0d7e2;border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.12);z-index:2}
-    .for-mini .menu .pop button{display:block;width:100%;text-align:left;padding:8px 12px;background:#fff;border:0}
-    .for-mini .menu .pop button:hover{background:#f3f6fb}
-    .for-mini .editor{padding:10px;border:1px dashed #d0d7e2;border-radius:8px;background:#fafcff;margin-top:8px}
-    .for-mini .grid{display:grid;grid-template-columns:repeat(4,minmax(140px,1fr));gap:.5rem}
-    .for-mini .fld{display:flex;flex-direction:column;gap:4px}
-    .for-mini input, .for-mini select, .for-mini textarea{padding:8px;border:1px solid #d0d7e2;border-radius:8px}
-    .for-mini .btn{padding:8px 10px;border:1px solid #d0d7e2;border-radius:8px;background:#fff;cursor:pointer}
-  `)]);
-
-  const header = el('div',{className:'row',style:'justify-content:space-between;align-items:center;margin-bottom:8px'},[
-    el('h3',{textContent:'Fornecedores', style:'margin:0;color:#0b65c2;font-size:1rem'}),
+  const header = el('div',{className:'row row--between row--center row--tight'},[
+    el('h3',{textContent:'Fornecedores', className:'miniapp__title'}),
   ]);
 
   const kpiWrap = el('div');
   const progWrap = el('div',{className:'progress progress--lg'});
 
   // Form de novo contrato
-  const inFornecedor = el('input',{type:'text',placeholder:'Fornecedor',style:'flex:1'});
-  const inContato    = el('input',{type:'text',placeholder:'Contato',style:'flex:1'});
-  const inTel        = el('input',{type:'text',placeholder:'Telefone',style:'width:160px'});
-  const inCat        = el('input',{type:'text',placeholder:'Categoria',style:'width:160px'});
-  const inEnt        = el('input',{type:'date',style:'width:160px'});
-  const inVal        = el('input',{type:'text',placeholder:'R$ 0,00',style:'width:140px'});
-  const inPago       = el('input',{type:'text',placeholder:'R$ 0,00',style:'width:140px'});
-  const inStatus     = el('select',{},[
+  const inFornecedor = el('input',{type:'text',placeholder:'Fornecedor',className:'miniapp__input miniapp__input--flex'});
+  const inContato    = el('input',{type:'text',placeholder:'Contato',className:'miniapp__input miniapp__input--flex'});
+  const inTel        = el('input',{type:'text',placeholder:'Telefone',className:'miniapp__input w-160'});
+  const inCat        = el('input',{type:'text',placeholder:'Categoria',className:'miniapp__input w-160'});
+  const inEnt        = el('input',{type:'date',className:'miniapp__input w-160'});
+  const inVal        = el('input',{type:'text',placeholder:'R$ 0,00',className:'miniapp__input w-140'});
+  const inPago       = el('input',{type:'text',placeholder:'R$ 0,00',className:'miniapp__input w-140'});
+  const inStatus     = el('select',{className:'miniapp__select w-160'},[
     el('option',{value:'',textContent:'Status…'}),
     el('option',{value:'planejado',textContent:'Planejado'}),
     el('option',{value:'contratado',textContent:'Contratado'}),
@@ -258,22 +226,21 @@ export function mountFornecedoresMiniApp(root, { ac, store, bus, getCurrentId })
     el('option',{value:'cancelado',textContent:'Cancelado'})
   ]);
   const btnAdd = el('button',{className:'btn',textContent:'Adicionar contrato'});
-  inTel.addEventListener('input', ()=>{ inTel.value = maskTelBR(inTel.value); });
-  const moneyBlur = (inp)=> inp.addEventListener('blur', ()=>{ const n=parseBRL(inp.value); inp.value = fmtBRL(ac,n); });
+  inTel.addEventListener('input', ()=>{ inTel.value = maskPhoneValue(ac, inTel.value); });
+  const moneyBlur = (inp)=> inp.addEventListener('blur', ()=>{ const n=parseMoneyValue(ac, inp.value); inp.value = formatMoney(ac,n); });
   moneyBlur(inVal); moneyBlur(inPago);
-  const addRow = el('div',{className:'row',style:'gap:.5rem;align-items:center;margin:8px 0;flex-wrap:wrap'},[
+  const addRow = el('div',{className:'row row--center row--gap-sm'},[
     inFornecedor,inContato,inTel,inCat,inEnt,inVal,inPago,inStatus,btnAdd
   ]);
 
   // Tabela
-  const table = el('table',{className:'table'});
+  const table = el('table',{className:'miniapp__table'});
   const thead = tableHeader();
   const tbody = el('tbody');
   table.append(thead, tbody);
 
   // Monta no root
-  root.classList?.add('for-mini');
-  root.append(style, header, kpiWrap, progWrap, addRow, table);
+  host.append(header, kpiWrap, progWrap, addRow, table);
 
   // ------- Estado local -------
   let currentId = getCurrentId?.();
@@ -301,15 +268,15 @@ export function mountFornecedoresMiniApp(root, { ac, store, bus, getCurrentId })
     clear(tbody);
     list.forEach((it,i)=>{
       const tr = el('tr');
-      const td = (child)=> el('td',{},[child]);
+      const td = (child, cls)=> el('td',cls?{className:cls}:{},[child]);
 
       const tFor = el('span',{textContent: it.fornecedor||'—'});
       const tCon = el('span',{textContent: it.contato||'—'});
-      const tTel = el('span',{textContent: it.telefone||'—'});
+      const tTel = el('span',{textContent: it.telefone || '—'});
       const tCat = el('span',{textContent: it.categoria||'—'});
-      const tEnt = el('span',{textContent: fmtBRDate(ac, it.dataEntrega)||'—'});
-      const tVal = el('span',{textContent: fmtBRL(ac, it.valor||0)});
-      const tPag = el('span',{textContent: fmtBRL(ac, it.pago||0)});
+      const tEnt = el('span',{textContent: formatDate(ac, it.dataEntrega)||'—'});
+      const tVal = el('span',{textContent: formatMoney(ac, it.valor||0)});
+      const tPag = el('span',{textContent: formatMoney(ac, it.pago||0)});
 
       const st = el('select',{},[
         el('option',{value:'planejado',textContent:'Planejado'}),
@@ -325,17 +292,17 @@ export function mountFornecedoresMiniApp(root, { ac, store, bus, getCurrentId })
       });
 
       // menu de ações por linha
-      const menu = el('div',{className:'menu'},[ el('details',{},[
+      const menu = el('div',{className:'miniapp__menu'},[ el('details',{},[
         el('summary',{},['⋯']),
-        el('div',{className:'pop'},[
+        el('div',{className:'miniapp__menu-pop'},[
           el('button',{type:'button',textContent:'Editar',onclick:()=> openEditor()}),
-          el('button',{type:'button',textContent:'Duplicar',onclick:async ()=>{ await saveList((normed)=>{ const clone = JSON.parse(JSON.stringify(normed[i])); clone.id=uid(); normed.splice(i+1,0,clone); }); await rerender(); }}),
+          el('button',{type:'button',textContent:'Duplicar',onclick:async ()=>{ await saveList((normed)=>{ const clone = JSON.parse(JSON.stringify(normed[i])); clone.id = nextId(); normed.splice(i+1,0,clone); }); await rerender(); }}),
           el('button',{type:'button',textContent:'Excluir',onclick:async ()=>{ await saveList((normed)=>{ normed.splice(i,1); }); await rerender(); }})
         ])
       ])]);
 
       tr.append(
-        td(tFor), td(tCon), td(tTel), td(tCat), td(tEnt), td(tVal), td(tPag), td(st), td(menu)
+        td(tFor), td(tCon), td(tTel), td(tCat), td(tEnt), td(tVal), td(tPag), td(st), td(menu,'actions')
       );
       tbody.appendChild(tr);
 
@@ -368,11 +335,11 @@ export function mountFornecedoresMiniApp(root, { ac, store, bus, getCurrentId })
     const base = normFornecedor({
       fornecedor:(inFornecedor.value||'').trim(),
       contato:(inContato.value||'').trim(),
-      telefone:(inTel.value||'').trim(),
+      telefone:maskPhoneValue(ac, (inTel.value||'').trim()),
       categoria:(inCat.value||'').trim(),
       dataEntrega: inEnt.value||'',
-      valor: parseBRL(inVal.value),
-      pago: parseBRL(inPago.value),
+      valor: parseMoneyValue(ac, inVal.value),
+      pago: parseMoneyValue(ac, inPago.value),
       status: inStatus.value||''
     });
     if(!base.fornecedor){ inFornecedor.focus(); return; }

--- a/tools/shared/miniapps/mensagens/v1.mjs
+++ b/tools/shared/miniapps/mensagens/v1.mjs
@@ -1,4 +1,7 @@
-// AC — Mini‑App de Mensagens (v1)
+import { uid as makeUid } from '../../utils/ids.mjs';
+import { formatDateBR } from '../../utils/br.mjs';
+
+// tools/shared/miniapps/mensagens/v1.mjs — Mini‑App de Mensagens (v1)
 // Padrão de montagem: mountMensagensMiniApp(host, { ac, store, bus, getCurrentId })
 // Mantém compatibilidade com o ecossistema (autosave via store, eventos via bus).
 
@@ -16,9 +19,9 @@ export function mountMensagensMiniApp(host, deps){
   // ===== Helpers =====
   const $  = (sel, root = host) => root.querySelector(sel);
   const $$ = (sel, root = host) => [...root.querySelectorAll(sel)];
-  const uid = () => (Date.now().toString(36) + Math.random().toString(36).slice(2,7));
+  const uid = () => makeUid('msg');
 
-  const fmtDateBR = (d) => ac?.format?.fmtDateBR ? ac.format.fmtDateBR(d) : (d ? d.split('-').reverse().join('/') : '');
+  const fmtDateBR = (d) => ac?.format?.fmtDateBR ? ac.format.fmtDateBR(d) : formatDateBR(d);
   const fmtDateTime = (d,h) => [fmtDateBR(d), (h||'').slice(0,5)].filter(Boolean).join(' ');
   const nowIsoDate = () => new Date(Date.now() - (new Date()).getTimezoneOffset()*60000).toISOString().slice(0,10);
   const today = nowIsoDate();

--- a/tools/shared/runtime/loader.mjs
+++ b/tools/shared/runtime/loader.mjs
@@ -1,0 +1,123 @@
+// tools/shared/runtime/loader.mjs
+// Loader utilitário para resolver módulos compartilhados localmente ou via CDN.
+// Mantém a estratégia "shared" pública para que os apps orquestradores possam
+// montar miniapps sem duplicar lógica de import dinâmico.
+
+const CDN_BASES = [
+  'https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main/tools/shared/',
+  'https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main/tools/shared/'
+];
+
+const LOCAL_BASES = [
+  '../',                  // raiz de `tools/shared/`
+  './',                   // mesma pasta (para submódulos)
+  '../../shared/',        // fallback quando servido de `/tools/`
+  '/tools/shared/'        // absoluto quando hospedado na raiz do repositório
+];
+
+const pendingStyles = new Map();
+
+async function tryImport(url, { verbose } = {}) {
+  try {
+    return await import(/* @vite-ignore */ url);
+  } catch (err) {
+    if (verbose) console.warn(`[runtimeLoader] falha ao importar ${url}`, err);
+    return null;
+  }
+}
+
+function buildAttempts(file, extraBases = []) {
+  const normalized = String(file || '').replace(/^\/+/, '');
+  const bases = [...extraBases, ...LOCAL_BASES, ...CDN_BASES];
+  const attempts = [];
+
+  for (const base of bases) {
+    if (!base) continue;
+    try {
+      if (/^https?:/i.test(base)) {
+        attempts.push(base.replace(/\/+$/, '/') + normalized);
+      } else {
+        const url = new URL(base.replace(/\/+$/, '/') + normalized, import.meta.url).href;
+        attempts.push(url);
+      }
+    } catch (err) {
+      console.warn('[runtimeLoader] base inválida ignorada:', base, err);
+    }
+  }
+
+  return [...new Set(attempts)];
+}
+
+export async function loadSharedModule(file, options = {}) {
+  const { extraBases = [], verbose = false } = options;
+  const attempts = buildAttempts(file, extraBases);
+
+  for (const url of attempts) {
+    const mod = await tryImport(url, { verbose });
+    if (mod) return mod;
+  }
+
+  throw new Error(`Não foi possível carregar o módulo compartilhado "${file}".`);
+}
+
+export async function loadSharedModules(files, options = {}) {
+  return Promise.all((files || []).map(file => loadSharedModule(file, options)));
+}
+
+export { CDN_BASES };
+
+function ensureDocument() {
+  if (typeof document === 'undefined') {
+    throw new Error('[runtimeLoader] Ambiente sem DOM não suporta carregamento de estilos compartilhados.');
+  }
+}
+
+function createStylesheet(href, key) {
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    link.dataset.sharedStyle = key;
+    link.addEventListener('load', () => resolve(link), { once: true });
+    link.addEventListener('error', (err) => {
+      link.remove();
+      reject(err || new Error(`Falha ao carregar stylesheet ${href}`));
+    }, { once: true });
+    document.head.appendChild(link);
+  });
+}
+
+export async function ensureSharedStyle(file, options = {}) {
+  const { extraBases = [], verbose = false, key = file } = options;
+  if (!file) throw new Error('[runtimeLoader] Caminho de stylesheet inválido.');
+  ensureDocument();
+
+  const existing = document.querySelector(`link[data-shared-style="${key}"]`);
+  if (existing) return existing;
+
+  if (pendingStyles.has(key)) return pendingStyles.get(key);
+
+  const attempts = buildAttempts(file, extraBases);
+
+  const promise = (async () => {
+    for (const href of attempts) {
+      try {
+        const sheet = await createStylesheet(href, key);
+        pendingStyles.delete(key);
+        return sheet;
+      } catch (err) {
+        if (verbose) console.warn(`[runtimeLoader] falha ao carregar ${href}`, err);
+      }
+    }
+
+    pendingStyles.delete(key);
+    throw new Error(`Não foi possível carregar a folha de estilos compartilhada "${file}".`);
+  })();
+
+  pendingStyles.set(key, promise);
+  return promise;
+}
+
+export async function ensureSharedStyles(files, options = {}) {
+  return Promise.all((files || []).map(file => ensureSharedStyle(file, options)));
+}

--- a/tools/shared/runtimeLoader.mjs
+++ b/tools/shared/runtimeLoader.mjs
@@ -1,0 +1,1 @@
+export * from './runtime/loader.mjs';

--- a/tools/shared/styles/app.css
+++ b/tools/shared/styles/app.css
@@ -1,0 +1,976 @@
+/* tools/shared/styles/app.css */
+/* Camada unificada de estilos do Projeto Marco.
+   Esta folha combina o layout do app de Eventos, utilitários compartilhados
+   pelos miniapps e as regras específicas para convidados/convites.
+   Manter este arquivo como única dependência de CSS permite incorporar o
+   aplicativo em hosts (WordPress/Elementor) com um único `<link>` dinâmico. */
+
+:root {
+  --ac-font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --ac-radius-sm: 8px;
+  --ac-radius-md: 12px;
+  --ac-radius-lg: 18px;
+  --ac-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --ac-shadow-md: 0 10px 30px rgba(15, 23, 42, 0.12);
+  --ac-bg-body: #f3f6fb;
+  --ac-bg-card: #ffffff;
+  --ac-bg-card-muted: #f8faff;
+  --ac-border: #d6deeb;
+  --ac-border-strong: #b6c4de;
+  --ac-border-soft: #e4e9f3;
+  --ac-text-strong: #0f172a;
+  --ac-text-body: #1e293b;
+  --ac-text-muted: #64748b;
+  --ac-primary: #0b65c2;
+  --ac-primary-soft: #e6f1ff;
+  --ac-secondary: #ffa245;
+  --ac-success: #0a8f60;
+  --ac-success-soft: #e6f6ef;
+  --ac-warning: #a25a00;
+  --ac-warning-soft: #fff7ed;
+  --ac-danger: #b71c1c;
+  --ac-danger-soft: #ffebee;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--ac-font-family);
+  background: var(--ac-bg-body);
+  color: var(--ac-text-body);
+  line-height: 1.5;
+}
+
+body {
+  min-height: 100vh;
+}
+
+main.ac {
+  display: block;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(243, 246, 251, 1) 100%);
+  padding: 32px 0 64px;
+  font-family: var(--ac-font-family);
+}
+
+.ac .container {
+  width: min(1180px, 92vw);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.ac h1, .ac h2, .ac h3, .ac h4 {
+  font-weight: 600;
+  color: var(--ac-text-strong);
+  margin: 0;
+}
+
+.ac h1.app-title {
+  font-size: clamp(1.45rem, 1.2rem + 0.7vw, 2rem);
+  letter-spacing: -0.01em;
+}
+
+.ac h2 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--ac-text-body);
+}
+
+.ac .small {
+  font-size: 0.8rem;
+}
+
+.ac .muted {
+  color: var(--ac-text-muted);
+}
+
+.ac .card {
+  background: var(--ac-bg-card);
+  border-radius: var(--ac-radius-lg);
+  box-shadow: var(--ac-shadow-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  padding: clamp(20px, 18px + 0.8vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.ac .card--tight {
+  gap: 16px;
+}
+
+.ac .row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.ac .row--center {
+  align-items: center;
+}
+
+.ac .row--between {
+  justify-content: space-between;
+}
+
+.ac .row--tight {
+  gap: 8px;
+}
+
+.ac .row--loose {
+  gap: 20px;
+}
+
+.ac .row--nowrap {
+  flex-wrap: nowrap;
+}
+
+.ac .row--gap-xs { gap: 6px; }
+.ac .row--gap-sm { gap: 10px; }
+.ac .row--gap-md { gap: 16px; }
+.ac .row--gap-lg { gap: 24px; }
+
+.ac .push-end {
+  margin-left: auto;
+}
+
+.ac .btn {
+  border: 1px solid var(--ac-border);
+  background: var(--ac-bg-card);
+  color: var(--ac-text-body);
+  border-radius: var(--ac-radius-sm);
+  padding: 8px 14px;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ac .btn:hover {
+  background: var(--ac-primary-soft);
+  border-color: var(--ac-primary);
+}
+
+.ac .btn:active {
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.08);
+}
+
+.ac .btn[disabled],
+.ac .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ac .btn.btn--ghost {
+  background: transparent;
+  border-color: rgba(15, 23, 42, 0.16);
+}
+
+.ac .btn.btn--ghost:hover {
+  background: rgba(11, 101, 194, 0.08);
+}
+
+.ac .btn.primary,
+.ac .btn.btn--primary,
+.ac button.primary {
+  background: var(--ac-primary);
+  border-color: var(--ac-primary);
+  color: #fff;
+}
+
+.ac .btn.primary:hover,
+.ac .btn.btn--primary:hover,
+.ac button.primary:hover {
+  background: #0a57a5;
+}
+
+.ac .btn.danger,
+.ac .btn.btn--danger {
+  color: var(--ac-danger);
+  border-color: rgba(183, 28, 28, 0.35);
+}
+
+.ac .btn.danger:hover,
+.ac .btn.btn--danger:hover {
+  background: rgba(183, 28, 28, 0.08);
+}
+
+.ac .status-stack {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ac .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: var(--ac-primary-soft);
+  color: var(--ac-primary);
+}
+
+.ac .pill--status {
+  display: none;
+}
+
+.ac .pillok { background: var(--ac-success-soft); color: var(--ac-success); border-color: rgba(10, 143, 96, 0.24); }
+.ac .pillwarn { background: var(--ac-warning-soft); color: var(--ac-warning); border-color: rgba(162, 90, 0, 0.32); }
+.ac .pillsaving { background: var(--ac-primary-soft); color: var(--ac-primary); border-color: rgba(11, 101, 194, 0.3); }
+
+.ac .pill.show,
+.ac .pill[aria-hidden="false"],
+.ac .pill.active {
+  display: inline-flex;
+}
+
+.ac label {
+  font-weight: 600;
+  color: var(--ac-text-body);
+}
+
+.ac input,
+.ac select,
+.ac textarea {
+  font: inherit;
+  padding: 10px 12px;
+  border-radius: var(--ac-radius-sm);
+  border: 1px solid var(--ac-border);
+  background: #fff;
+  color: var(--ac-text-body);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 42px;
+}
+
+.ac input:focus,
+.ac select:focus,
+.ac textarea:focus {
+  outline: none;
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 3px rgba(11, 101, 194, 0.15);
+}
+
+.ac textarea {
+  resize: vertical;
+}
+
+.ac .field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ac .twocol {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.ac .threecol {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.ac .details-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-radius: var(--ac-radius-md);
+  background: var(--ac-bg-card-muted);
+  border: 1px dashed rgba(11, 101, 194, 0.18);
+}
+
+.ac details {
+  border-radius: var(--ac-radius-md);
+  background: #fff;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ac details + details {
+  margin-top: 12px;
+}
+
+.ac details > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 18px;
+  font-weight: 600;
+  color: var(--ac-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ac details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.ac details[open] {
+  border-color: rgba(11, 101, 194, 0.32);
+  box-shadow: 0 6px 22px rgba(11, 101, 194, 0.08);
+}
+
+.ac details[open] > summary {
+  border-bottom: 1px solid rgba(11, 101, 194, 0.18);
+}
+
+.ac .close-hint {
+  font-size: 0.78rem;
+  color: var(--ac-text-muted);
+  text-align: right;
+}
+
+.ac .select-block {
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ac .badge-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.ac .badge {
+  position: relative;
+  background: var(--ac-bg-card);
+  border-radius: var(--ac-radius-md);
+  padding: 18px;
+  border: 1px solid var(--ac-border-soft);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ac .badge h3 {
+  font-size: 1rem;
+  color: var(--ac-primary);
+}
+
+.ac .badge .actions {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+}
+
+.ac .badge .edit-btn {
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  background: #fff;
+  border-radius: 10px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.ac .badge .edit-btn:hover {
+  background: rgba(11, 101, 194, 0.12);
+}
+
+.ac dl.kv {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 12px;
+  row-gap: 6px;
+  font-size: 0.9rem;
+  color: var(--ac-text-body);
+}
+
+.ac dl.kv dt {
+  font-weight: 600;
+  color: var(--ac-text-muted);
+}
+
+.ac dl.kv dd {
+  margin: 0;
+  font-weight: 500;
+}
+
+/* Indicadores & progressos */
+#ac-cardIndicadores,
+#cardIndicadores {
+  display: grid;
+  gap: 18px;
+}
+
+#ac-cardIndicadores .mini,
+#cardIndicadores .mini {
+  background: var(--ac-bg-card);
+  border-radius: var(--ac-radius-md);
+  border: 1px solid var(--ac-border-soft);
+  padding: 18px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  min-height: 160px;
+}
+
+#cardIndicadores .mini.kpi .label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ac-primary);
+}
+
+#cardIndicadores .mini.kpi .label h3 {
+  font-size: 1rem;
+  margin: 0;
+  color: inherit;
+}
+
+#cardIndicadores .mini.kpi .actions {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+#cardIndicadores .mini.kpi.active {
+  border-color: var(--ac-secondary);
+  background: rgba(255, 162, 69, 0.12);
+  box-shadow: 0 0 0 2px rgba(255, 162, 69, 0.25);
+}
+
+.progress {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress__track {
+  width: 100%;
+  background: #eef2f6;
+  border-radius: 999px;
+  overflow: hidden;
+  height: 8px;
+}
+
+.progress.progress--lg .progress__track {
+  height: 10px;
+}
+
+.progress__bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--ac-primary);
+  width: 0;
+  transition: width 0.3s ease;
+}
+
+.progress--segments .progress__track {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.progress--segments .seg {
+  flex: 0 0 auto;
+  height: 10px;
+  border-radius: 6px;
+  background: var(--ac-primary);
+}
+
+.hbar-legend,
+#cardIndicadores .hbar-legend {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--ac-text-muted);
+}
+
+/* Miniapps compartilhados */
+.miniapp {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  font-family: inherit;
+}
+
+.miniapp .miniapp__title {
+  font-size: 1.05rem;
+  color: var(--ac-primary);
+}
+
+.miniapp .miniapp__subtitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ac-text-strong);
+}
+
+.miniapp .miniapp__legend {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--ac-text-muted);
+}
+
+.miniapp .miniapp__progress-track {
+  height: 10px;
+  border-radius: 8px;
+  background: #eef2f6;
+  overflow: hidden;
+}
+
+.miniapp .miniapp__progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--ac-primary);
+  transition: width 0.3s ease;
+}
+
+.miniapp .miniapp__input,
+.miniapp .miniapp__select,
+.miniapp .miniapp__textarea {
+  font: inherit;
+  padding: 9px 11px;
+  border-radius: var(--ac-radius-sm);
+  border: 1px solid var(--ac-border);
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.miniapp .miniapp__input:focus,
+.miniapp .miniapp__select:focus,
+.miniapp .miniapp__textarea:focus {
+  outline: none;
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 3px rgba(11, 101, 194, 0.15);
+}
+
+.miniapp .miniapp__textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.miniapp .miniapp__input--flex,
+.miniapp .miniapp__select--flex {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+
+.miniapp .w-100 { width: 100%; }
+.miniapp .w-140 { width: 140px; }
+.miniapp .w-160 { width: 160px; }
+.miniapp .w-180 { width: 180px; }
+.miniapp .w-200 { width: 200px; }
+
+.miniapp .miniapp__table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 10px;
+}
+
+.miniapp .miniapp__table thead th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ac-text-muted);
+  border-bottom: none;
+}
+
+.miniapp .miniapp__table tbody tr {
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.25);
+  border-radius: var(--ac-radius-sm);
+}
+
+.miniapp .miniapp__table tbody td {
+  padding: 10px 12px;
+  vertical-align: middle;
+}
+
+.miniapp .miniapp__table tbody td:first-child {
+  border-top-left-radius: var(--ac-radius-sm);
+  border-bottom-left-radius: var(--ac-radius-sm);
+}
+
+.miniapp .miniapp__table tbody td:last-child {
+  border-top-right-radius: var(--ac-radius-sm);
+  border-bottom-right-radius: var(--ac-radius-sm);
+}
+
+.miniapp .miniapp__icon-btn {
+  min-width: 36px;
+  height: 36px;
+  border-radius: var(--ac-radius-sm);
+}
+
+.miniapp .miniapp__hint {
+  font-size: 0.78rem;
+  color: var(--ac-text-muted);
+}
+
+.miniapp .miniapp__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.miniapp .fld {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.miniapp .fld--full {
+  grid-column: 1 / -1;
+}
+
+.miniapp .miniapp__editor {
+  padding: 14px;
+  border: 1px dashed var(--ac-border);
+  border-radius: var(--ac-radius-sm);
+  background: rgba(243, 246, 251, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.miniapp .miniapp__menu {
+  position: relative;
+}
+
+.miniapp .miniapp__menu summary {
+  list-style: none;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+  background: #fff;
+}
+
+.miniapp .miniapp__menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.miniapp .miniapp__menu details[open] summary {
+  box-shadow: inset 0 0 0 1px var(--ac-primary);
+}
+
+.miniapp .miniapp__menu-pop {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  background: #fff;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius-sm);
+  box-shadow: var(--ac-shadow-md);
+  min-width: 160px;
+  z-index: 10;
+}
+
+.miniapp .miniapp__menu-pop button {
+  width: 100%;
+  padding: 10px 12px;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.miniapp .miniapp__menu-pop button:hover {
+  background: rgba(11, 101, 194, 0.08);
+}
+
+/* Miniapp Convidados */
+.ac-convidados {
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ac-convidados .toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.ac-convidados .toolbar .grow {
+  flex: 1 1 220px;
+}
+
+.ac-convidados input,
+.ac-convidados select,
+.ac-convidados textarea {
+  font: inherit;
+  padding: 8px 10px;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius-sm);
+}
+
+.ac-convidados .btn {
+  border-radius: var(--ac-radius-sm);
+  padding: 8px 14px;
+}
+
+.ac-convidados .btn.primary {
+  background: var(--ac-primary);
+  color: #fff;
+  border-color: var(--ac-primary);
+}
+
+.ac-convidados .grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr 0.8fr 0.6fr 0.7fr 0.6fr 0.5fr 0.4fr 0.3fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.ac-convidados .head {
+  font-weight: 600;
+  color: var(--ac-primary);
+}
+
+.ac-convidados .row {
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: var(--ac-radius-sm);
+  padding: 10px;
+  background: #fff;
+  display: contents;
+}
+
+.ac-convidados .row > * {
+  padding: 6px 0;
+}
+
+.ac-convidados .pill {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.ac-convidados .pill.ok {
+  background: var(--ac-success-soft);
+  color: var(--ac-success);
+  border-color: rgba(10, 143, 96, 0.24);
+}
+
+.ac-convidados .pill.warn {
+  background: var(--ac-warning-soft);
+  color: var(--ac-warning);
+  border-color: rgba(162, 90, 0, 0.32);
+}
+
+.ac-convidados .pill.deny {
+  background: var(--ac-danger-soft);
+  color: var(--ac-danger);
+  border-color: rgba(183, 28, 28, 0.28);
+}
+
+.ac-convidados details.editor {
+  margin-top: 12px;
+}
+
+.ac-convidados .editor .grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.ac-convidados .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.ac-convidados .menu {
+  position: relative;
+}
+
+.ac-convidados .menu > button,
+.ac-convidados .btn-menu {
+  width: 36px;
+  height: 32px;
+  border-radius: var(--ac-radius-sm);
+}
+
+.ac-convidados .menu .popup {
+  position: absolute;
+  right: 0;
+  top: 36px;
+  background: #fff;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius-sm);
+  box-shadow: var(--ac-shadow-md);
+  display: none;
+  min-width: 160px;
+  z-index: 12;
+}
+
+.ac-convidados .menu.open .popup {
+  display: block;
+}
+
+.ac-convidados .popup button {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.ac-convidados .popup button:hover {
+  background: rgba(11, 101, 194, 0.08);
+}
+
+/* Responsividade */
+@media (max-width: 1100px) {
+  .ac .badge-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ac .threecol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 920px) {
+  .ac .container {
+    width: min(100%, 94vw);
+  }
+
+  .ac .badge {
+    min-height: 160px;
+  }
+
+  .ac-convidados .grid {
+    grid-template-columns: 1fr 0.9fr 0.8fr 0.6fr 0.7fr 0.5fr 0.4fr 0.3fr;
+  }
+}
+
+@media (max-width: 760px) {
+  main.ac {
+    padding: 24px 0 48px;
+  }
+
+  .ac .container {
+    gap: 24px;
+  }
+
+  .ac .card {
+    padding: 18px;
+  }
+
+  .ac .row {
+    gap: 10px;
+  }
+
+  .ac .twocol,
+  .ac .threecol {
+    grid-template-columns: 1fr;
+  }
+
+  .ac .select-block {
+    width: 100%;
+  }
+
+  .ac .status-stack {
+    justify-content: flex-start;
+  }
+
+  .ac .badge-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ac dl.kv {
+    grid-template-columns: 1fr;
+  }
+
+  #cardIndicadores .mini.kpi {
+    min-height: 140px;
+  }
+
+  .ac-convidados .grid {
+    grid-template-columns: 1fr 0.8fr 0.7fr 0.6fr 0.7fr 0.6fr 0.5fr;
+  }
+
+  .ac-convidados .col-presenca {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .ac .container {
+    width: 100%;
+    padding: 0 18px;
+  }
+
+  .ac h1.app-title {
+    font-size: 1.4rem;
+  }
+
+  .ac .status-stack {
+    gap: 6px;
+  }
+
+  .ac .btn {
+    padding: 7px 12px;
+  }
+
+  .ac-convidados .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ac-convidados .grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    row-gap: 6px;
+  }
+
+  .ac-convidados .grid > *:nth-child(n+5) {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .ac .container {
+    padding: 0 14px;
+  }
+
+  .ac .badge {
+    padding: 16px;
+  }
+
+  .ac .status-stack {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ac .btn {
+    width: 100%;
+  }
+}

--- a/tools/shared/utils/br.mjs
+++ b/tools/shared/utils/br.mjs
@@ -1,0 +1,70 @@
+// tools/shared/utils/br.mjs
+// Funções utilitárias para formatos brasileiros (datas, moeda e telefone).
+
+export function formatMoneyBR(value, options = {}) {
+  const amount = Number(value ?? 0) || 0;
+  const baseOptions = { style: 'currency', currency: 'BRL', minimumFractionDigits: 2 };
+  try {
+    return new Intl.NumberFormat('pt-BR', { ...baseOptions, ...options }).format(amount);
+  } catch {
+    return `R$ ${amount.toFixed(2)}`;
+  }
+}
+
+export function parseCurrencyBR(input) {
+  if (typeof input === 'number') return input;
+  const sanitized = String(input ?? '')
+    .replace(/[^0-9,.-]+/g, '')
+    .replace(/\.(?=.*\.)/g, '')
+    .replace(',', '.');
+  const parsed = parseFloat(sanitized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatDateBR(value) {
+  if (!value) return '';
+  if (value instanceof Date) {
+    return Number.isNaN(+value) ? '' : value.toLocaleDateString('pt-BR');
+  }
+  const isoMatch = String(value).match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    const [, y, m, d] = isoMatch;
+    return `${d}/${m}/${y}`;
+  }
+  return String(value);
+}
+
+export function parseDateBR(value) {
+  if (!value) return '';
+  const match = String(value).match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
+  if (!match) return String(value);
+  const [, dd, mm, yy] = match;
+  const year = yy.length === 2 ? `20${yy}` : yy;
+  return `${year.padStart(4, '0')}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
+}
+
+export function toISODate(value) {
+  if (!value) return '';
+  if (/^\d{4}-\d{2}-\d{2}/.test(String(value))) {
+    return String(value).slice(0, 10);
+  }
+  const parsed = parseDateBR(value);
+  if (parsed && /^\d{4}-\d{2}-\d{2}/.test(parsed)) return parsed;
+  const date = new Date(value);
+  return Number.isNaN(+date) ? '' : date.toISOString().slice(0, 10);
+}
+
+export function normalizePhoneBR(value) {
+  let digits = String(value ?? '').replace(/\D+/g, '');
+  if (digits.length > 11) digits = digits.slice(-11);
+  if (digits.length < 10) return '';
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7, 11)}`;
+}
+
+export function maskPhoneBR(value) {
+  const digits = String(value ?? '').replace(/\D+/g, '').slice(0, 11);
+  return normalizePhoneBR(digits) || digits;
+}

--- a/tools/shared/utils/dom.mjs
+++ b/tools/shared/utils/dom.mjs
@@ -1,0 +1,36 @@
+// tools/shared/utils/dom.mjs
+// Utilidades leves para construção e manipulação de nós DOM.
+
+export function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  Object.entries(attrs || {}).forEach(([key, value]) => {
+    if (key === 'className') {
+      node.className = value || '';
+    } else if (key === 'dataset') {
+      Object.assign(node.dataset, value || {});
+    } else if (key in node) {
+      node[key] = value;
+    } else if (value !== undefined) {
+      node.setAttribute(key, value);
+    }
+  });
+
+  (Array.isArray(children) ? children : [children]).forEach(child => {
+    if (child === null || child === undefined) return;
+    node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+  });
+
+  return node;
+}
+
+export function clear(node) {
+  while (node && node.firstChild) node.removeChild(node.firstChild);
+}
+
+export const qs = (selector, root = document) => root.querySelector(selector);
+export const qsa = (selector, root = document) => [...root.querySelectorAll(selector)];
+
+export function ensureHost(host) {
+  if (!host) throw new Error('[dom.ensureHost] host inválido para miniapp');
+  return host;
+}

--- a/tools/shared/utils/ids.mjs
+++ b/tools/shared/utils/ids.mjs
@@ -1,0 +1,12 @@
+// tools/shared/utils/ids.mjs
+// Gerador centralizado de identificadores (curtos, mas únicos o bastante para miniapps).
+
+export function uid(prefix = 'id') {
+  const rand = Math.random().toString(36).slice(2, 9);
+  const time = Date.now().toString(36);
+  return `${prefix}_${time}_${rand}`;
+}
+
+export function shortId(prefix = 'id') {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/tools/shared/utils/invites.mjs
+++ b/tools/shared/utils/invites.mjs
@@ -1,4 +1,4 @@
-// shared/inviteUtils.js
+// tools/shared/utils/invites.mjs
 // Converte LINHAS em "convites" estruturados (titular, acompanhantes, telefone, total).
 // Regras:
 // - Cada **linha** = 1 convite.
@@ -6,25 +6,21 @@
 // - Telefone pode estar em qualquer lugar na linha; é detectado e padronizado (BR 10/11 dígitos).
 // - Sequências com 2+ dígitos não são consideradas parte do nome.
 
-import { normalizeName, stripNumbersFromName } from "./listUtils.js";
+import { normalizeName, stripNumbersFromName } from './list.mjs';
+import { normalizePhoneBR } from './br.mjs';
+import { uid as makeUid } from './ids.mjs';
 
 // Telefones soltos: aceita +55, DDD, espaços, hífens e parênteses
 const PHONE_RE = /(?:\+?\d[\d\s().-]{6,}\d)/g;
 
 // ID estável para cada convite
-export function uid() {
-  return (crypto?.randomUUID?.() ?? `id_${Date.now().toString(36)}_${Math.random().toString(36).slice(2,8)}`);
-}
+export const uid = () => makeUid('invite');
 
 // Normaliza telefone BR (10/11 dígitos). Se vier +55, mantém os 11 finais.
-export function normalizePhone(s = "") {
-  let d = String(s).replace(/\D/g, "");
-  if (d.length > 11) d = d.slice(-11);
-  if (d.length < 10) return null;
-  return d.length === 10
-    ? `(${d.slice(0,2)}) ${d.slice(2,6)}-${d.slice(6)}`
-    : `(${d.slice(0,2)}) ${d.slice(2,7)}-${d.slice(7,11)}`;
-}
+export const normalizePhone = (s = '') => {
+  const normalized = normalizePhoneBR(s);
+  return normalized || null;
+};
 
 // Pega o "melhor" telefone (mais dígitos) e remove da linha
 function extractPhone(line = "") {

--- a/tools/shared/utils/list.mjs
+++ b/tools/shared/utils/list.mjs
@@ -1,0 +1,20 @@
+// tools/shared/utils/list.mjs
+// Helpers para higienizar e normalizar nomes vindos de textos livres.
+
+export function normalizeName(name = '') {
+  const cleaned = String(name)
+    .normalize('NFD')
+    .replace(/\p{Diacritic}+/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return '';
+  return cleaned
+    .split(' ')
+    .map(part => part ? part[0].toUpperCase() + part.slice(1).toLowerCase() : '')
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function stripNumbersFromName(value = '') {
+  return String(value).replace(/\d{2,}/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/tools/shared/utils/store.mjs
+++ b/tools/shared/utils/store.mjs
@@ -1,0 +1,31 @@
+// tools/shared/utils/store.mjs
+// Abstrações leves sobre a API do projectStore.
+
+const clone = (obj) => {
+  if (typeof structuredClone === 'function') return structuredClone(obj);
+  return JSON.parse(JSON.stringify(obj));
+};
+
+export async function getProject(store, id) {
+  if (!store || typeof store.getProject !== 'function' || !id) return null;
+  return await store.getProject(id);
+}
+
+export async function updateProject(store, id, mutator, { ensure } = {}) {
+  if (!store || typeof store.updateProject !== 'function' || !id) return null;
+  const current = (await getProject(store, id)) || {};
+  const draft = clone(current);
+  if (ensure) ensure(draft);
+  if (typeof mutator === 'function') mutator(draft, current);
+  draft.updatedAt = Date.now();
+  await store.updateProject(id, draft);
+  return await getProject(store, id);
+}
+
+export async function upsertProject(store, id, payload) {
+  if (!store || typeof store.updateProject !== 'function' || !id) return null;
+  const next = clone(payload || {});
+  next.updatedAt = Date.now();
+  await store.updateProject(id, next);
+  return await getProject(store, id);
+}

--- a/tools/unique/README.md
+++ b/tools/unique/README.md
@@ -1,0 +1,17 @@
+# tools/unique/
+
+Este diretório permanece reservado para integrações pontuais ou sensíveis que não devam ir para o catálogo compartilhado.
+No momento, todos os miniapps ativos foram promovidos para `tools/shared/`.
+
+## Quando usar
+- Regras corporativas específicas de um cliente/parceiro.
+- Conectores que dependem de credenciais particulares ou contratos de confidencialidade.
+- Experimentos que ainda não cumpriram os critérios para serem tornados públicos.
+
+## Como documentar um módulo `unique`
+1. Crie um arquivo `nomeDoModulo.unix.mjs` (sufixo `.unix` sinaliza que é temporário) com comentários iniciais explicando por que não está em `shared`.
+2. Declare no topo as dependências obrigatórias (`ac`, `store`, `bus`, `getCurrentId`) e descreva no README do app como configurá-las.
+3. Liste no final do arquivo os gatilhos para promoção ao catálogo comum (ex.: número de apps interessados, removal de credenciais).
+4. Atualize `log.md` registrando o motivo da criação e o plano de futura migração.
+
+Assim que o módulo se mostrar reutilizável, promova-o para `tools/shared/`, remova o sufixo `.unix` e documente a mudança na arquitetura.


### PR DESCRIPTION
## Summary
- consolida as folhas de estilo em `tools/shared/styles/app.css`, cobrindo layout do app Eventos, widgets e miniapp de convidados com regras responsivas
- ajusta o bootstrap do app de Eventos para carregar a nova folha única via `ensureSharedStyle('styles/app.css')`
- atualiza README, guia de arquitetura, agent e log para refletir a base visual unificada

## Testing
- not run (documentação e estilos)


------
https://chatgpt.com/codex/tasks/task_e_68dfe83f7e288320b210dad2bcfbb95d