### PR TITLE
Documenta política de QA para entregas

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -4,12 +4,17 @@
 Este documento fornece um rápido resumo para quem automatiza tarefas neste repositório, descrevendo práticas recomendadas e pontos de atenção ao modificar os módulos compartilhados do projeto.
 
 ## Diretrizes Gerais
-- 
+- Respeitar os fluxos de QA documentados no `readme.md` e em `docs/arquitetura.md`.
+- Registrar evidências de cada automação executada nos canais acordados com a equipe.
 
 ## Convenções de Estilo
-- 
+- Manter mensagens de commit descritivas, utilizando português claro.
+- Evitar alterações irrelevantes ou quebrem o formato Markdown existente.
 
 ## Checklist Rápido
-1. 
+1. Garantir captura de screenshot dos chips do cabeçalho (`chipReady`, `chipDirty`, `chipSaving`) durante a execução automatizada.
+2. Executar `projectStore.ping()` e `projectStore.backupAll()`, salvando logs que comprovem sucesso antes da entrega.
+3. Confirmar que o processo de bootstrap cria o documento local esperado e anexar a evidência correspondente.
+4. Atualizar o diário de QA com data, responsável e links das evidências coletadas.
 
 Seguir estas orientações ajuda a manter o código consistente e facilita o trabalho colaborativo entre agentes e desenvolvedores humanos.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,6 @@
+# Arquitetura do Projeto
+
+## QA antes da entrega
+- **Estados do cabeçalho**: capturar screenshots ou gravações dos chips nos estados de pronto (`chipReady`), em edição (`chipDirty`) e salvando (`chipSaving`). Cada captura deve ser arquivada com referência ao build.
+- **Confirmação de backup**: executar `projectStore.ping()` para validar conectividade e `projectStore.backupAll()` para garantir persistência. Registrar evidências (logs ou capturas) das execuções bem-sucedidas.
+- **Registro dos resultados**: documentar as verificações no diário de QA compartilhado (pasta `docs/qa/diario.md` ou ferramenta equivalente), mencionando data, responsável e links para as evidências.

--- a/log.md
+++ b/log.md
@@ -2,3 +2,6 @@
 
 ## 2025-10-02
 - Adicionados arquivos de README e log para facilitar a documentação das atividades.
+
+## 2025-10-03
+- Formalizada a política de QA exigindo evidências de estados dos chips, validação manual de botões e confirmação de backup antes das entregas.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,11 @@
 # Projeto Marco
 
 Este repositório...
+
+## Metodologia de Entrega e Experiência
+
+### Build e Testes
+- Antes de cada release, capturar e anexar prints do cabeçalho exibindo os chips `chipReady`, `chipDirty` e `chipSaving`, garantindo que os três estados estejam registrados.
+- Validar manualmente os botões de ação (ícone `✎`, menus contextuais e opções principais), confirmando que respondem conforme esperado em ambiente de staging.
+- Executar e registrar os resultados de `projectStore.ping()` e `projectStore.backupAll()` imediatamente antes do release, assegurando que ambos concluam sem erros.
+


### PR DESCRIPTION
## Summary
- Atualiza o guia de build e testes no readme para incluir evidências dos chips, validação manual e verificações de backup.
- Documenta na arquitetura o checklist de QA antes da entrega e aponta onde registrar os resultados.
- Amplia o agent.md com passos operacionais e registra a nova política no log do projeto.

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e06177f3c48320a78abfbc74e74f72