### PR TITLE
Adjust widget shell layout height handling

### DIFF
--- a/tools/gestao-de-convidados/widget-shell.html
+++ b/tools/gestao-de-convidados/widget-shell.html
@@ -16,7 +16,7 @@
       html,
       body {
         margin: 0;
-        height: 100%;
+        min-height: 100vh;
         background: #0f1824;
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
         color: #f5f7fa;
@@ -25,7 +25,7 @@
       iframe {
         border: 0;
         width: 100%;
-        height: 100%;
+        min-height: 100vh;
         display: block;
       }
 


### PR DESCRIPTION
## Summary
- update the widget shell stylesheet to use min-height instead of fixed 100% heights
- allow the iframe container to expand with its embedded application

## Testing
- python -m http.server 8000 (manual check in browser)


------
https://chatgpt.com/codex/tasks/task_e_68ddec2b312c83208923cc8edaa01437