### PR TITLE
feat: add shared list utilities for invite parsing

### DIFF
--- a/shared/inviteUtils.js
+++ b/shared/inviteUtils.js
@@ -7,6 +7,7 @@
 // - Sequências com 2+ dígitos não são consideradas parte do nome.
 
 import { normalizeName, stripNumbersFromName } from "./listUtils.js";
+export { normalizeName, stripNumbersFromName } from "./listUtils.js";
 
 // Telefones soltos: aceita +55, DDD, espaços, hífens e parênteses
 const PHONE_RE = /(?:\+?\d[\d\s().-]{6,}\d)/g;

--- a/shared/listUtils.js
+++ b/shared/listUtils.js
@@ -1,0 +1,73 @@
+// shared/listUtils.js
+// Utilitários para tratamento de nomes em listas de convidados.
+
+const LOWERCASE_PARTICLES = new Set([
+  "da",
+  "de",
+  "do",
+  "das",
+  "dos",
+  "e"
+]);
+
+function titleCaseWord(word = "", forceCapitalize = false) {
+  const lower = word.toLowerCase();
+  if (!forceCapitalize && LOWERCASE_PARTICLES.has(lower)) {
+    return lower;
+  }
+  // Trata nomes hifenizados mantendo capitalização adequada em cada parte.
+  return lower
+    .split("-")
+    .map(part => part ? part[0].toUpperCase() + part.slice(1) : "")
+    .join("-");
+}
+
+/**
+ * Remove sequências de 2+ dígitos dos nomes para evitar que números
+ * (telefones, quantidades, etc.) passem para o campo de texto.
+ * @param {string} value
+ * @returns {string}
+ */
+export function stripNumbersFromName(value = "") {
+  const cleaned = String(value)
+    // Remove sequências longas de dígitos.
+    .replace(/\d{2,}/g, " ")
+    // Remove símbolos comuns deixados por cópias de planilhas.
+    .replace(/[()\[\]{}]/g, " ")
+    .replace(/[+•]/g, " ")
+    // Normaliza múltiplos espaços em branco.
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned;
+}
+
+/**
+ * Padroniza nomes: remove espaços extras, garante capitalização básica e
+ * mantém partículas comuns em minúsculas (de, da, dos, etc.).
+ * @param {string} value
+ * @returns {string}
+ */
+export function normalizeName(value = "") {
+  const base = stripNumbersFromName(value);
+  if (!base) return "";
+
+  const normalized = base
+    // Mantém apenas letras, caracteres acentuados, apóstrofos, espaços e hifens.
+    .replace(/[^\p{L}\p{M}'\s-]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  const words = normalized.split(/\s+/);
+  return words
+    .map((word, index) => titleCaseWord(word, index === 0))
+    .join(" ");
+}
+
+export default {
+  normalizeName,
+  stripNumbersFromName
+};

--- a/tools/gestao-de-convidados/app.html
+++ b/tools/gestao-de-convidados/app.html
@@ -233,6 +233,11 @@
     const inviteUtils = await loadShared(PATH_INV);
     await store?.init?.();
 
+    if (inviteUtils) {
+      console.assert(typeof inviteUtils.normalizeName === 'function', '[smoke] inviteUtils.normalizeName indisponível');
+      console.assert(typeof inviteUtils.stripNumbersFromName === 'function', '[smoke] inviteUtils.stripNumbersFromName indisponível');
+    }
+
     if (!store || !bus || !inviteUtils) {
       const errorMessage = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
       const main = document.querySelector('main.ac');

--- a/tools/gestao-de-convidados/convidados.html
+++ b/tools/gestao-de-convidados/convidados.html
@@ -132,6 +132,11 @@
   const inv   = await loadShared(PATH_INV);  // { parseInvites, normalizePhone }
   await store?.init?.();
 
+  if (inv) {
+    console.assert(typeof inv.normalizeName === 'function', '[smoke] inviteUtils.normalizeName indisponível');
+    console.assert(typeof inv.stripNumbersFromName === 'function', '[smoke] inviteUtils.stripNumbersFromName indisponível');
+  }
+
   // Estado e utilitários
   const AUTO_SAVE_MS = 700;
   const state = { currentId:null, project:null, lista:[], dirty:false, saving:false, timer:null };


### PR DESCRIPTION
## Summary
- add a new shared list utilities module that provides name normalization helpers without external dependencies
- reuse the helpers inside inviteUtils and expose them for other consumers
- add smoke checks in the guest management widgets to ensure the helpers are available at runtime

## Testing
- node -e "import('./shared/listUtils.js').then(m=>{console.log(m.normalizeName('  joao da silva  '));console.log(m.stripNumbersFromName('Ana 1234 (11)'));}).catch(err=>{console.error(err);process.exit(1);});"


------
https://chatgpt.com/codex/tasks/task_e_68ddda6f00a883208116f71e521b60aa