### PR TITLE
Ensure shared modules load locally before widget CDNs

### DIFF
--- a/tools/gestao-de-convidados/convidados.html
+++ b/tools/gestao-de-convidados/convidados.html
@@ -120,12 +120,38 @@
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
   const PATH_INV   = "/shared/inviteUtils.js"; // ferramenta de convites (fonte de verdade)
-  const CANDIDATES = [
+  const CDN_BASES = [
+    (() => {
+      try {
+        const url = new URL(import.meta.url);
+        return url.origin.startsWith('http') ? url.origin : null;
+      } catch {
+        return null;
+      }
+    })(),
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-  ];
-  async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
-  async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+  ].filter(Boolean);
+
+  const buildUrl = (base, rel) => {
+    if (!base) return rel;
+    const cleanRel = rel.startsWith('/') ? rel.slice(1) : rel;
+    const normalized = base.endsWith('/') ? base : base + '/';
+    return normalized + cleanRel;
+  };
+
+  async function loadShared(rel){
+    const attempts = [rel, ...CDN_BASES.map((base) => buildUrl(base, rel))];
+    for (const url of attempts) {
+      try {
+        const mod = await import(url);
+        if (mod) return mod;
+      } catch (err) {
+        console.warn('[convidados] Falha ao importar', url, err);
+      }
+    }
+    return null;
+  }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);

--- a/tools/gestao-de-convidados/eventos.html
+++ b/tools/gestao-de-convidados/eventos.html
@@ -100,12 +100,38 @@
 <script type="module">
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
-  const CANDIDATES = [
+  const CDN_BASES = [
+    (() => {
+      try {
+        const url = new URL(import.meta.url);
+        return url.origin.startsWith('http') ? url.origin : null;
+      } catch {
+        return null;
+      }
+    })(),
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-  ];
-  async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
-  async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+  ].filter(Boolean);
+
+  const buildUrl = (base, rel) => {
+    if (!base) return rel;
+    const cleanRel = rel.startsWith('/') ? rel.slice(1) : rel;
+    const normalized = base.endsWith('/') ? base : base + '/';
+    return normalized + cleanRel;
+  };
+
+  async function loadShared(rel){
+    const attempts = [rel, ...CDN_BASES.map((base) => buildUrl(base, rel))];
+    for (const url of attempts) {
+      try {
+        const mod = await import(url);
+        if (mod) return mod;
+      } catch (err) {
+        console.warn('[eventos] Falha ao importar', url, err);
+      }
+    }
+    return null;
+  }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);

--- a/tools/gestao-de-convidados/fornecedores.html
+++ b/tools/gestao-de-convidados/fornecedores.html
@@ -110,12 +110,38 @@
   // Módulos compartilhados
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
-  const CANDIDATES = [
+  const CDN_BASES = [
+    (() => {
+      try {
+        const url = new URL(import.meta.url);
+        return url.origin.startsWith('http') ? url.origin : null;
+      } catch {
+        return null;
+      }
+    })(),
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-  ];
-  async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
-  async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+  ].filter(Boolean);
+
+  const buildUrl = (base, rel) => {
+    if (!base) return rel;
+    const cleanRel = rel.startsWith('/') ? rel.slice(1) : rel;
+    const normalized = base.endsWith('/') ? base : base + '/';
+    return normalized + cleanRel;
+  };
+
+  async function loadShared(rel){
+    const attempts = [rel, ...CDN_BASES.map((base) => buildUrl(base, rel))];
+    for (const url of attempts) {
+      try {
+        const mod = await import(url);
+        if (mod) return mod;
+      } catch (err) {
+        console.warn('[fornecedores] Falha ao importar', url, err);
+      }
+    }
+    return null;
+  }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);

--- a/tools/gestao-de-convidados/mensagens.html
+++ b/tools/gestao-de-convidados/mensagens.html
@@ -95,12 +95,38 @@
 <script type="module">
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
-  const CANDIDATES = [
+  const CDN_BASES = [
+    (() => {
+      try {
+        const url = new URL(import.meta.url);
+        return url.origin.startsWith('http') ? url.origin : null;
+      } catch {
+        return null;
+      }
+    })(),
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-  ];
-  async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
-  async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+  ].filter(Boolean);
+
+  const buildUrl = (base, rel) => {
+    if (!base) return rel;
+    const cleanRel = rel.startsWith('/') ? rel.slice(1) : rel;
+    const normalized = base.endsWith('/') ? base : base + '/';
+    return normalized + cleanRel;
+  };
+
+  async function loadShared(rel){
+    const attempts = [rel, ...CDN_BASES.map((base) => buildUrl(base, rel))];
+    for (const url of attempts) {
+      try {
+        const mod = await import(url);
+        if (mod) return mod;
+      } catch (err) {
+        console.warn('[mensagens] Falha ao importar', url, err);
+      }
+    }
+    return null;
+  }
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
   await store?.init?.();

--- a/tools/gestao-de-convidados/tarefas.html
+++ b/tools/gestao-de-convidados/tarefas.html
@@ -88,12 +88,38 @@
   // Módulos compartilhados
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
-  const CANDIDATES = [
+  const CDN_BASES = [
+    (() => {
+      try {
+        const url = new URL(import.meta.url);
+        return url.origin.startsWith('http') ? url.origin : null;
+      } catch {
+        return null;
+      }
+    })(),
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-  ];
-  async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
-  async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
+  ].filter(Boolean);
+
+  const buildUrl = (base, rel) => {
+    if (!base) return rel;
+    const cleanRel = rel.startsWith('/') ? rel.slice(1) : rel;
+    const normalized = base.endsWith('/') ? base : base + '/';
+    return normalized + cleanRel;
+  };
+
+  async function loadShared(rel){
+    const attempts = [rel, ...CDN_BASES.map((base) => buildUrl(base, rel))];
+    for (const url of attempts) {
+      try {
+        const mod = await import(url);
+        if (mod) return mod;
+      } catch (err) {
+        console.warn('[tarefas] Falha ao importar', url, err);
+      }
+    }
+    return null;
+  }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);


### PR DESCRIPTION
## Summary
- update each guest management widget to try loading shared modules from the local relative path before CDN fallbacks
- reuse the app buildUrl helper to generate CDN URLs consistently across widgets
- keep logging failures while iterating through every alternative before returning null

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dddafa9f948320b5417941a7a77178