### PR TITLE
Add shared module load guards for guest management tools

### DIFF
--- a/tools/gestao-de-convidados/convidados.html
+++ b/tools/gestao-de-convidados/convidados.html
@@ -120,16 +120,27 @@
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
   const PATH_INV   = "/shared/inviteUtils.js"; // ferramenta de convites (fonte de verdade)
+  const LOAD_ERROR_MESSAGE = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
   const CANDIDATES = [
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
   ];
+  function renderLoadError(message){
+    const main = document.querySelector('main.ac');
+    if(main){
+      main.innerHTML = `<div class="container"><section class="card"><h2>Carregamento interrompido</h2><p>${message}</p></section></div>`;
+    }
+  }
   async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
   async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
   const inv   = await loadShared(PATH_INV);  // { parseInvites, normalizePhone }
+  if(!store || !bus || !inv){
+    renderLoadError(LOAD_ERROR_MESSAGE);
+    throw new Error(LOAD_ERROR_MESSAGE);
+  }
   await store?.init?.();
 
   // Estado e utilitários

--- a/tools/gestao-de-convidados/eventos.html
+++ b/tools/gestao-de-convidados/eventos.html
@@ -100,15 +100,26 @@
 <script type="module">
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
+  const LOAD_ERROR_MESSAGE = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
   const CANDIDATES = [
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
   ];
+  function renderLoadError(message){
+    const main = document.querySelector('main.ac');
+    if(main){
+      main.innerHTML = `<div class="container"><section class="card"><h2>Carregamento interrompido</h2><p>${message}</p></section></div>`;
+    }
+  }
   async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
   async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
+  if(!store || !bus){
+    renderLoadError(LOAD_ERROR_MESSAGE);
+    throw new Error(LOAD_ERROR_MESSAGE);
+  }
   await store?.init?.();
 
   const AUTO_SAVE_MS = 700;

--- a/tools/gestao-de-convidados/fornecedores.html
+++ b/tools/gestao-de-convidados/fornecedores.html
@@ -110,15 +110,26 @@
   // Módulos compartilhados
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
+  const LOAD_ERROR_MESSAGE = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
   const CANDIDATES = [
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
   ];
+  function renderLoadError(message){
+    const main = document.querySelector('main.ac');
+    if(main){
+      main.innerHTML = `<div class="container"><section class="card"><h2>Carregamento interrompido</h2><p>${message}</p></section></div>`;
+    }
+  }
   async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
   async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
+  if(!store || !bus){
+    renderLoadError(LOAD_ERROR_MESSAGE);
+    throw new Error(LOAD_ERROR_MESSAGE);
+  }
   await store?.init?.();
 
   // Estado e utilitários (nomes/ids exclusivos com prefixo f2_)

--- a/tools/gestao-de-convidados/mensagens.html
+++ b/tools/gestao-de-convidados/mensagens.html
@@ -95,14 +95,25 @@
 <script type="module">
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
+  const LOAD_ERROR_MESSAGE = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
   const CANDIDATES = [
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
   ];
+  function renderLoadError(message){
+    const main = document.querySelector('main.ac');
+    if(main){
+      main.innerHTML = `<div class="container"><section class="card"><h2>Carregamento interrompido</h2><p>${message}</p></section></div>`;
+    }
+  }
   async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
   async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
+  if(!store || !bus){
+    renderLoadError(LOAD_ERROR_MESSAGE);
+    throw new Error(LOAD_ERROR_MESSAGE);
+  }
   await store?.init?.();
 
   const AUTO_SAVE_MS = 700;

--- a/tools/gestao-de-convidados/tarefas.html
+++ b/tools/gestao-de-convidados/tarefas.html
@@ -88,15 +88,26 @@
   // Módulos compartilhados
   const PATH_BUS   = "/shared/marcoBus.js";
   const PATH_STORE = "/shared/projectStore.js";
+  const LOAD_ERROR_MESSAGE = 'Não foi possível carregar os módulos compartilhados. Atualize a página ou tente novamente mais tarde.';
   const CANDIDATES = [
     "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
     "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
   ];
+  function renderLoadError(message){
+    const main = document.querySelector('main.ac');
+    if(main){
+      main.innerHTML = `<div class="container"><section class="card"><h2>Carregamento interrompido</h2><p>${message}</p></section></div>`;
+    }
+  }
   async function tryImport(url){ try{ return await import(url); } catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; } } }
   async function loadShared(rel){ for(const base of CANDIDATES){ const mod = await tryImport(base+rel); if(mod) return mod; } return null; }
 
   const store = await loadShared(PATH_STORE);
   const bus   = await loadShared(PATH_BUS);
+  if(!store || !bus){
+    renderLoadError(LOAD_ERROR_MESSAGE);
+    throw new Error(LOAD_ERROR_MESSAGE);
+  }
   await store?.init?.();
 
   // Estado


### PR DESCRIPTION
## Summary
- render a shared failure message when the bus, store, or invite utilities fail to load
- abort initialization across guest management tools when shared modules are unavailable

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dddae01c6c83209b28906afc286aeb