### PR TITLE
docs: formalizar política de QA antes das releases

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,15 +1,20 @@
 # Agent.md
 
 ## Propósito
-Este documento fornece um rápido resumo para quem automatiza tarefas neste repositório, descrevendo práticas recomendadas e pontos de atenção ao modificar os módulos compartilhados do projeto.
+Este documento orienta automações e agentes que atuam neste repositório, garantindo que tarefas críticas sejam executadas com evidências claras e verificações mínimas antes de qualquer entrega.
 
 ## Diretrizes Gerais
-- 
+- Priorize a coleta de evidências (capturas de tela, logs e hashes de build) durante cada execução.
+- Registre todas as ações relevantes no `log.md` sempre que uma política operacional for alterada ou reafirmada.
 
 ## Convenções de Estilo
-- 
+- Utilize português claro e objetivo ao atualizar documentação.
+- Quando descrever comandos, envolva-os em crases para facilitar a leitura em markdown.
 
 ## Checklist Rápido
-1. 
+1. Gerar e arquivar uma captura de tela do cabeçalho nos estados `chipReady`, `chipDirty` e `chipSaving` durante o fluxo automatizado.
+2. Executar `projectStore.ping()` e `projectStore.backupAll()` para verificar conectividade e backups, anexando as saídas ao relatório da automação.
+3. Confirmar que o processo de bootstrap cria um documento local válido antes de prosseguir com outras etapas (verificar a presença do arquivo e o identificador associado).
+4. Atualizar o relatório de execução com links para as evidências coletadas e o status final da rotina.
 
 Seguir estas orientações ajuda a manter o código consistente e facilita o trabalho colaborativo entre agentes e desenvolvedores humanos.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,22 @@
+# Arquitetura do Projeto Marco
+
+Este documento descreve os componentes principais da solução e como eles interagem para entregar a experiência do editor colaborativo do Projeto Marco.
+
+## Componentes Principais
+- **Cliente Web:** interface principal de edição e visualização, responsável por exibir o cabeçalho com indicadores de status (`chipReady`, `chipDirty`, `chipSaving`).
+- **Project Store:** camada responsável pela persistência local e sincronização dos documentos, expondo utilitários como `ping()` e `backupAll()` para validações operacionais.
+- **Serviços de Sincronização:** serviços backend que garantem consistência entre clientes e backups off-line.
+
+## Fluxo de Dados
+1. O cliente web registra eventos de interação (edição, salvamento, mudanças de estado do cabeçalho).
+2. O Project Store orquestra gravações locais, executa `ping()` para avaliar latência e disponibiliza `backupAll()` para sincronização de snapshots.
+3. Os serviços de sincronização persistem alterações definitivas e alimentam o log de auditoria utilizado no QA.
+
+## QA antes da entrega
+- **Capturas de tela por estado:** produza três prints do cabeçalho representando: modo pronto (`chipReady` exibindo estado estável), modo de edição (`chipDirty` após modificar o documento) e modo salvando (`chipSaving` enquanto o backend confirma a escrita).
+- **Revisão do log de eventos:** consulte o log de eventos do cliente e do backend para confirmar que as transições entre estados ocorreram sem erros ou warnings inesperados.
+- **Registro do resultado:** anexe as capturas e um resumo da revisão do log ao relatório de QA, citando explicitamente a hora, o ambiente e o número da build inspecionada.
+
+## Considerações Futuras
+- Automatizar a coleta de evidências para reduzir esforço manual nas releases recorrentes.
+- Integrar análises de telemetria que antecipem degradações de desempenho antes de impactar o usuário final.

--- a/log.md
+++ b/log.md
@@ -1,4 +1,7 @@
 # Histórico do Projeto
 
+## 2025-10-03
+- Formalizada a nova política de QA exigindo capturas do cabeçalho (`chipReady`, `chipDirty`, `chipSaving`), validação manual dos botões e execução de `projectStore.ping()`/`projectStore.backupAll()` antes de cada release. Motivo: reduzir regressões não detectadas no fluxo do editor. Impacto: aumenta a rastreabilidade das entregas e estabelece critérios mínimos para aprovar builds.
+
 ## 2025-10-02
 - Adicionados arquivos de README e log para facilitar a documentação das atividades.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,13 @@
 # Projeto Marco
 
-Este repositório...
+Este repositório concentra utilitários internos e documentação operacional do Projeto Marco. A organização está focada em facilitar entregas consistentes e reprodutíveis, com ênfase em processos claros de QA antes de cada release.
+
+## Metodologia de Entrega e Experiência
+A metodologia de entrega prioriza visibilidade e rastreabilidade de cada etapa. Toda release deve ser documentada com evidências visuais e validações manuais dos fluxos críticos do editor.
+
+### Build e Testes
+- **Capturas de tela obrigatórias:** registre o cabeçalho da aplicação nos três estados do indicador (`chipReady`, `chipDirty`, `chipSaving`) durante o ciclo de validação.
+- **Validação manual do cabeçalho:** exercite e confirme o funcionamento do botão `✎`, dos menus contextuais e de qualquer atalho relevante exposto no cabeçalho.
+- **Execução de rotinas internas:** execute `projectStore.ping()` e `projectStore.backupAll()` na console antes de liberar a build, registrando a saída como evidência de que os serviços estão responsivos.
+
+Documente as evidências no relatório de entrega e vincule-as à versão publicada.


### PR DESCRIPTION
## Summary
- atualiza o README para exigir evidências visuais, validação manual do cabeçalho e execução de rotinas internas antes de publicar builds
- descreve no guia de arquitetura como coletar capturas, revisar logs e registrar resultados em QA
- expande o agent.md com checklist operacional e registra a nova política no log do projeto

## Testing
- not run (documentação)


------
https://chatgpt.com/codex/tasks/task_e_68e05a768b988320ae67c738cf6b0ecd