### PR TITLE
Fix shared import path for convites view

### DIFF
--- a/tools/gestao-de-convidados/views/convites.mjs
+++ b/tools/gestao-de-convidados/views/convites.mjs
@@ -1,5 +1,5 @@
 // tools/gestao-de-convidados/views/convites.mjs
-import { higienizarLinha, higienizarLista } from '/shared/higienizarLista.mjs';
+import { higienizarLinha, higienizarLista } from '../../../shared/higienizarLista.mjs';
 
 export async function render(root, ctx){
   const project = await ctx.store.getProject(ctx.projectId);


### PR DESCRIPTION
## Summary
- update the convites view to import the shared higienization helpers from the repository root

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8814feee48320b55336413b01084f