### PR TITLE
Create Assistente Cerimonial v4 single-page app

### DIFF
--- a/Assistentes/Cerimonial/app_free_v4/codigo_unico.html
+++ b/Assistentes/Cerimonial/app_free_v4/codigo_unico.html
@@ -1,1 +1,1635 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Assistente Cerimonial – v4 (HTML único)</title>
+  <style>
+    :root {
+      color-scheme: light;
+    }
 
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+      background: #f5f5f5;
+      color: #1a1a1a;
+    }
+
+    #ac-app {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .ac-nav {
+      background: #121212;
+      color: #fff;
+      padding: 16px 0;
+    }
+
+    .ac-nav .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .ac-nav button {
+      appearance: none;
+      border: 0;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      color: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    .ac-nav button[aria-current="page"],
+    .ac-nav button.active {
+      background: #fff;
+      color: #121212;
+    }
+
+    .ac-nav button:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+
+    .ac-toolbar {
+      background: #fff;
+      border-bottom: 1px solid #d9d9d9;
+    }
+
+    .ac-toolbar-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 12px 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .ac-button {
+      appearance: none;
+      border: 1px solid #121212;
+      border-radius: 12px;
+      padding: 9px 14px;
+      background: #fff;
+      color: #121212;
+      font-weight: 600;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      line-height: 1.2;
+      transition: transform 0.1s ease, background 0.2s ease;
+    }
+
+    .ac-button.secondary {
+      border-color: #b3b3b3;
+      color: #3a3a3a;
+    }
+
+    .ac-button:active {
+      transform: translateY(1px);
+    }
+
+    .ac-button:focus-visible {
+      outline: 2px solid #121212;
+      outline-offset: 2px;
+    }
+
+    .ac-toolbar .ac-status {
+      margin-left: auto;
+      font-size: 14px;
+      color: #555;
+      white-space: nowrap;
+    }
+
+    .ac-wrapper {
+      flex: 1;
+      max-width: 1080px;
+      margin: 0 auto;
+      width: 100%;
+      padding: 24px 20px 48px;
+      box-sizing: border-box;
+    }
+
+    .ac-card {
+      background: #fff;
+      border: 1px solid #d8d8d8;
+      border-radius: 18px;
+      padding: 24px;
+      margin-bottom: 20px;
+      box-shadow: 0 20px 45px rgba(18, 18, 18, 0.08);
+    }
+
+    .ac-card h2,
+    .ac-card h3 {
+      margin-top: 0;
+    }
+
+    .ac-card h2 {
+      font-size: 22px;
+      margin-bottom: 12px;
+    }
+
+    .ac-grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .ac-grid.two {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .ac-grid.three {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    label {
+      font-weight: 600;
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    input[type="text"],
+    input[type="date"],
+    input[type="time"],
+    input[type="tel"],
+    input[type="email"],
+    textarea,
+    select,
+    input[type="number"] {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 11px 12px;
+      border-radius: 12px;
+      border: 1px solid #c9c9c9;
+      background: #fff;
+      font: inherit;
+      line-height: 1.4;
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 120px;
+    }
+
+    .ac-help {
+      font-size: 13px;
+      color: #666;
+      margin-top: 4px;
+    }
+
+    .ac-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: #efefef;
+      font-size: 12px;
+      font-weight: 600;
+      color: #333;
+    }
+
+    .ac-progress {
+      width: 140px;
+      height: 8px;
+      border-radius: 999px;
+      background: #e8e8e8;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .ac-progress span {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 0;
+      background: #121212;
+      transition: width 0.2s ease;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+    }
+
+    table thead th {
+      text-align: left;
+      background: #fafafa;
+      border-bottom: 1px solid #e0e0e0;
+      padding: 10px 12px;
+      font-size: 14px;
+    }
+
+    table tbody td {
+      padding: 10px 12px;
+      border-bottom: 1px solid #f1f1f1;
+      vertical-align: top;
+      font-size: 14px;
+    }
+
+    table tfoot td {
+      font-weight: 700;
+      padding: 12px;
+      font-size: 14px;
+      border-top: 1px solid #e0e0e0;
+    }
+
+    .ac-empty {
+      padding: 24px;
+      text-align: center;
+      font-size: 14px;
+      color: #777;
+      border: 1px dashed #d0d0d0;
+      border-radius: 16px;
+    }
+
+    .ac-template-grid {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .ac-template {
+      border: 1px solid #e0e0e0;
+      border-radius: 14px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      background: #fff;
+    }
+
+    .ac-template.active {
+      border-color: #121212;
+      box-shadow: 0 0 0 3px rgba(18, 18, 18, 0.12);
+    }
+
+    .ac-preview {
+      border: 1px solid #e0e0e0;
+      border-radius: 14px;
+      padding: 16px;
+      background: #fbfbfb;
+      white-space: pre-wrap;
+      font-size: 14px;
+    }
+
+    .ac-section[hidden] {
+      display: none !important;
+    }
+
+    .ac-label-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      background: #fff;
+      border: 1px solid #d9d9d9;
+      border-radius: 16px;
+      padding: 16px 20px;
+      margin-bottom: 24px;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    }
+
+    .ac-label-bar span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: 600;
+    }
+
+    .ac-label-bar em {
+      font-style: normal;
+      color: #888;
+    }
+
+    .ac-list-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      margin-top: 12px;
+    }
+
+    .ac-chip-alert {
+      background: #fff3cd;
+      color: #8a6d3b;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .ac-message-item {
+      border: 1px solid #e0e0e0;
+      border-radius: 14px;
+      padding: 16px;
+      background: #fff;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .ac-message-item header {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .ac-message-item pre {
+      margin: 0;
+      white-space: pre-wrap;
+      font-size: 14px;
+    }
+
+    .ac-report-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .ac-report-grid div {
+      border: 1px solid #ededed;
+      border-radius: 14px;
+      padding: 16px;
+      background: #fafafa;
+    }
+
+    .ac-report-grid dt {
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #777;
+      margin-bottom: 4px;
+    }
+
+    .ac-report-grid dd {
+      margin: 0;
+      font-weight: 600;
+      font-size: 15px;
+      color: #1f1f1f;
+    }
+
+    .ac-table-responsive {
+      overflow-x: auto;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    @media (max-width: 960px) {
+      .ac-grid.two,
+      .ac-template-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .ac-toolbar .ac-status {
+        width: 100%;
+        margin-left: 0;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .ac-nav .nav-inner {
+        justify-content: center;
+      }
+
+      .ac-toolbar-inner {
+        justify-content: center;
+      }
+
+      .ac-toolbar .ac-status {
+        text-align: center;
+      }
+
+      .ac-label-bar {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+
+    @media print {
+      body {
+        background: #fff;
+      }
+
+      .ac-nav,
+      .ac-toolbar,
+      .ac-list-actions button,
+      #mensagens-controls,
+      .ac-button.print-only {
+        display: none !important;
+      }
+
+      .ac-wrapper {
+        padding: 0;
+      }
+
+      .ac-card {
+        box-shadow: none;
+        border: 1px solid #d0d0d0;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="ac-app">
+    <nav class="ac-nav" aria-label="Navegação principal">
+      <div class="nav-inner" role="tablist">
+        <button class="ac-tab" data-goto="#dados" aria-current="page">Dados</button>
+        <button class="ac-tab" data-goto="#lista">Lista</button>
+        <button class="ac-tab" data-goto="#mensagens">Mensagens</button>
+        <button class="ac-tab" data-goto="#relatorio">Relatório</button>
+      </div>
+    </nav>
+
+    <div class="ac-toolbar">
+      <div class="ac-toolbar-inner">
+        <button class="ac-button" id="btnStart">Iniciar</button>
+        <button class="ac-button" id="btnOpen">Abrir</button>
+        <button class="ac-button" id="btnSave">Salvar</button>
+        <button class="ac-button" id="btnPrint">Imprimir/Salvar PDF</button>
+        <button class="ac-button" id="btnCopyLabel">Copiar etiqueta</button>
+        <button class="ac-button" id="btnLabelTxt">Baixar etiqueta .txt</button>
+        <button class="ac-button" id="btnCsv">Exportar .csv</button>
+        <span class="ac-status" id="statusInfo">Andamento: 0% • Convites: 0 • Pessoas: 0</span>
+      </div>
+    </div>
+
+    <main class="ac-wrapper">
+      <div class="ac-label-bar" id="etiquetaBar" aria-live="polite">
+        <span><em>Etiqueta:</em> <strong id="etiquetaResumo">Preencha os dados para gerar a etiqueta do evento.</strong></span>
+      </div>
+
+      <section id="dados" class="ac-section" aria-labelledby="tab-dados">
+        <div class="ac-card">
+          <header style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;">
+            <h2 id="tab-dados">Dados do evento</h2>
+            <div class="ac-badge" id="evtCount">0/5</div>
+            <div class="ac-progress" aria-hidden="true"><span id="evtBar"></span></div>
+          </header>
+          <div class="ac-grid two">
+            <div class="ac-field">
+              <label for="evt_nome">Nome do evento</label>
+              <input id="evt_nome" data-field="evento.nome" placeholder="Ex.: Casamento Ana & João" />
+            </div>
+            <div class="ac-field">
+              <label for="evt_data">Data</label>
+              <input id="evt_data" type="date" data-field="evento.data" />
+            </div>
+            <div class="ac-field">
+              <label for="evt_hora">Hora</label>
+              <input id="evt_hora" type="time" data-field="evento.hora" />
+            </div>
+            <div class="ac-field">
+              <label for="evt_local">Local</label>
+              <input id="evt_local" data-field="evento.local" placeholder="Espaço, cidade" />
+            </div>
+            <div class="ac-field" style="grid-column: span 2;">
+              <label for="evt_endereco">Endereço</label>
+              <input id="evt_endereco" data-field="evento.endereco" placeholder="Endereço completo" />
+            </div>
+          </div>
+        </div>
+
+        <div class="ac-card">
+          <header style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;">
+            <h3>Dados dos anfitriões</h3>
+            <div class="ac-badge" id="hostCount">0/2</div>
+            <div class="ac-progress" aria-hidden="true"><span id="hostBar"></span></div>
+          </header>
+          <div class="ac-grid two">
+            <div class="ac-field" style="grid-column: span 2;">
+              <label for="host_nome">Nome no convite</label>
+              <input id="host_nome" data-field="anfitria.nomeConvite" placeholder="Ex.: Ana & João" />
+            </div>
+            <div class="ac-field">
+              <label for="host_contato">Contato principal</label>
+              <input id="host_contato" data-field="anfitria.contato" placeholder="(00) 90000-0000" />
+            </div>
+          </div>
+        </div>
+
+        <div class="ac-card">
+          <header style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;">
+            <h3>Equipe cerimonial</h3>
+            <div class="ac-badge" id="cerCount">0/4</div>
+            <div class="ac-progress" aria-hidden="true"><span id="cerBar"></span></div>
+          </header>
+          <div class="ac-grid two">
+            <div class="ac-field">
+              <label for="cer_nome">Responsável</label>
+              <input id="cer_nome" data-field="cerimonial.nome" placeholder="Nome completo" />
+            </div>
+            <div class="ac-field">
+              <label for="cer_tel">Telefone</label>
+              <input id="cer_tel" data-field="cerimonial.telefone" placeholder="(00) 90000-0000" />
+            </div>
+            <div class="ac-field">
+              <label for="cer_email">E-mail</label>
+              <input id="cer_email" type="email" data-field="cerimonial.email" placeholder="contato@exemplo.com" />
+            </div>
+            <div class="ac-field">
+              <label for="cer_insta">Instagram</label>
+              <input id="cer_insta" data-field="cerimonial.instagram" placeholder="@perfil" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="lista" class="ac-section" hidden aria-labelledby="tab-lista">
+        <div class="ac-card">
+          <h2 id="tab-lista">Lista de convidados</h2>
+          <label for="quickAdd">Adicionar convites (um por linha)</label>
+          <textarea id="quickAdd" placeholder="Ex.: 01 - Maria e João (41) 99999-0000 +2"></textarea>
+          <div class="ac-help">Dica: informe telefone e quantidade usando +2, x3 ou "4 pessoas" ao final da linha.</div>
+          <div class="ac-list-actions">
+            <button class="ac-button" id="btnAddLines">Processar linhas</button>
+            <button class="ac-button secondary" id="btnSampleLines">Gerar exemplo</button>
+            <div style="margin-left:auto;display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+              <label for="sortMode" class="sr-only">Ordenação</label>
+              <select id="sortMode" style="width:auto;min-width:200px;">
+                <option value="seq">Número do convite (ordem de inserção)</option>
+                <option value="nome">Nome do convidado</option>
+              </select>
+              <button class="ac-button secondary" id="btnSort">Aplicar ordenação</button>
+            </div>
+          </div>
+          <div class="ac-help" id="quickFeedback" aria-live="polite"></div>
+        </div>
+
+        <div class="ac-card">
+          <div class="ac-table-responsive">
+            <table aria-describedby="tab-lista">
+              <thead>
+                <tr>
+                  <th style="width:10%">Nº</th>
+                  <th style="width:40%">Convidado(s)</th>
+                  <th style="width:26%">Telefone</th>
+                  <th style="width:12%">Total</th>
+                  <th style="width:12%">Ações</th>
+                </tr>
+              </thead>
+              <tbody id="inviteBody"></tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="2" id="totConvites">Total de convites: 0</td>
+                  <td colspan="3" style="text-align:right;" id="totPessoas">Total de convidados: 0</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+          <div class="ac-empty" id="inviteEmpty" hidden>Nenhum convite cadastrado ainda. Utilize o campo acima para adicionar convidados rapidamente.</div>
+        </div>
+      </section>
+
+      <section id="mensagens" class="ac-section" hidden aria-labelledby="tab-mensagens">
+        <div class="ac-card" id="mensagens-controls">
+          <h2 id="tab-mensagens">Modelos de mensagens</h2>
+          <div class="ac-grid two">
+            <div>
+              <label for="msgTemplate">Situação</label>
+              <select id="msgTemplate"></select>
+            </div>
+            <div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;">
+              <button class="ac-button secondary" id="btnResetTemplate">Restaurar padrão</button>
+              <button class="ac-button" id="btnCopyPreview">Copiar prévia</button>
+              <button class="ac-button" id="btnCopyAll">Copiar todas</button>
+            </div>
+            <div style="grid-column: span 2;">
+              <label for="msgEditor">Texto base (use variáveis como {{nome}}, {{evento.nome}})</label>
+              <textarea id="msgEditor"></textarea>
+              <div class="ac-help">Variáveis disponíveis: {{nome}}, {{convite.total}}, {{evento.nome}}, {{evento.data}}, {{evento.hora}}, {{evento.local}}, {{evento.endereco}}, {{anfitria.nomeConvite}}, {{anfitria.contato}}, {{cerimonial.nome}}, {{cerimonial.telefone}}, {{cerimonial.email}}, {{cerimonial.instagram}}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="ac-card">
+          <header style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+            <h3>Prévia</h3>
+            <div class="ac-badge" id="previewLabel">Sem convites</div>
+          </header>
+          <div class="ac-preview" id="msgPreview">Cadastre convidados para visualizar a mensagem personalizada.</div>
+        </div>
+
+        <div class="ac-card">
+          <h3>Mensagens por convite</h3>
+          <div class="ac-grid" id="messageList" style="gap:16px;"></div>
+          <div class="ac-empty" id="messageEmpty" hidden>Sem convidados cadastrados no momento.</div>
+        </div>
+      </section>
+
+      <section id="relatorio" class="ac-section" hidden aria-labelledby="tab-relatorio">
+        <div class="ac-card">
+          <h2 id="tab-relatorio">Resumo geral</h2>
+          <div class="ac-report-grid">
+            <div>
+              <dt>Evento</dt>
+              <dd id="repEvento">—</dd>
+            </div>
+            <div>
+              <dt>Data &amp; hora</dt>
+              <dd id="repDataHora">—</dd>
+            </div>
+            <div>
+              <dt>Local</dt>
+              <dd id="repLocal">—</dd>
+            </div>
+            <div>
+              <dt>Etiqueta</dt>
+              <dd id="repEtiqueta">—</dd>
+            </div>
+            <div>
+              <dt>Anfitriões</dt>
+              <dd id="repHosts">—</dd>
+            </div>
+            <div>
+              <dt>Cerimonial</dt>
+              <dd id="repCerimonial">—</dd>
+            </div>
+            <div>
+              <dt>Totais</dt>
+              <dd id="repTotals">—</dd>
+            </div>
+          </div>
+        </div>
+
+        <div class="ac-card">
+          <h3>Lista final</h3>
+          <div class="ac-table-responsive">
+            <table>
+              <thead>
+                <tr>
+                  <th style="width:10%">Nº</th>
+                  <th style="width:42%">Convidado(s)</th>
+                  <th style="width:26%">Telefone</th>
+                  <th style="width:12%">Total</th>
+                  <th style="width:10%">Ações</th>
+                </tr>
+              </thead>
+              <tbody id="reportBody"></tbody>
+            </table>
+          </div>
+          <div class="ac-empty" id="reportEmpty" hidden>Nenhum convidado para exibir.</div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (() => {
+      const storageKey = 'assistenteCerimonialV4';
+
+      const templateCatalog = {
+        save: {
+          label: 'Save the date',
+          text: 'Olá {{nome}}! Queremos compartilhar uma notícia especial: {{evento.nome}} acontece em {{evento.data}} às {{evento.hora}}, no {{evento.local}}. Reserve essa data com carinho e qualquer dúvida fale com {{cerimonial.nome}} ({{cerimonial.telefone}}).'
+        },
+        convite: {
+          label: 'Envio de convite',
+          text: 'Olá {{nome}}! Você está convidado(a) para {{evento.nome}}, que acontecerá no {{evento.local}} em {{evento.data}} às {{evento.hora}}. São {{convite.total}} lugares reservados para você. Confirme com {{cerimonial.nome}} pelo {{cerimonial.telefone}}.'
+        },
+        confirmacao: {
+          label: 'Confirmação de presença',
+          text: 'Olá {{nome}}, tudo bem? Estamos finalizando os preparativos de {{evento.nome}} e gostaríamos de confirmar sua presença. Podemos contar com você e seus {{convite.total}} convidados? Responda para {{cerimonial.nome}} em {{cerimonial.telefone}}.'
+        },
+        lembrete: {
+          label: 'Lembrete',
+          text: 'Falta pouco para {{evento.nome}}! Esperamos você no {{evento.local}} em {{evento.data}} às {{evento.hora}}. Qualquer ajuste de última hora, conte com {{cerimonial.nome}} pelo {{cerimonial.telefone}}.'
+        },
+        agradecimento: {
+          label: 'Agradecimento',
+          text: 'Olá {{nome}}, agradecemos por ter celebrado {{evento.nome}} conosco. Foi incrível viver esse momento ao seu lado! Se precisar falar com a equipe, é só procurar {{cerimonial.nome}}.'
+        },
+        logistica: {
+          label: 'Informações de logística',
+          text: 'Olá {{nome}}! Para {{evento.nome}}, sugerimos chegar com 30 minutos de antecedência. O endereço é {{evento.endereco}}. Em caso de dúvidas, contate {{cerimonial.nome}} no {{cerimonial.telefone}}.'
+        }
+      };
+
+      const defaultState = () => ({
+        evento: {
+          nome: '',
+          data: '',
+          hora: '',
+          local: '',
+          endereco: ''
+        },
+        anfitria: {
+          nomeConvite: '',
+          contato: ''
+        },
+        cerimonial: {
+          nome: '',
+          telefone: '',
+          email: '',
+          instagram: ''
+        },
+        convites: [],
+        preferencias: {
+          sortMode: 'seq'
+        },
+        mensagens: {
+          template: 'convite',
+          personalizados: {}
+        }
+      });
+
+      let state = defaultState();
+      let nextConviteId = 1;
+      let nextInviteOrder = 1;
+
+      const fieldInputs = document.querySelectorAll('[data-field]');
+      const inviteBody = document.getElementById('inviteBody');
+      const inviteEmpty = document.getElementById('inviteEmpty');
+      const reportBody = document.getElementById('reportBody');
+      const reportEmpty = document.getElementById('reportEmpty');
+      const messageList = document.getElementById('messageList');
+      const messageEmpty = document.getElementById('messageEmpty');
+      const sortSelect = document.getElementById('sortMode');
+      const templateSelect = document.getElementById('msgTemplate');
+      const msgEditor = document.getElementById('msgEditor');
+      const msgPreview = document.getElementById('msgPreview');
+      const previewLabel = document.getElementById('previewLabel');
+      const statusInfo = document.getElementById('statusInfo');
+      const quickFeedback = document.getElementById('quickFeedback');
+
+      function ingestState(data = {}) {
+        const base = defaultState();
+        state = base;
+        if (data.evento) {
+          Object.assign(state.evento, pick(data.evento, ['nome', 'data', 'hora', 'local', 'endereco']));
+        }
+        if (data.anfitria) {
+          Object.assign(state.anfitria, pick(data.anfitria, ['nomeConvite', 'contato']));
+        }
+        if (data.anfitrioes && !data.anfitria) {
+          state.anfitria.nomeConvite = data.anfitrioes.nomeConvite || data.anfitrioes.nome || '';
+          state.anfitria.contato = data.anfitrioes.contato || data.anfitrioes.telefone || '';
+        }
+        if (data.cerimonial) {
+          Object.assign(state.cerimonial, pick(data.cerimonial, ['nome', 'telefone', 'email', 'instagram']));
+        }
+        if (Array.isArray(data.convites)) {
+          state.convites = data.convites.map((item) => ({
+            id: Number(item.id) || 0,
+            ordem: Number(item.ordem) || 0,
+            nome: (item.nome || item.convidado || '').trim(),
+            telefone: (item.telefone || '').trim(),
+            total: normalizeTotal(item.total),
+            observacao: (item.observacao || '').trim()
+          }));
+        }
+        if (data.preferencias && data.preferencias.sortMode) {
+          state.preferencias.sortMode = data.preferencias.sortMode;
+        }
+        if (data.mensagens) {
+          state.mensagens.template = data.mensagens.template || state.mensagens.template;
+          if (data.mensagens.personalizados && typeof data.mensagens.personalizados === 'object') {
+            state.mensagens.personalizados = { ...data.mensagens.personalizados };
+          }
+        }
+        nextConviteId = state.convites.reduce((max, c) => Math.max(max, Number(c.id) || 0), 0) + 1;
+        nextInviteOrder = state.convites.reduce((max, c) => Math.max(max, Number(c.ordem) || 0), 0) + 1;
+        applySort(false);
+        renumberConvites();
+        syncInputs();
+        updateTemplateOptions();
+        updateUI();
+        persistState();
+      }
+
+      function pick(source, keys) {
+        const result = {};
+        keys.forEach((key) => {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            result[key] = source[key];
+          }
+        });
+        return result;
+      }
+
+      function normalizeTotal(value) {
+        const num = Number(value);
+        return Number.isFinite(num) && num > 0 ? Math.round(num) : 1;
+      }
+
+      function persistState() {
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(state));
+        } catch (error) {
+          console.warn('Não foi possível salvar automaticamente.', error);
+        }
+      }
+
+      function loadFromStorage() {
+        try {
+          const raw = localStorage.getItem(storageKey);
+          if (raw) {
+            const parsed = JSON.parse(raw);
+            ingestState(parsed);
+            return;
+          }
+        } catch (error) {
+          console.warn('Falha ao carregar estado salvo.', error);
+        }
+        ingestState({});
+      }
+
+      function syncInputs() {
+        fieldInputs.forEach((input) => {
+          const value = getValue(input.dataset.field);
+          if (input.type === 'date' || input.type === 'time') {
+            input.value = value || '';
+          } else {
+            input.value = value ?? '';
+          }
+        });
+        sortSelect.value = state.preferencias.sortMode;
+        templateSelect.value = state.mensagens.template;
+        msgEditor.value = getTemplateText(state.mensagens.template);
+      }
+
+      function getValue(path) {
+        return path.split('.').reduce((acc, key) => {
+          if (acc && typeof acc === 'object' && key in acc) {
+            return acc[key];
+          }
+          return '';
+        }, state);
+      }
+
+      function setValue(path, value) {
+        const parts = path.split('.');
+        let ctx = state;
+        parts.forEach((part, index) => {
+          if (index === parts.length - 1) {
+            ctx[part] = value;
+          } else {
+            if (!ctx[part] || typeof ctx[part] !== 'object') {
+              ctx[part] = {};
+            }
+            ctx = ctx[part];
+          }
+        });
+      }
+
+      function updateUI() {
+        updateProgress();
+        renderEtiqueta();
+        renderInvites();
+        renderMessages();
+        renderReport();
+        updateStatusLine();
+      }
+
+      function updateProgress() {
+        const evtKeys = ['nome', 'data', 'hora', 'local', 'endereco'];
+        const hostKeys = ['nomeConvite', 'contato'];
+        const cerKeys = ['nome', 'telefone', 'email', 'instagram'];
+        const evtFilled = countFilled(state.evento, evtKeys);
+        const hostFilled = countFilled(state.anfitria, hostKeys);
+        const cerFilled = countFilled(state.cerimonial, cerKeys);
+        document.getElementById('evtCount').textContent = `${evtFilled}/${evtKeys.length}`;
+        document.getElementById('hostCount').textContent = `${hostFilled}/${hostKeys.length}`;
+        document.getElementById('cerCount').textContent = `${cerFilled}/${cerKeys.length}`;
+        document.getElementById('evtBar').style.width = `${(evtFilled / evtKeys.length) * 100}%`;
+        document.getElementById('hostBar').style.width = `${(hostFilled / hostKeys.length) * 100}%`;
+        document.getElementById('cerBar').style.width = `${(cerFilled / cerKeys.length) * 100}%`;
+      }
+
+      function countFilled(obj, keys) {
+        return keys.reduce((acc, key) => acc + (obj[key] ? 1 : 0), 0);
+      }
+
+      function renderEtiqueta() {
+        const parts = [];
+        if (state.evento.nome) parts.push(state.evento.nome);
+        const dataPart = formatDate(state.evento.data);
+        if (dataPart || state.evento.hora) {
+          const timePart = state.evento.hora ? formatTime(state.evento.hora) : '';
+          parts.push([dataPart, timePart].filter(Boolean).join(' às '));
+        }
+        if (state.evento.local) parts.push(state.evento.local);
+        if (state.evento.endereco) parts.push(state.evento.endereco);
+        if (state.anfitria.contato) parts.push(`Contato: ${state.anfitria.contato}`);
+        const resumo = parts.length ? parts.join(' • ') : 'Preencha os dados para gerar a etiqueta do evento.';
+        document.getElementById('etiquetaResumo').textContent = resumo;
+      }
+
+      function renderInvites() {
+        inviteBody.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+        renumberConvites();
+        state.convites.forEach((convite) => {
+          const tr = document.createElement('tr');
+
+          const tdSeq = document.createElement('td');
+          tdSeq.textContent = convite.codigo || '';
+          tr.appendChild(tdSeq);
+
+          const tdNome = document.createElement('td');
+          tdNome.textContent = convite.nome || '—';
+          if (!convite.nome) {
+            const warn = document.createElement('span');
+            warn.className = 'ac-chip-alert';
+            warn.textContent = 'Sem nome';
+            warn.style.marginLeft = '8px';
+            tdNome.appendChild(warn);
+          }
+          tr.appendChild(tdNome);
+
+          const tdTelefone = document.createElement('td');
+          tdTelefone.textContent = convite.telefone || '—';
+          if (!convite.telefone) {
+            const badge = document.createElement('span');
+            badge.className = 'ac-chip-alert';
+            badge.textContent = 'Sem telefone';
+            badge.style.marginLeft = '8px';
+            tdTelefone.appendChild(badge);
+          }
+          tr.appendChild(tdTelefone);
+
+          const tdTotal = document.createElement('td');
+          tdTotal.textContent = convite.total;
+          tr.appendChild(tdTotal);
+
+          const tdActions = document.createElement('td');
+          const editBtn = document.createElement('button');
+          editBtn.className = 'ac-button secondary';
+          editBtn.dataset.action = 'edit';
+          editBtn.dataset.id = String(convite.id);
+          editBtn.textContent = 'Editar';
+          editBtn.style.marginRight = '6px';
+          editBtn.setAttribute('aria-label', `Editar convite ${convite.codigo}`);
+          const delBtn = document.createElement('button');
+          delBtn.className = 'ac-button secondary';
+          delBtn.dataset.action = 'delete';
+          delBtn.dataset.id = String(convite.id);
+          delBtn.textContent = 'Excluir';
+          delBtn.setAttribute('aria-label', `Excluir convite ${convite.codigo}`);
+          tdActions.appendChild(editBtn);
+          tdActions.appendChild(delBtn);
+          tr.appendChild(tdActions);
+
+          fragment.appendChild(tr);
+        });
+        inviteBody.appendChild(fragment);
+        inviteEmpty.hidden = state.convites.length !== 0;
+
+        const totalConvites = state.convites.length;
+        const totalPessoas = state.convites.reduce((acc, item) => acc + normalizeTotal(item.total), 0);
+        document.getElementById('totConvites').textContent = `Total de convites: ${totalConvites}`;
+        document.getElementById('totPessoas').textContent = `Total de convidados: ${totalPessoas}`;
+      }
+
+      function renderMessages() {
+        updateTemplateOptions();
+        templateSelect.value = state.mensagens.template;
+        msgEditor.value = getTemplateText(state.mensagens.template);
+        const convites = state.convites;
+        if (!convites.length) {
+          msgPreview.textContent = 'Cadastre convidados para visualizar a mensagem personalizada.';
+          previewLabel.textContent = 'Sem convites';
+        } else {
+          const primeiro = convites[0];
+          previewLabel.textContent = `Prévia para convite ${primeiro.codigo}`;
+          msgPreview.textContent = buildMessage(primeiro);
+        }
+
+        messageList.innerHTML = '';
+        if (!convites.length) {
+          messageEmpty.hidden = false;
+          return;
+        }
+        messageEmpty.hidden = true;
+        const fragment = document.createDocumentFragment();
+        convites.forEach((convite) => {
+          const item = document.createElement('div');
+          item.className = 'ac-message-item';
+
+          const header = document.createElement('header');
+          const title = document.createElement('strong');
+          title.textContent = `Convite ${convite.codigo} · ${convite.nome || 'Sem nome'}`;
+          header.appendChild(title);
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'ac-button secondary';
+          copyBtn.dataset.action = 'copy-message';
+          copyBtn.dataset.id = String(convite.id);
+          copyBtn.textContent = 'Copiar';
+          copyBtn.setAttribute('aria-label', `Copiar mensagem do convite ${convite.codigo}`);
+          header.appendChild(copyBtn);
+          item.appendChild(header);
+
+          const pre = document.createElement('pre');
+          pre.textContent = buildMessage(convite);
+          item.appendChild(pre);
+          fragment.appendChild(item);
+        });
+        messageList.appendChild(fragment);
+      }
+
+      function renderReport() {
+        document.getElementById('repEvento').textContent = state.evento.nome || '—';
+        const dataFormatada = formatDate(state.evento.data);
+        const horaFormatada = formatTime(state.evento.hora);
+        document.getElementById('repDataHora').textContent = dataFormatada || horaFormatada ? [dataFormatada, horaFormatada].filter(Boolean).join(' às ') : '—';
+        document.getElementById('repLocal').textContent = state.evento.local || state.evento.endereco || '—';
+        document.getElementById('repEtiqueta').textContent = document.getElementById('etiquetaResumo').textContent;
+        document.getElementById('repHosts').textContent = state.anfitria.nomeConvite ? `${state.anfitria.nomeConvite}${state.anfitria.contato ? ' · ' + state.anfitria.contato : ''}` : '—';
+        const cerParts = [];
+        if (state.cerimonial.nome) cerParts.push(state.cerimonial.nome);
+        if (state.cerimonial.telefone) cerParts.push(state.cerimonial.telefone);
+        if (state.cerimonial.email) cerParts.push(state.cerimonial.email);
+        if (state.cerimonial.instagram) cerParts.push(state.cerimonial.instagram);
+        document.getElementById('repCerimonial').textContent = cerParts.join(' · ') || '—';
+        const totalConvites = state.convites.length;
+        const totalPessoas = state.convites.reduce((acc, item) => acc + normalizeTotal(item.total), 0);
+        document.getElementById('repTotals').textContent = `${totalConvites} convites · ${totalPessoas} convidados`;
+
+        reportBody.innerHTML = '';
+        if (!state.convites.length) {
+          reportEmpty.hidden = false;
+          return;
+        }
+        reportEmpty.hidden = true;
+        const fragment = document.createDocumentFragment();
+        state.convites.forEach((convite) => {
+          const tr = document.createElement('tr');
+          const tdSeq = document.createElement('td');
+          tdSeq.textContent = convite.codigo || '';
+          tr.appendChild(tdSeq);
+          const tdNome = document.createElement('td');
+          tdNome.textContent = convite.nome || '—';
+          tr.appendChild(tdNome);
+          const tdTel = document.createElement('td');
+          tdTel.textContent = convite.telefone || '—';
+          tr.appendChild(tdTel);
+          const tdTotal = document.createElement('td');
+          tdTotal.textContent = convite.total;
+          tr.appendChild(tdTotal);
+          const tdAction = document.createElement('td');
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'ac-button secondary';
+          copyBtn.dataset.action = 'copy-report';
+          copyBtn.dataset.id = String(convite.id);
+          copyBtn.textContent = 'Copiar';
+          copyBtn.setAttribute('aria-label', `Copiar linha do convite ${convite.codigo}`);
+          tdAction.appendChild(copyBtn);
+          tr.appendChild(tdAction);
+          fragment.appendChild(tr);
+        });
+        reportBody.appendChild(fragment);
+      }
+
+      function updateStatusLine() {
+        const totalConvites = state.convites.length;
+        const totalPessoas = state.convites.reduce((acc, item) => acc + normalizeTotal(item.total), 0);
+        const evtKeys = ['nome', 'data', 'hora', 'local', 'endereco'];
+        const hostKeys = ['nomeConvite', 'contato'];
+        const cerKeys = ['nome', 'telefone', 'email', 'instagram'];
+        const progress = Math.round(((countFilled(state.evento, evtKeys) + countFilled(state.anfitria, hostKeys) + countFilled(state.cerimonial, cerKeys)) / (evtKeys.length + hostKeys.length + cerKeys.length)) * 100);
+        statusInfo.textContent = `Andamento: ${progress}% • Convites: ${totalConvites} • Pessoas: ${totalPessoas}`;
+      }
+
+      function formatDate(value) {
+        if (!value) return '';
+        const parts = value.split('-');
+        if (parts.length !== 3) return value;
+        return `${parts[2]}/${parts[1]}/${parts[0]}`;
+      }
+
+      function formatTime(value) {
+        if (!value) return '';
+        return value.length > 5 ? value.slice(0, 5) : value;
+      }
+
+      function renumberConvites() {
+        state.convites.forEach((convite, index) => {
+          convite.codigo = index + 1;
+          if (!convite.ordem) {
+            convite.ordem = nextInviteOrder++;
+          }
+          if (!convite.id) {
+            convite.id = nextConviteId++;
+          }
+        });
+      }
+
+      function updateTemplateOptions() {
+        const current = state.mensagens.template;
+        templateSelect.innerHTML = '';
+        Object.entries(templateCatalog).forEach(([key, info]) => {
+          const option = document.createElement('option');
+          option.value = key;
+          option.textContent = info.label;
+          templateSelect.appendChild(option);
+        });
+        if (!templateCatalog[current]) {
+          state.mensagens.template = 'convite';
+        }
+        templateSelect.value = state.mensagens.template;
+      }
+      function getTemplateText(templateKey) {
+        const userText = state.mensagens.personalizados[templateKey];
+        if (typeof userText === 'string' && userText.trim()) {
+          return userText;
+        }
+        return templateCatalog[templateKey]?.text || '';
+      }
+
+      function setTemplateText(templateKey, text) {
+        if (text.trim() === templateCatalog[templateKey]?.text) {
+          delete state.mensagens.personalizados[templateKey];
+        } else {
+          state.mensagens.personalizados[templateKey] = text;
+        }
+      }
+
+      function buildMessage(convite) {
+        const template = getTemplateText(state.mensagens.template);
+        return template.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (match, tokenRaw) => {
+          const token = tokenRaw.trim();
+          switch (token) {
+            case 'nome':
+            case 'convidado':
+              return convite.nome || '';
+            case 'convite.total':
+              return convite.total;
+            case 'convite.sequencia':
+              return convite.codigo || '';
+            case 'evento.nome':
+              return state.evento.nome || '';
+            case 'evento.data':
+              return formatDate(state.evento.data);
+            case 'evento.hora':
+              return formatTime(state.evento.hora);
+            case 'evento.local':
+              return state.evento.local || '';
+            case 'evento.endereco':
+              return state.evento.endereco || '';
+            case 'anfitria.nomeConvite':
+              return state.anfitria.nomeConvite || '';
+            case 'anfitria.contato':
+              return state.anfitria.contato || '';
+            case 'cerimonial.nome':
+              return state.cerimonial.nome || '';
+            case 'cerimonial.telefone':
+              return state.cerimonial.telefone || '';
+            case 'cerimonial.email':
+              return state.cerimonial.email || '';
+            case 'cerimonial.instagram':
+              return state.cerimonial.instagram || '';
+            default:
+              return '';
+          }
+        });
+      }
+
+      function parseLines(input) {
+        const lines = input.split(/\r?\n/);
+        const added = [];
+        lines.forEach((line) => {
+          const parsed = parseInviteLine(line);
+          if (parsed) {
+            state.convites.push(parsed);
+            added.push(parsed);
+          }
+        });
+        if (!added.length) {
+          quickFeedback.textContent = 'Nenhum convite válido encontrado nas linhas informadas.';
+        } else {
+          quickFeedback.textContent = `${added.length} convite(s) adicionado(s) com sucesso.`;
+        }
+        document.getElementById('quickAdd').value = '';
+        applySort(false);
+        persistState();
+        updateUI();
+      }
+
+      function parseInviteLine(rawLine) {
+        if (!rawLine || !rawLine.trim()) return null;
+        let working = rawLine.trim();
+        let telefone = '';
+        const telefoneMatch = working.match(/(\+?55)?\s*\(?\d{2}\)?\s*\d{4,5}[-\s]?\d{4}/);
+        if (telefoneMatch) {
+          telefone = formatPhone(telefoneMatch[0]);
+          working = working.replace(telefoneMatch[0], '');
+        }
+        let total = 1;
+        const totalMatch = working.match(/([+xX]\s?\d+|\d+\s*(?:pessoas?|convidados?))/);
+        if (totalMatch) {
+          total = extractTotal(totalMatch[0]);
+          working = working.replace(totalMatch[0], '');
+        }
+        working = working.replace(/[-–|•]+/g, ' ');
+        const nome = working.replace(/\s{2,}/g, ' ').trim().replace(/[,.]+$/, '');
+        const convite = {
+          id: nextConviteId++,
+          ordem: nextInviteOrder++,
+          nome: nome || 'Convidado sem nome',
+          telefone,
+          total,
+          observacao: ''
+        };
+        return convite;
+      }
+
+      function formatPhone(raw) {
+        const digits = raw.replace(/\D/g, '');
+        let cleaned = digits;
+        if (cleaned.length === 13 && cleaned.startsWith('55')) {
+          cleaned = cleaned.slice(2);
+        }
+        if (cleaned.length === 11) {
+          return `(${cleaned.slice(0, 2)}) ${cleaned.slice(2, 7)}-${cleaned.slice(7)}`;
+        }
+        if (cleaned.length === 10) {
+          return `(${cleaned.slice(0, 2)}) ${cleaned.slice(2, 6)}-${cleaned.slice(6)}`;
+        }
+        if (cleaned.length === 9) {
+          return `${cleaned.slice(0, 5)}-${cleaned.slice(5)}`;
+        }
+        return raw.trim();
+      }
+
+      function extractTotal(fragment) {
+        const match = fragment.match(/\d+/);
+        if (!match) return 1;
+        const value = Number(match[0]);
+        return Number.isFinite(value) && value > 0 ? value : 1;
+      }
+
+      function applySort(shouldPersist = true) {
+        if (state.preferencias.sortMode === 'nome') {
+          state.convites.sort((a, b) => {
+            return (a.nome || '').localeCompare(b.nome || '', 'pt-BR', { sensitivity: 'base' });
+          });
+        } else {
+          state.convites.sort((a, b) => (a.ordem || 0) - (b.ordem || 0));
+        }
+        renumberConvites();
+        if (shouldPersist) {
+          persistState();
+          updateUI();
+        }
+      }
+
+      function handleInviteAction(event) {
+        const target = event.target.closest('button[data-action]');
+        if (!target) return;
+        const id = Number(target.dataset.id);
+        const action = target.dataset.action;
+        if (action === 'edit') {
+          editInvite(id);
+        } else if (action === 'delete') {
+          deleteInvite(id);
+        } else if (action === 'copy-message') {
+          const convite = state.convites.find((item) => item.id === id);
+          if (convite) {
+            copyText(buildMessage(convite));
+          }
+        } else if (action === 'copy-report') {
+          const convite = state.convites.find((item) => item.id === id);
+          if (convite) {
+            const line = `Convite ${convite.codigo} - ${convite.nome || 'Sem nome'} - ${convite.telefone || 'Sem telefone'} - ${convite.total} convidado(s)`;
+            copyText(line);
+          }
+        }
+      }
+
+      function editInvite(id) {
+        const convite = state.convites.find((item) => item.id === id);
+        if (!convite) return;
+        const nome = prompt('Nome do convidado(s):', convite.nome || '');
+        if (nome === null) return;
+        const telefone = prompt('Telefone do convidado:', convite.telefone || '');
+        if (telefone === null) return;
+        const totalInput = prompt('Total de pessoas para este convite:', convite.total);
+        if (totalInput === null) return;
+        convite.nome = nome.trim() || convite.nome;
+        convite.telefone = telefone.trim();
+        convite.total = normalizeTotal(totalInput);
+        persistState();
+        updateUI();
+      }
+
+      function deleteInvite(id) {
+        const convite = state.convites.find((item) => item.id === id);
+        if (!convite) return;
+        if (!confirm(`Remover o convite ${convite.codigo}?`)) return;
+        state.convites = state.convites.filter((item) => item.id !== id);
+        renumberConvites();
+        persistState();
+        updateUI();
+      }
+
+      function buildEtiquetaTexto() {
+        return document.getElementById('etiquetaResumo').textContent || '';
+      }
+
+      function copyText(value) {
+        if (!value) return;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(value).catch(() => fallbackCopy(value));
+        } else {
+          fallbackCopy(value);
+        }
+      }
+
+      function fallbackCopy(value) {
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        try {
+          document.execCommand('copy');
+        } catch (error) {
+          console.warn('Falha ao copiar automaticamente.', error);
+        }
+        document.body.removeChild(textarea);
+      }
+      function downloadFile(filename, content, type) {
+        const blob = new Blob([content], { type });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(() => {
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+        }, 0);
+      }
+
+      function exportCsv() {
+        if (!state.convites.length) {
+          alert('Adicione convites antes de exportar o CSV.');
+          return;
+        }
+        const rows = [
+          toCsvRow(['numero', 'convidado', 'telefone', 'total'])
+        ];
+        state.convites.forEach((convite) => {
+          rows.push(toCsvRow([convite.codigo, convite.nome, convite.telefone, convite.total]));
+        });
+        const csv = '\ufeff' + rows.join('\n');
+        downloadFile(`${buildBaseFilename()}-convites.csv`, csv, 'text/csv;charset=utf-8;');
+      }
+
+      function toCsvRow(values) {
+        return values.map((value) => `"${String(value ?? '').replace(/"/g, '""')}"`).join(';');
+      }
+
+      function buildBaseFilename() {
+        const base = state.evento.nome || 'assistente-cerimonial';
+        return sanitizeFilename(base) || 'assistente-cerimonial';
+      }
+
+      function sanitizeFilename(name) {
+        return name
+          .toLowerCase()
+          .normalize('NFD')
+          .replace(/[^a-z0-9\s-]/g, '')
+          .trim()
+          .replace(/\s+/g, '-')
+          .slice(0, 60);
+      }
+
+      function handleCopyAll() {
+        if (!state.convites.length) {
+          alert('Cadastre convites para gerar as mensagens.');
+          return;
+        }
+        const texto = state.convites.map((convite) => buildMessage(convite)).join('\n\n');
+        copyText(texto);
+      }
+
+      function handleCopyPreview() {
+        const texto = msgPreview.textContent || '';
+        if (!texto.trim()) {
+          alert('Nenhuma mensagem disponível para copiar no momento.');
+          return;
+        }
+        copyText(texto);
+      }
+
+      function handleCopyLabel() {
+        const texto = buildEtiquetaTexto();
+        if (!texto.trim()) {
+          alert('Preencha os dados do evento para gerar a etiqueta.');
+          return;
+        }
+        copyText(texto);
+      }
+
+      function downloadEtiquetaTxt() {
+        const texto = buildEtiquetaTexto();
+        if (!texto.trim()) {
+          alert('Preencha os dados do evento para gerar a etiqueta.');
+          return;
+        }
+        downloadFile(`${buildBaseFilename()}-etiqueta.txt`, texto, 'text/plain;charset=utf-8;');
+      }
+
+      function downloadJson() {
+        const data = JSON.stringify(state, null, 2);
+        downloadFile(`${buildBaseFilename()}-assistente.json`, data, 'application/json');
+      }
+
+      function handleOpenFile(event) {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          try {
+            const parsed = JSON.parse(String(e.target?.result || '{}'));
+            ingestState(parsed);
+            alert('Arquivo importado com sucesso.');
+          } catch (error) {
+            console.error(error);
+            alert('Não foi possível interpretar o arquivo selecionado.');
+          }
+        };
+        reader.readAsText(file);
+        event.target.value = '';
+      }
+
+      function buildSampleLines() {
+        return [
+          '01 - Maria & João (41) 98888-0000 +2',
+          '02 - Família Oliveira (41) 97777-1111 +4',
+          '03 - Carla Lima (41) 95555-2222',
+          '04 - Pedro e Ana',
+          '05 - Marcelo (41) 94444-3333 x3'
+        ].join('\n');
+      }
+
+      function handleStart() {
+        if (!confirm('Iniciar um novo planejamento? Os dados atuais serão apagados.')) {
+          return;
+        }
+        localStorage.removeItem(storageKey);
+        ingestState({});
+      }
+
+      function handleFieldInput(event) {
+        const input = event.target;
+        const field = input.dataset.field;
+        if (!field) return;
+        let value = input.value;
+        if (input.type !== 'textarea' && typeof value === 'string') {
+          value = value.trimStart();
+        }
+        setValue(field, value);
+        persistState();
+        updateUI();
+      }
+
+      function setupTabs() {
+        const tabs = document.querySelectorAll('.ac-tab');
+        const sections = document.querySelectorAll('.ac-section');
+
+        function activate(hash, push = true) {
+          const target = document.querySelector(hash);
+          if (!target) return;
+          sections.forEach((section) => {
+            section.hidden = section !== target;
+          });
+          tabs.forEach((tab) => {
+            const goto = tab.getAttribute('data-goto');
+            const isActive = goto === hash;
+            tab.classList.toggle('active', isActive);
+            tab.setAttribute('aria-current', isActive ? 'page' : 'false');
+          });
+          if (push) {
+            history.replaceState(null, '', hash);
+          }
+        }
+
+        tabs.forEach((tab) => {
+          tab.addEventListener('click', () => {
+            const hash = tab.getAttribute('data-goto');
+            activate(hash);
+          });
+        });
+
+        window.addEventListener('hashchange', () => {
+          const hash = location.hash || '#dados';
+          activate(hash, false);
+        });
+
+        const initialHash = location.hash || '#dados';
+        activate(initialHash, false);
+      }
+
+      function setupEvents() {
+        fieldInputs.forEach((input) => {
+          input.addEventListener('input', handleFieldInput);
+        });
+
+        document.getElementById('btnAddLines').addEventListener('click', () => {
+          parseLines(document.getElementById('quickAdd').value);
+        });
+
+        document.getElementById('quickAdd').addEventListener('keydown', (event) => {
+          if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+            event.preventDefault();
+            parseLines(event.target.value);
+          }
+        });
+
+        document.getElementById('btnSampleLines').addEventListener('click', () => {
+          document.getElementById('quickAdd').value = buildSampleLines();
+          quickFeedback.textContent = 'Exemplo carregado. Revise antes de importar.';
+        });
+
+        sortSelect.addEventListener('change', () => {
+          state.preferencias.sortMode = sortSelect.value;
+        });
+
+        document.getElementById('btnSort').addEventListener('click', () => {
+          state.preferencias.sortMode = sortSelect.value;
+          applySort();
+        });
+
+        inviteBody.addEventListener('click', handleInviteAction);
+        messageList.addEventListener('click', handleInviteAction);
+        reportBody.addEventListener('click', handleInviteAction);
+
+        templateSelect.addEventListener('change', () => {
+          state.mensagens.template = templateSelect.value;
+          msgEditor.value = getTemplateText(state.mensagens.template);
+          persistState();
+          renderMessages();
+        });
+
+        msgEditor.addEventListener('input', () => {
+          const current = state.mensagens.template;
+          setTemplateText(current, msgEditor.value);
+          persistState();
+          renderMessages();
+        });
+
+        document.getElementById('btnResetTemplate').addEventListener('click', () => {
+          const current = state.mensagens.template;
+          delete state.mensagens.personalizados[current];
+          msgEditor.value = getTemplateText(current);
+          persistState();
+          renderMessages();
+        });
+
+        document.getElementById('btnCopyAll').addEventListener('click', handleCopyAll);
+        document.getElementById('btnCopyPreview').addEventListener('click', handleCopyPreview);
+        document.getElementById('btnCopyLabel').addEventListener('click', handleCopyLabel);
+        document.getElementById('btnLabelTxt').addEventListener('click', downloadEtiquetaTxt);
+        document.getElementById('btnCsv').addEventListener('click', exportCsv);
+        document.getElementById('btnPrint').addEventListener('click', () => window.print());
+        document.getElementById('btnSave').addEventListener('click', downloadJson);
+        document.getElementById('btnStart').addEventListener('click', handleStart);
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = '.json,application/json';
+        fileInput.style.display = 'none';
+        fileInput.addEventListener('change', handleOpenFile);
+        document.body.appendChild(fileInput);
+        document.getElementById('btnOpen').addEventListener('click', () => fileInput.click());
+      }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        loadFromStorage();
+        setupTabs();
+        setupEvents();
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build the v4 Cerimonial assistant HTML page with redesigned navigation, toolbar, and data/list/message/report sections
- implement client-side state management, invite processing, messaging templates, and export/copy utilities persisted with localStorage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3f02ada008320bbe5ef81d471cf73