### PR TITLE
Add standalone invite processor tool

### DIFF
--- a/Assistentes/Cerimonial/app_free_v4/assistente-cerimonial-v4-lite.html
+++ b/Assistentes/Cerimonial/app_free_v4/assistente-cerimonial-v4-lite.html
@@ -1,0 +1,1964 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Assistente Cerimonial V4 Lite</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      .ac-app,
+      .ac-app * {
+        box-sizing: border-box;
+      }
+
+      .ac-app {
+        font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
+        color: #111111;
+        background: #f5f5f5;
+        padding: 24px 16px 48px;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+
+      .ac-header {
+        background: #111;
+        color: #fff;
+        border-radius: 20px;
+        padding: 24px;
+        margin-bottom: 24px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .ac-header::before,
+      .ac-header::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 10px;
+        background-image: repeating-linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.32) 0,
+          rgba(255, 255, 255, 0.32) 6px,
+          transparent 6px,
+          transparent 12px
+        );
+      }
+
+      .ac-header::before {
+        left: 0;
+      }
+
+      .ac-header::after {
+        right: 0;
+      }
+
+      .ac-header__inner {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: flex-start;
+      }
+
+      .ac-title {
+        margin: 0;
+        font-size: clamp(1.6rem, 2.4vw + 1rem, 2.4rem);
+        letter-spacing: -0.01em;
+      }
+
+      .ac-subtitle {
+        margin: 4px 0 0;
+        font-size: 0.95rem;
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .ac-menu {
+        margin-left: auto;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .ac-menu__btn {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        color: #fff;
+        font-weight: 600;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.1s ease;
+      }
+
+      .ac-menu__btn:hover,
+      .ac-menu__btn:focus-visible {
+        background: rgba(255, 255, 255, 0.3);
+        outline: none;
+      }
+
+      .ac-menu__btn:active {
+        transform: translateY(1px);
+      }
+
+      .ac-menu__btn[disabled] {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+
+      .ac-main {
+        display: grid;
+        gap: 20px;
+      }
+
+      .ac-card {
+        background: #fff;
+        border-radius: 24px;
+        padding: 28px;
+        position: relative;
+        box-shadow: 0 16px 45px rgba(17, 17, 17, 0.08);
+        overflow: hidden;
+      }
+
+      .ac-card::before,
+      .ac-card::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 12px;
+        background-image: repeating-linear-gradient(
+          180deg,
+          rgba(17, 17, 17, 0.18) 0,
+          rgba(17, 17, 17, 0.18) 6px,
+          transparent 6px,
+          transparent 12px
+        );
+        pointer-events: none;
+      }
+
+      .ac-card::before {
+        left: 0;
+      }
+
+      .ac-card::after {
+        right: 0;
+      }
+
+      .ac-card__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 20px;
+      }
+
+      .ac-card__header-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        justify-content: flex-end;
+      }
+
+      .ac-card__title {
+        margin: 0;
+        font-size: 1.35rem;
+        letter-spacing: -0.01em;
+      }
+
+      .ac-card__subtitle {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #4d4d4d;
+      }
+
+      .ac-resumo__grid {
+        display: grid;
+        gap: 12px;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+
+      .ac-resumo__item {
+        border: 1px solid rgba(17, 17, 17, 0.12);
+        border-radius: 16px;
+        padding: 14px 16px;
+        background: rgba(17, 17, 17, 0.03);
+      }
+
+      .ac-resumo__label {
+        display: block;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #5a5a5a;
+        margin-bottom: 6px;
+      }
+
+      .ac-resumo__value {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #111;
+        word-break: break-word;
+      }
+
+      .ac-field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-bottom: 18px;
+      }
+
+      .ac-label {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: #303030;
+      }
+
+      .ac-input,
+      .ac-textarea {
+        border-radius: 14px;
+        border: 1px solid rgba(17, 17, 17, 0.2);
+        padding: 12px 14px;
+        font: inherit;
+        color: inherit;
+        background: #fff;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .ac-input:focus-visible,
+      .ac-textarea:focus-visible {
+        outline: none;
+        border-color: #111;
+        box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.12);
+      }
+
+      .ac-textarea {
+        resize: vertical;
+        min-height: 120px;
+      }
+
+      .ac-inline {
+        display: grid;
+        gap: 14px;
+      }
+
+      .ac-inline.two {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .ac-convidados__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .ac-convites__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        justify-content: flex-end;
+        margin-bottom: 12px;
+      }
+
+      .ac-convites__stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin: 12px 0 8px;
+        font-size: 0.9rem;
+        color: #4d4d4d;
+      }
+
+      .ac-convites__issues {
+        border-radius: 16px;
+        border: 1px solid rgba(180, 35, 35, 0.2);
+        background: rgba(180, 35, 35, 0.06);
+        padding: 14px 18px;
+        margin-top: 12px;
+        color: #7a1f1f;
+      }
+
+      .ac-convites__issues-list {
+        margin: 8px 0 0;
+        padding-left: 18px;
+        display: grid;
+        gap: 6px;
+      }
+
+      .ac-convites__table-wrap {
+        margin-top: 16px;
+        border-radius: 18px;
+        border: 1px solid rgba(17, 17, 17, 0.08);
+        background: rgba(17, 17, 17, 0.02);
+        overflow: hidden;
+      }
+
+      .ac-convites__table-scroll {
+        max-height: 320px;
+        overflow: auto;
+      }
+
+      .ac-table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 520px;
+        font-size: 0.92rem;
+      }
+
+      .ac-table thead th {
+        text-align: left;
+        padding: 12px 16px;
+        background: rgba(17, 17, 17, 0.08);
+        font-weight: 600;
+        color: #111;
+      }
+
+      .ac-table tbody td {
+        padding: 10px 16px;
+        border-top: 1px solid rgba(17, 17, 17, 0.08);
+        vertical-align: top;
+      }
+
+      .ac-table tbody tr:nth-child(even) {
+        background: rgba(17, 17, 17, 0.03);
+      }
+
+      .ac-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        border-radius: 999px;
+        padding: 3px 10px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+
+      .ac-badge--warning {
+        background: rgba(255, 191, 0, 0.2);
+        color: #7a5400;
+      }
+
+      .ac-badge--info {
+        background: rgba(17, 17, 17, 0.12);
+        color: #111;
+      }
+
+      .ac-badge--error {
+        background: rgba(180, 35, 35, 0.18);
+        color: #7a1f1f;
+      }
+
+      .ac-button {
+        appearance: none;
+        border-radius: 12px;
+        border: 1px solid #111;
+        background: #111;
+        color: #fff;
+        font-weight: 600;
+        padding: 10px 18px;
+        cursor: pointer;
+        transition: transform 0.1s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+
+      .ac-button.secondary {
+        background: #fff;
+        color: #111;
+      }
+
+      .ac-button:hover,
+      .ac-button:focus-visible {
+        box-shadow: 0 10px 24px rgba(17, 17, 17, 0.16);
+        outline: none;
+      }
+
+      .ac-button:active {
+        transform: translateY(1px);
+      }
+
+      .ac-button[disabled] {
+        opacity: 0.5;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+
+      .ac-convidados__list {
+        margin: 24px 0 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 12px;
+      }
+
+      .ac-convidado {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        border-radius: 14px;
+        border: 1px solid rgba(17, 17, 17, 0.1);
+        background: rgba(17, 17, 17, 0.03);
+      }
+
+      .ac-convidado__index {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        background: #111;
+        color: #fff;
+        font-weight: 600;
+        font-size: 0.85rem;
+      }
+
+      .ac-convidado__input {
+        flex: 1;
+        min-width: 0;
+        border: none;
+        background: transparent;
+        font: inherit;
+        padding: 6px 4px;
+        border-bottom: 1px solid transparent;
+        transition: border-color 0.2s ease;
+      }
+
+      .ac-convidado__input:focus-visible {
+        outline: none;
+        border-color: #111;
+      }
+
+      .ac-convidado__remove {
+        appearance: none;
+        background: none;
+        border: 0;
+        color: #b42323;
+        font-weight: 600;
+        cursor: pointer;
+        border-radius: 50%;
+        width: 32px;
+        height: 32px;
+        display: grid;
+        place-items: center;
+      }
+
+      .ac-convidados__stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 16px;
+        font-size: 0.9rem;
+        color: #4d4d4d;
+      }
+
+      .ac-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 999px;
+        padding: 6px 12px;
+        background: rgba(17, 17, 17, 0.06);
+      }
+
+      .ac-modal {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: rgba(17, 17, 17, 0.45);
+        padding: 24px;
+        z-index: 999;
+      }
+
+      .ac-modal[hidden] {
+        display: none;
+      }
+
+      .ac-modal__dialog {
+        width: min(520px, 100%);
+        background: #fff;
+        border-radius: 20px;
+        padding: 24px;
+        position: relative;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+      }
+
+      .ac-modal__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .ac-modal__title {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .ac-modal__close {
+        background: none;
+        border: 0;
+        font-size: 1.4rem;
+        cursor: pointer;
+        line-height: 1;
+        padding: 4px 8px;
+      }
+
+      .ac-event-list {
+        display: grid;
+        gap: 12px;
+        max-height: min(420px, 60vh);
+        overflow-y: auto;
+      }
+
+      .ac-event-card {
+        border: 1px solid rgba(17, 17, 17, 0.12);
+        border-radius: 16px;
+        padding: 14px 16px;
+        background: rgba(17, 17, 17, 0.02);
+        display: grid;
+        gap: 8px;
+      }
+
+      .ac-event-card__meta {
+        font-size: 0.85rem;
+        color: #4d4d4d;
+      }
+
+      .ac-event-card__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .ac-toast {
+        position: fixed;
+        right: 24px;
+        bottom: 24px;
+        padding: 14px 18px;
+        border-radius: 14px;
+        background: #111;
+        color: #fff;
+        font-weight: 600;
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.2);
+        opacity: 0;
+        transform: translateY(10px);
+        pointer-events: none;
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        z-index: 1000;
+      }
+
+      .ac-toast[data-visible="true"] {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .ac-toast[data-variant="error"] {
+        background: #b42323;
+      }
+
+      .ac-toast[data-variant="success"] {
+        background: #0b8a3b;
+      }
+
+      .ac-toast[data-variant="info"] {
+        background: #111;
+      }
+
+      .ac-footer {
+        margin-top: 36px;
+        text-align: center;
+        font-size: 0.85rem;
+        color: #4d4d4d;
+      }
+
+      .ac-warning {
+        margin-top: 12px;
+        padding: 12px 14px;
+        border-radius: 14px;
+        background: rgba(180, 35, 35, 0.08);
+        color: #7a1414;
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 720px) {
+        .ac-app {
+          padding: 20px 12px 36px;
+        }
+
+        .ac-header {
+          padding: 20px;
+        }
+
+        .ac-card {
+          padding: 22px;
+        }
+
+        .ac-menu {
+          width: 100%;
+        }
+
+        .ac-menu__btn {
+          flex: 1;
+          text-align: center;
+        }
+
+        .ac-menu {
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app" class="ac-app">
+      <header class="ac-header">
+        <div class="ac-header__inner">
+          <div>
+            <h1 class="ac-title">Assistente Cerimonial V4 Lite</h1>
+            <p class="ac-subtitle">Gestão rápida de convites e RSVP diretamente no seu navegador.</p>
+          </div>
+          <nav class="ac-menu" aria-label="Menu de controle">
+            <button type="button" class="ac-menu__btn" data-action="novo">Novo</button>
+            <button type="button" class="ac-menu__btn" data-action="salvar">Salvar</button>
+            <button type="button" class="ac-menu__btn" data-action="carregar">Carregar</button>
+            <button type="button" class="ac-menu__btn" data-action="excluir">Excluir</button>
+            <button type="button" class="ac-menu__btn" data-action="exportar">Exportar</button>
+          </nav>
+        </div>
+      </header>
+      <main class="ac-main" aria-live="polite">
+        <section class="ac-card" id="ac-resumo" aria-labelledby="ac-resumo-title">
+          <div class="ac-card__header">
+            <div>
+              <h2 class="ac-card__title" id="ac-resumo-title">Resumo do evento</h2>
+              <p class="ac-card__subtitle">Atualize as informações abaixo e acompanhe os totais em tempo real.</p>
+            </div>
+          </div>
+          <div class="ac-resumo__grid" data-role="resumo-grid"></div>
+        </section>
+        <section class="ac-card" id="ac-dados-evento" aria-labelledby="ac-dados-title">
+          <div class="ac-card__header">
+            <div>
+              <h2 class="ac-card__title" id="ac-dados-title">Dados do evento</h2>
+              <p class="ac-card__subtitle">Informe título, data, local e mensagem padrão que será utilizada nos convites.</p>
+            </div>
+          </div>
+          <div class="ac-inline">
+            <div class="ac-field">
+              <label class="ac-label" for="ac-evento-nome">Título do evento *</label>
+              <input class="ac-input" type="text" id="ac-evento-nome" name="ac-evento-nome" maxlength="120" autocomplete="off" required />
+            </div>
+            <div class="ac-inline two">
+              <div class="ac-field">
+                <label class="ac-label" for="ac-evento-data">Data (ISO)</label>
+                <input class="ac-input" type="date" id="ac-evento-data" name="ac-evento-data" />
+              </div>
+              <div class="ac-field">
+                <label class="ac-label" for="ac-evento-local">Local</label>
+                <input class="ac-input" type="text" id="ac-evento-local" name="ac-evento-local" maxlength="140" autocomplete="off" />
+              </div>
+            </div>
+            <div class="ac-field">
+              <label class="ac-label" for="ac-evento-msg">Mensagem padrão do convite</label>
+              <textarea class="ac-textarea" id="ac-evento-msg" name="ac-evento-msg" rows="4" placeholder="É com alegria que convidamos você..."></textarea>
+            </div>
+          </div>
+          <div class="ac-warning" data-role="warning" hidden></div>
+        </section>
+        <section class="ac-card" id="ac-convites" aria-labelledby="ac-convites-title">
+          <div class="ac-card__header">
+            <div>
+              <h2 class="ac-card__title" id="ac-convites-title">Processador de convites</h2>
+              <p class="ac-card__subtitle">Cole cada convite em uma linha. Detectamos telefones, acompanhantes e titular automaticamente.</p>
+            </div>
+            <div class="ac-card__header-actions" data-role="convites-actions">
+              <button type="button" class="ac-button" data-action="processar-convites">Processar convites</button>
+              <button type="button" class="ac-button secondary" data-action="limpar-convites">Limpar campo</button>
+              <button type="button" class="ac-button secondary" data-action="convites-para-convidados">Adicionar nomes à lista</button>
+            </div>
+          </div>
+          <div class="ac-field">
+            <label class="ac-label" for="ac-convites-input">Convites brutos (um por linha)</label>
+            <textarea class="ac-textarea" id="ac-convites-input" name="ac-convites-input" rows="6" placeholder="Maria Silva, João - (41) 98888-0000&#10;Pedro - 41 97777-1111 - Ana e Lucas&#10;..." aria-describedby="ac-convites-ajuda"></textarea>
+            <span id="ac-convites-ajuda" class="ac-card__subtitle">Exemplos: "Fabio 41 99999-0000 Lud e Leo", "Marina, Gustavo - +55 11 98888-7766".</span>
+          </div>
+          <div class="ac-convites__stats" data-role="convites-stats"></div>
+          <div class="ac-convites__issues" data-role="convites-issues" hidden>
+            <strong>Linhas com problemas:</strong>
+            <ul class="ac-convites__issues-list" data-role="convites-issues-list"></ul>
+          </div>
+          <div class="ac-convites__table-wrap" data-role="convites-table-wrap" hidden>
+            <div class="ac-convites__table-scroll">
+              <table class="ac-table" aria-describedby="ac-convites-title">
+                <thead>
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Titular</th>
+                    <th scope="col">Acompanhantes</th>
+                    <th scope="col">Telefone</th>
+                    <th scope="col">Total</th>
+                    <th scope="col">Observações</th>
+                  </tr>
+                </thead>
+                <tbody data-role="convites-table"></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+        <section class="ac-card" id="ac-convidados" aria-labelledby="ac-convidados-title">
+          <div class="ac-card__header">
+            <div>
+              <h2 class="ac-card__title" id="ac-convidados-title">Convidados</h2>
+              <p class="ac-card__subtitle">Cole nomes (um por linha) e clique em “Adicionar Convidados”. Duplicidades são ignoradas automaticamente.</p>
+            </div>
+          </div>
+          <div class="ac-field">
+            <label class="ac-label" for="ac-convidados-input">Nomes dos convidados</label>
+            <textarea class="ac-textarea" id="ac-convidados-input" name="ac-convidados-input" rows="6" placeholder="Maria de Souza\nJoão dos Santos\n..." aria-describedby="ac-convidados-ajuda"></textarea>
+            <span id="ac-convidados-ajuda" class="ac-card__subtitle">As preposições comuns são mantidas em minúsculas automaticamente.</span>
+          </div>
+          <div class="ac-convidados__actions">
+            <button type="button" class="ac-button" data-action="adicionar-convidados">Adicionar Convidados</button>
+            <button type="button" class="ac-button secondary" data-action="limpar-lista">Limpar lista</button>
+          </div>
+          <div class="ac-convidados__stats" data-role="convidados-stats"></div>
+          <ul class="ac-convidados__list" data-role="lista-convidados"></ul>
+        </section>
+      </main>
+      <footer class="ac-footer">Os dados ficam somente no seu navegador. Você pode excluir a qualquer momento.</footer>
+      <div class="ac-modal" id="ac-modal-carregar" role="dialog" aria-modal="true" aria-labelledby="ac-modal-title" hidden>
+        <div class="ac-modal__dialog">
+          <header class="ac-modal__header">
+            <h2 class="ac-modal__title" id="ac-modal-title">Eventos salvos</h2>
+            <button type="button" class="ac-modal__close" data-action="fechar-modal" aria-label="Fechar modal">×</button>
+          </header>
+          <div class="ac-event-list" data-role="event-list"></div>
+        </div>
+      </div>
+      <div class="ac-toast" id="ac-toast" role="status" aria-live="polite" hidden></div>
+    </div>
+    <script>
+      (function () {
+        "use strict";
+
+        // [constants]
+        const DB_NAME = "marco_db";
+        const DB_VER = 1;
+        const STORE = "kv";
+        const INDEX_KEY = "ac:index:v1";
+        const PREPOSITIONS = new Set(["de", "da", "das", "do", "dos", "e", "ou"]);
+        const PHONE_REGEX = /(?:\+?\d[\d\s().-]{6,}\d)/g;
+
+        // [state]
+        const appState = {
+          evento: createEmptyEvent(),
+          eventosIndex: [],
+          lastAction: "Pronto para começar.",
+          hasIndexedDB: typeof indexedDB !== "undefined",
+          loadingIndex: false,
+          convitesAnalise: createConvitesAnalise(),
+        };
+
+        let toastTimer = null;
+        let modalPreviouslyFocused = null;
+
+        const dom = {
+          resumoGrid: document.querySelector('[data-role="resumo-grid"]'),
+          nomeInput: document.getElementById("ac-evento-nome"),
+          dataInput: document.getElementById("ac-evento-data"),
+          localInput: document.getElementById("ac-evento-local"),
+          mensagemInput: document.getElementById("ac-evento-msg"),
+          convitesTextarea: document.getElementById("ac-convites-input"),
+          convitesStats: document.querySelector('[data-role="convites-stats"]'),
+          convitesIssues: document.querySelector('[data-role="convites-issues"]'),
+          convitesIssuesList: document.querySelector('[data-role="convites-issues-list"]'),
+          convitesTableWrap: document.querySelector('[data-role="convites-table-wrap"]'),
+          convitesTableBody: document.querySelector('[data-role="convites-table"]'),
+          convitesActions: document.querySelector('[data-role="convites-actions"]'),
+          convidadosTextarea: document.getElementById("ac-convidados-input"),
+          convidadosList: document.querySelector('[data-role="lista-convidados"]'),
+          convidadosStats: document.querySelector('[data-role="convidados-stats"]'),
+          toast: document.getElementById("ac-toast"),
+          modal: document.getElementById("ac-modal-carregar"),
+          modalList: document.querySelector('[data-role="event-list"]'),
+          warning: document.querySelector('[data-role="warning"]'),
+          menuButtons: document.querySelectorAll(".ac-menu__btn"),
+          menu: document.querySelector(".ac-menu"),
+          convidadosActions: document.querySelector(".ac-convidados__actions"),
+        };
+
+        // [db]
+        const db = {
+          async open() {
+            return new Promise((resolve, reject) => {
+              const request = indexedDB.open(DB_NAME, DB_VER);
+              request.onupgradeneeded = () => {
+                const database = request.result;
+                if (!database.objectStoreNames.contains(STORE)) {
+                  database.createObjectStore(STORE);
+                }
+              };
+              request.onsuccess = () => resolve(request.result);
+              request.onerror = () => reject(request.error);
+            });
+          },
+          async put(value, key) {
+            const database = await db.open();
+            return new Promise((resolve, reject) => {
+              const tx = database.transaction(STORE, "readwrite");
+              tx.oncomplete = () => resolve();
+              tx.onerror = () => reject(tx.error);
+              tx.objectStore(STORE).put(value, key);
+            });
+          },
+          async get(key) {
+            const database = await db.open();
+            return new Promise((resolve, reject) => {
+              const tx = database.transaction(STORE, "readonly");
+              const store = tx.objectStore(STORE);
+              const request = store.get(key);
+              request.onsuccess = () => resolve(request.result);
+              request.onerror = () => reject(request.error);
+            });
+          },
+          async delete(key) {
+            const database = await db.open();
+            return new Promise((resolve, reject) => {
+              const tx = database.transaction(STORE, "readwrite");
+              tx.oncomplete = () => resolve();
+              tx.onerror = () => reject(tx.error);
+              tx.objectStore(STORE).delete(key);
+            });
+          },
+          async keys() {
+            const database = await db.open();
+            return new Promise((resolve, reject) => {
+              const tx = database.transaction(STORE, "readonly");
+              const request = tx.objectStore(STORE).getAllKeys();
+              request.onsuccess = () => resolve(request.result || []);
+              request.onerror = () => reject(request.error);
+            });
+          },
+        };
+
+        // [utils]
+        function createEmptyEvent() {
+          const now = Date.now();
+          return {
+            id: "",
+            nome: "",
+            dataISO: "",
+            local: "",
+            mensagem: "",
+            convidados: [],
+            convitesBrutos: "",
+            convitesEstruturados: [],
+            createdAt: now,
+            updatedAt: now,
+            version: "1",
+          };
+        }
+
+        function cloneEvento(evento) {
+          return JSON.parse(JSON.stringify(evento));
+        }
+
+        function normalizeEvento(raw) {
+          const base = createEmptyEvent();
+          const clone = cloneEvento(raw || {});
+          const evento = { ...base, ...clone };
+          evento.convidados = Array.isArray(clone.convidados)
+            ? clone.convidados.map((nome) => String(nome || "").trim()).filter(Boolean)
+            : [];
+          evento.convitesBrutos = typeof clone.convitesBrutos === "string" ? clone.convitesBrutos : "";
+          let analise = createConvitesAnalise();
+          if (evento.convitesBrutos.trim()) {
+            const { convites, analise: novaAnalise } = analisarConvitesBrutos(evento.convitesBrutos);
+            evento.convitesEstruturados = convites.map(mapConviteParaStorage);
+            analise = novaAnalise;
+          } else if (Array.isArray(clone.convitesEstruturados) && clone.convitesEstruturados.length) {
+            const sanitizados = clone.convitesEstruturados.map(sanitizeStoredInvite).filter(Boolean);
+            evento.convitesEstruturados = sanitizados.map(mapConviteParaStorage);
+            analise = construirAnaliseAPartirDosConvites(evento.convitesEstruturados);
+          } else {
+            evento.convitesEstruturados = [];
+          }
+          return { evento, analise };
+        }
+
+        function setLastAction(message) {
+          appState.lastAction = message;
+          renderResumo();
+        }
+
+        function formatDate(iso) {
+          if (!iso) return "—";
+          try {
+            const date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return "—";
+            return date.toLocaleDateString("pt-BR", { timeZone: "UTC" });
+          } catch (err) {
+            return "—";
+          }
+        }
+
+        function formatDateTime(ms) {
+          if (!ms) return "—";
+          try {
+            const date = new Date(ms);
+            return (
+              date.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric" }) +
+              " às " +
+              date.toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })
+            );
+          } catch (err) {
+            return "—";
+          }
+        }
+
+        function escapeHtml(value) {
+          const text = value == null ? "" : String(value);
+          return text.replace(/[&<>"']/g, (char) => {
+            switch (char) {
+              case "&":
+                return "&amp;";
+              case "<":
+                return "&lt;";
+              case ">":
+                return "&gt;";
+              case '"':
+                return "&quot;";
+              case "'":
+                return "&#39;";
+              default:
+                return char;
+            }
+          });
+        }
+
+        function toTitleCase(nome) {
+          if (!nome) return "";
+          const palavras = nome.trim().split(/\s+/);
+          const resultado = palavras.map((palavra, indexPalavra) => {
+            const partes = palavra.split(/([-'])/).filter(Boolean);
+            return partes
+              .map((parte) => {
+                if (parte === "-" || parte === "'") return parte;
+                const lower = parte.toLocaleLowerCase("pt-BR");
+                const shouldKeepLower = indexPalavra > 0 && PREPOSITIONS.has(lower);
+                if (shouldKeepLower) return lower;
+                return lower.charAt(0).toLocaleUpperCase("pt-BR") + lower.slice(1);
+              })
+              .join("");
+          });
+          return resultado.join(" ");
+        }
+
+        function normalizeLista(rawInput, existentes) {
+          const existingSet = new Set((existentes || []).map((nome) => nome.toLocaleLowerCase("pt-BR")));
+          const novos = [];
+          const linhas = rawInput.split(/\r?\n/);
+          for (const linha of linhas) {
+            const trimmed = linha.trim();
+            if (!trimmed) continue;
+            const nomeFormatado = toTitleCase(trimmed);
+            if (!nomeFormatado) continue;
+            const key = nomeFormatado.toLocaleLowerCase("pt-BR");
+            if (existingSet.has(key)) continue;
+            existingSet.add(key);
+            novos.push(nomeFormatado);
+          }
+          return novos;
+        }
+
+        function createConvitesAnalise() {
+          return {
+            totalLinhas: 0,
+            processadas: 0,
+            ignoradas: [],
+            duplicadas: [],
+            semTelefone: 0,
+          };
+        }
+
+        function digitsOnly(value = "") {
+          return String(value).replace(/\D/g, "");
+        }
+
+        function normalizePhoneNumber(value = "") {
+          let digits = digitsOnly(value);
+          if (digits.length > 11) digits = digits.slice(-11);
+          if (digits.length < 10) return null;
+          return digits.length === 10
+            ? `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`
+            : `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+        }
+
+        function stripInviteNoise(text = "") {
+          return String(text)
+            .normalize("NFKC")
+            .replace(PHONE_REGEX, " ")
+            .replace(/\d{2,}/g, " ")
+            .replace(/[()._]+/g, " ")
+            .replace(/\s{2,}/g, " ")
+            .trim();
+        }
+
+        function normalizeInviteName(value = "") {
+          const cleaned = stripInviteNoise(value);
+          if (!cleaned) return "";
+          return toTitleCase(cleaned);
+        }
+
+        function extractNamesSegment(segment = "") {
+          return String(segment)
+            .split(/[,;|/]+|\s+(?:e|&|com|\+|e\/ou)\s+/gi)
+            .map((parte) => normalizeInviteName(parte))
+            .filter(Boolean);
+        }
+
+        function uniqueCaseInsensitive(list = []) {
+          const seen = new Set();
+          const result = [];
+          for (const item of list) {
+            const value = String(item || "");
+            if (!value) continue;
+            const key = value.toLocaleLowerCase("pt-BR");
+            if (seen.has(key)) continue;
+            seen.add(key);
+            result.push(value);
+          }
+          return result;
+        }
+
+        function generateInviteId() {
+          if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            return crypto.randomUUID();
+          }
+          return `invite-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+        }
+
+        function extractPhoneFromLine(line = "") {
+          const matches = String(line).match(PHONE_REGEX) || [];
+          let best = null;
+          let bestDigits = "";
+          for (const candidate of matches) {
+            const candidateDigits = digitsOnly(candidate);
+            if (candidateDigits.length > bestDigits.length) {
+              best = candidate;
+              bestDigits = candidateDigits;
+            }
+          }
+          const telefone = best ? normalizePhoneNumber(best) : null;
+          const semTelefone = best ? String(line).replace(best, " ") : String(line).replace(PHONE_REGEX, " ");
+          return { semTelefone, telefone, digits: bestDigits };
+        }
+
+        function parseConviteLinha(linha = "") {
+          const original = String(linha).trim();
+          if (!original) return null;
+
+          const { semTelefone, telefone, digits } = extractPhoneFromLine(original);
+          const rawParts = semTelefone
+            .split(/[,;|]+|\s+-\s+|\s+–\s+/g)
+            .map((parte) => parte.trim())
+            .filter(Boolean);
+
+          const parts = rawParts.length ? rawParts : [semTelefone.trim() || original];
+          const titularSegment = parts[0] || "";
+          const titularTokens = extractNamesSegment(titularSegment);
+          const titular = titularTokens.length ? titularTokens[0] : normalizeInviteName(titularSegment);
+          const restanteTokens = parts.slice(1).flatMap((parte) => extractNamesSegment(parte));
+          const acompanhantes = uniqueCaseInsensitive([...titularTokens.slice(1), ...restanteTokens]);
+          const total = Math.max(1, 1 + acompanhantes.length);
+          const avisos = [];
+          if (!titular) {
+            avisos.push("Titular não identificado");
+          }
+          if (!telefone) {
+            if (digits && digits.length) {
+              avisos.push("Telefone incompleto");
+            } else {
+              avisos.push("Sem telefone");
+            }
+          }
+          return {
+            id: generateInviteId(),
+            linhaOriginal: original,
+            titular,
+            acompanhantes,
+            telefone,
+            total,
+            avisos: uniqueCaseInsensitive(avisos),
+          };
+        }
+
+        function analisarConvitesBrutos(texto = "") {
+          const linhas = String(texto).replace(/\r\n?/g, "\n").split("\n");
+          const convites = [];
+          const ignoradas = [];
+          const duplicadas = [];
+          const vistos = new Map();
+          let semTelefone = 0;
+          let totalLinhas = 0;
+          for (let index = 0; index < linhas.length; index += 1) {
+            const raw = linhas[index].trim();
+            if (!raw) continue;
+            totalLinhas += 1;
+            const convite = parseConviteLinha(raw);
+            if (!convite || !convite.titular) {
+              ignoradas.push({ linha: index + 1, conteudo: raw });
+              continue;
+            }
+            convite.linha = index + 1;
+            if (!convite.telefone) semTelefone += 1;
+            const chave = convite.titular.toLocaleLowerCase("pt-BR");
+            if (vistos.has(chave)) {
+              if (!convite.avisos.includes("Duplicado")) convite.avisos.push("Duplicado");
+              duplicadas.push({ linha: index + 1, titular: convite.titular, conteudo: raw });
+            } else {
+              vistos.set(chave, true);
+            }
+            convites.push(convite);
+          }
+          return {
+            convites,
+            analise: {
+              totalLinhas,
+              processadas: convites.length,
+              ignoradas,
+              duplicadas,
+              semTelefone,
+            },
+          };
+        }
+
+        function sanitizeStoredInvite(invite) {
+          if (!invite) return null;
+          const titular = normalizeInviteName(invite.titular || "");
+          const acompanhantes = Array.isArray(invite.acompanhantes)
+            ? uniqueCaseInsensitive(invite.acompanhantes.map((nome) => normalizeInviteName(nome)))
+            : [];
+          const telefone = invite.telefone ? normalizePhoneNumber(invite.telefone) : null;
+          const avisos = Array.isArray(invite.avisos) ? uniqueCaseInsensitive(invite.avisos) : [];
+          const total = Number.isFinite(Number(invite.total))
+            ? Math.max(1, Number(invite.total))
+            : 1 + acompanhantes.length;
+          return {
+            id: invite.id || generateInviteId(),
+            linha: invite.linha || null,
+            linhaOriginal: invite.linhaOriginal || "",
+            titular,
+            acompanhantes,
+            telefone,
+            total,
+            avisos,
+          };
+        }
+
+        function construirAnaliseAPartirDosConvites(convites) {
+          const analise = createConvitesAnalise();
+          analise.processadas = convites.length;
+          analise.totalLinhas = convites.length;
+          analise.semTelefone = convites.filter((c) => !c.telefone).length;
+          analise.ignoradas = [];
+          const duplicadas = [];
+          const vistos = new Map();
+          convites.forEach((convite) => {
+            const chave = convite.titular ? convite.titular.toLocaleLowerCase("pt-BR") : null;
+            if (!chave) return;
+            if (vistos.has(chave)) {
+              duplicadas.push({ linha: convite.linha || null, titular: convite.titular, conteudo: convite.linhaOriginal || "" });
+            } else {
+              vistos.set(chave, true);
+            }
+          });
+          analise.duplicadas = duplicadas;
+          return analise;
+        }
+
+        function mapConviteParaStorage(convite) {
+          if (!convite) {
+            return {
+              id: generateInviteId(),
+              linha: null,
+              linhaOriginal: "",
+              titular: "",
+              acompanhantes: [],
+              telefone: null,
+              total: 1,
+              avisos: [],
+            };
+          }
+          const acompanhantes = Array.isArray(convite.acompanhantes)
+            ? uniqueCaseInsensitive(convite.acompanhantes.map((nome) => normalizeInviteName(nome)))
+            : [];
+          const total = Number.isFinite(Number(convite.total))
+            ? Math.max(1, Number(convite.total))
+            : 1 + acompanhantes.length;
+          const linha = Number.isFinite(Number(convite.linha)) ? Number(convite.linha) : convite.linha || null;
+          return {
+            id: convite.id || generateInviteId(),
+            linha,
+            linhaOriginal: convite.linhaOriginal || "",
+            titular: normalizeInviteName(convite.titular || ""),
+            acompanhantes,
+            telefone: convite.telefone ? normalizePhoneNumber(convite.telefone) : null,
+            total,
+            avisos: Array.isArray(convite.avisos) ? uniqueCaseInsensitive(convite.avisos.map((aviso) => String(aviso))) : [],
+          };
+        }
+
+        function showToast(message, variant = "info") {
+          if (!dom.toast) return;
+          dom.toast.textContent = message;
+          dom.toast.dataset.variant = variant;
+          dom.toast.dataset.visible = "true";
+          dom.toast.hidden = false;
+          clearTimeout(toastTimer);
+          toastTimer = setTimeout(() => {
+            dom.toast.dataset.visible = "false";
+            toastTimer = setTimeout(() => {
+              dom.toast.hidden = true;
+            }, 320);
+          }, 3200);
+        }
+
+        function updateMenuState() {
+          dom.menuButtons.forEach((button) => {
+            const action = button.dataset.action;
+            if (["salvar", "carregar", "excluir"].includes(action) && !appState.hasIndexedDB) {
+              button.disabled = true;
+              button.title = "IndexedDB indisponível neste navegador.";
+              return;
+            }
+            if (action === "salvar") {
+              button.disabled = !appState.evento.nome.trim();
+              button.title = button.disabled ? "Informe o título do evento para salvar." : "Salvar evento";
+              return;
+            }
+            if (action === "excluir") {
+              button.disabled = !appState.evento.id;
+              button.title = button.disabled ? "Nenhum evento salvo selecionado." : "Excluir evento atual";
+              return;
+            }
+            button.disabled = false;
+            button.removeAttribute("title");
+          });
+        }
+
+        // [ui]
+        function renderResumo() {
+          if (!dom.resumoGrid) return;
+          const { evento, lastAction, convitesAnalise } = appState;
+          const convitesProcessados = Array.isArray(evento.convitesEstruturados)
+            ? evento.convitesEstruturados.length
+            : 0;
+          const alertasConvites =
+            (convitesAnalise?.semTelefone || 0) +
+            (convitesAnalise?.duplicadas?.length || 0) +
+            (convitesAnalise?.ignoradas?.length || 0);
+          const itens = [
+            { label: "Título", value: evento.nome ? escapeHtml(evento.nome) : "—" },
+            { label: "Data", value: evento.dataISO ? formatDate(evento.dataISO) : "—" },
+            { label: "Local", value: evento.local ? escapeHtml(evento.local) : "—" },
+            { label: "Total de convidados", value: String(evento.convidados.length) },
+            { label: "Convites processados", value: String(convitesProcessados) },
+            { label: "Alertas de convites", value: String(alertasConvites) },
+            { label: "Última ação", value: escapeHtml(lastAction) },
+          ];
+          dom.resumoGrid.innerHTML = itens
+            .map(
+              (item) => `
+                <div class="ac-resumo__item">
+                  <span class="ac-resumo__label">${item.label}</span>
+                  <span class="ac-resumo__value">${item.value || "—"}</span>
+                </div>
+              `
+            )
+            .join("");
+        }
+
+        function renderDadosEvento() {
+          const { evento, hasIndexedDB } = appState;
+          if (dom.nomeInput && dom.nomeInput.value !== evento.nome) dom.nomeInput.value = evento.nome;
+          if (dom.dataInput && dom.dataInput.value !== evento.dataISO) dom.dataInput.value = evento.dataISO;
+          if (dom.localInput && dom.localInput.value !== evento.local) dom.localInput.value = evento.local;
+          if (dom.mensagemInput && dom.mensagemInput.value !== evento.mensagem) dom.mensagemInput.value = evento.mensagem;
+
+          if (!hasIndexedDB && dom.warning) {
+            dom.warning.hidden = false;
+            dom.warning.textContent = "IndexedDB indisponível. Salvar e carregar eventos não estarão ativos.";
+          } else if (dom.warning) {
+            dom.warning.hidden = true;
+          }
+        }
+
+        function renderConvites() {
+          const { evento, convitesAnalise } = appState;
+          const analise = convitesAnalise || createConvitesAnalise();
+          if (dom.convitesTextarea && dom.convitesTextarea.value !== (evento.convitesBrutos || "")) {
+            dom.convitesTextarea.value = evento.convitesBrutos || "";
+          }
+
+          if (dom.convitesStats) {
+            if (!analise.totalLinhas && !evento.convitesEstruturados.length) {
+              dom.convitesStats.innerHTML =
+                '<span class="ac-card__subtitle">Cole convites brutos para gerar a estrutura automaticamente.</span>';
+            } else {
+              const tags = [
+                { label: "Linhas informadas", value: analise.totalLinhas },
+                { label: "Estruturados", value: analise.processadas },
+                { label: "Sem telefone", value: analise.semTelefone },
+                { label: "Duplicados", value: analise.duplicadas.length },
+                { label: "Ignorados", value: analise.ignoradas.length },
+              ];
+              dom.convitesStats.innerHTML = tags
+                .map((tag) => `<span class="ac-tag"><strong>${tag.label}:</strong> ${tag.value}</span>`)
+                .join("");
+            }
+          }
+
+          if (dom.convitesIssues && dom.convitesIssuesList) {
+            const issues = [];
+            (analise.ignoradas || []).forEach((item) => {
+              const bruto = (item.conteudo || "").trim();
+              const preview = bruto.length > 160 ? `${bruto.slice(0, 160)}…` : bruto;
+              issues.push(
+                `Linha ${item.linha}: não foi possível identificar um titular. Conteúdo: ${escapeHtml(preview)}`
+              );
+            });
+            (analise.duplicadas || []).forEach((item) => {
+              issues.push(`Linha ${item.linha}: duplicado para ${escapeHtml(item.titular || "—")}.`);
+            });
+            if (!issues.length) {
+              dom.convitesIssues.hidden = true;
+              dom.convitesIssuesList.innerHTML = "";
+            } else {
+              dom.convitesIssues.hidden = false;
+              dom.convitesIssuesList.innerHTML = issues.map((texto) => `<li>${texto}</li>`).join("");
+            }
+          }
+
+          if (dom.convitesTableBody && dom.convitesTableWrap) {
+            const convites = Array.isArray(evento.convitesEstruturados) ? evento.convitesEstruturados : [];
+            if (!convites.length) {
+              dom.convitesTableBody.innerHTML = "";
+              dom.convitesTableWrap.hidden = true;
+            } else {
+              dom.convitesTableWrap.hidden = false;
+              dom.convitesTableBody.innerHTML = convites
+                .map((convite, index) => {
+                  const acompanhantes = convite.acompanhantes?.length
+                    ? convite.acompanhantes.map((nome) => `<span>${escapeHtml(nome)}</span>`).join("<br />")
+                    : "—";
+                  const telefone = convite.telefone
+                    ? escapeHtml(convite.telefone)
+                    : '<span class="ac-badge ac-badge--warning">Sem telefone</span>';
+                  const observacoes = (convite.avisos || [])
+                    .map((aviso) => {
+                      const lower = String(aviso).toLocaleLowerCase("pt-BR");
+                      let classe = "ac-badge--info";
+                      if (lower.includes("sem telefone") || lower.includes("incompleto")) classe = "ac-badge--warning";
+                      if (lower.includes("duplicado") || lower.includes("titular")) classe = "ac-badge--error";
+                      return `<span class="ac-badge ${classe}">${escapeHtml(aviso)}</span>`;
+                    })
+                    .join(" ");
+                  const linhaInfo = convite.linha
+                    ? `<span class="ac-card__subtitle">Linha ${convite.linha}</span>`
+                    : "";
+                  return `
+                    <tr title="${escapeHtml(convite.linhaOriginal || "").replace(/"/g, '&quot;')}">
+                      <td>${index + 1}</td>
+                      <td>
+                        <div>${escapeHtml(convite.titular || "—")}</div>
+                        ${linhaInfo}
+                      </td>
+                      <td>${acompanhantes}</td>
+                      <td>${telefone}</td>
+                      <td>${Number.isFinite(convite.total) ? convite.total : 1 + (convite.acompanhantes?.length || 0)}</td>
+                      <td>${observacoes || "—"}</td>
+                    </tr>
+                  `;
+                })
+                .join("");
+            }
+          }
+        }
+
+        function renderConvidados() {
+          const { evento } = appState;
+          if (!dom.convidadosList) return;
+          if (!evento.convidados.length) {
+            dom.convidadosList.innerHTML = `<li class="ac-card__subtitle">Adicione convidados para começar a organizar sua lista.</li>`;
+          } else {
+            dom.convidadosList.innerHTML = evento.convidados
+              .map(
+                (nome, index) => `
+                  <li class="ac-convidado" data-index="${index}">
+                    <span class="ac-convidado__index" aria-hidden="true">${index + 1}</span>
+                    <input type="text" class="ac-convidado__input" data-guest-index="${index}" value="${escapeHtml(nome)}" aria-label="Editar nome do convidado ${index + 1}" />
+                    <button type="button" class="ac-convidado__remove" data-action="remover-convidado" data-guest-index="${index}" aria-label="Remover convidado ${escapeHtml(nome)}">×</button>
+                  </li>
+                `
+              )
+              .join("");
+          }
+
+          if (dom.convidadosStats) {
+            dom.convidadosStats.innerHTML = `
+              <span class="ac-tag"><strong>Total:</strong> ${evento.convidados.length}</span>
+              <span class="ac-tag"><strong>Confirmados:</strong> —</span>
+              <span class="ac-tag"><strong>Pendentes:</strong> —</span>
+            `;
+          }
+        }
+
+        function renderModal() {
+          if (!dom.modalList) return;
+          const { eventosIndex } = appState;
+          if (!eventosIndex.length) {
+            dom.modalList.innerHTML = `<p class="ac-card__subtitle">Nenhum evento salvo encontrado. Salve um evento para aparecer aqui.</p>`;
+            return;
+          }
+
+          dom.modalList.innerHTML = eventosIndex
+            .map((item) => {
+              const dataAtualizacao = formatDateTime(item.updatedAt);
+              const dataEvento = item.dataISO ? formatDate(item.dataISO) : "—";
+              return `
+                <article class="ac-event-card" data-event-id="${item.id}">
+                  <div>
+                    <strong>${escapeHtml(item.nome || "Sem título")}</strong>
+                  </div>
+                  <div class="ac-event-card__meta">Data do evento: ${dataEvento}</div>
+                  <div class="ac-event-card__meta">Atualizado em: ${dataAtualizacao}</div>
+                  <div class="ac-event-card__actions">
+                    <button type="button" class="ac-button" data-action="carregar-evento" data-event-id="${item.id}">Carregar</button>
+                    <button type="button" class="ac-button secondary" data-action="excluir-evento" data-event-id="${item.id}">Excluir</button>
+                  </div>
+                </article>
+              `;
+            })
+            .join("");
+        }
+
+        function renderAll() {
+          renderResumo();
+          renderDadosEvento();
+          renderConvites();
+          renderConvidados();
+          updateMenuState();
+        }
+
+        function updateIndexList(list) {
+          appState.eventosIndex = [...(list || [])].sort((a, b) => b.updatedAt - a.updatedAt);
+        }
+
+        // [logic]
+        async function carregarIndice() {
+          if (!appState.hasIndexedDB) return;
+          appState.loadingIndex = true;
+          try {
+            const indice = (await db.get(INDEX_KEY)) || [];
+            updateIndexList(indice);
+          } catch (error) {
+            console.warn("Erro ao carregar índice", error);
+            appState.hasIndexedDB = false;
+            showToast("IndexedDB indisponível. Alguns recursos foram desativados.", "error");
+          } finally {
+            appState.loadingIndex = false;
+            renderAll();
+          }
+        }
+
+        async function salvarEvento() {
+          if (!appState.hasIndexedDB) {
+            showToast("IndexedDB indisponível neste navegador.", "error");
+            return;
+          }
+          const nomeTrim = appState.evento.nome.trim();
+          if (!nomeTrim) {
+            showToast("Informe o título do evento antes de salvar.", "error");
+            if (dom.nomeInput) dom.nomeInput.focus();
+            return;
+          }
+          if ((appState.evento.convitesBrutos || "").trim()) {
+            processarConvites({ quiet: true, texto: appState.evento.convitesBrutos });
+          }
+          const now = Date.now();
+          const isNovo = !appState.evento.id;
+          const eventoParaSalvar = cloneEvento(appState.evento);
+          eventoParaSalvar.nome = nomeTrim;
+          if (!eventoParaSalvar.id) {
+            eventoParaSalvar.id = `ac-${now}-${Math.random().toString(36).slice(2, 8)}`;
+            eventoParaSalvar.createdAt = now;
+          }
+          eventoParaSalvar.updatedAt = now;
+
+          try {
+            await db.put(eventoParaSalvar, eventoParaSalvar.id);
+            const indice = (await db.get(INDEX_KEY)) || [];
+            const meta = {
+              id: eventoParaSalvar.id,
+              nome: eventoParaSalvar.nome,
+              updatedAt: eventoParaSalvar.updatedAt,
+              dataISO: eventoParaSalvar.dataISO,
+              local: eventoParaSalvar.local,
+            };
+            const semAtual = indice.filter((item) => item.id !== eventoParaSalvar.id);
+            semAtual.push(meta);
+            await db.put(semAtual, INDEX_KEY);
+            updateIndexList(semAtual);
+            appState.evento = eventoParaSalvar;
+            setLastAction(isNovo ? "Evento criado e salvo." : "Evento salvo com sucesso.");
+            renderAll();
+            showToast("Evento salvo no navegador!", "success");
+          } catch (error) {
+            console.error("Erro ao salvar evento", error);
+            showToast("Não foi possível salvar o evento.", "error");
+          }
+        }
+
+        async function abrirModalCarregar() {
+          if (!appState.hasIndexedDB) {
+            showToast("IndexedDB indisponível.", "error");
+            return;
+          }
+          await carregarIndice();
+          renderModal();
+          if (!dom.modal) return;
+          modalPreviouslyFocused = document.activeElement;
+          dom.modal.hidden = false;
+          dom.modal.addEventListener("click", onModalClick);
+          document.addEventListener("keydown", onModalKeydown);
+          const primeiroBotao = dom.modal.querySelector("button");
+          if (primeiroBotao) primeiroBotao.focus();
+        }
+
+        function fecharModal() {
+          if (!dom.modal || dom.modal.hidden) return;
+          dom.modal.hidden = true;
+          dom.modal.removeEventListener("click", onModalClick);
+          document.removeEventListener("keydown", onModalKeydown);
+          if (modalPreviouslyFocused && typeof modalPreviouslyFocused.focus === "function") {
+            modalPreviouslyFocused.focus();
+          }
+        }
+
+        function onModalClick(event) {
+          const target = event.target;
+          if (!(target instanceof HTMLElement)) return;
+          const action = target.dataset.action;
+          if (action === "fechar-modal") {
+            fecharModal();
+            return;
+          }
+          if (action === "carregar-evento") {
+            const id = target.dataset.eventId;
+            if (id) carregarEvento(id);
+            return;
+          }
+          if (action === "excluir-evento") {
+            const id = target.dataset.eventId;
+            if (id) excluirEvento(id, { fecharApos: false });
+            return;
+          }
+        }
+
+        function onModalKeydown(event) {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            fecharModal();
+          }
+        }
+
+        async function carregarEvento(id) {
+          if (!appState.hasIndexedDB) return;
+          try {
+            const evento = await db.get(id);
+            if (!evento) {
+              showToast("Evento não encontrado.", "error");
+              return;
+            }
+            const normalizado = normalizeEvento(evento);
+            appState.evento = normalizado.evento;
+            appState.convitesAnalise = normalizado.analise;
+            setLastAction("Evento carregado.");
+            renderAll();
+            showToast("Evento carregado!", "success");
+            fecharModal();
+          } catch (error) {
+            console.error("Erro ao carregar", error);
+            showToast("Não foi possível carregar o evento.", "error");
+          }
+        }
+
+        async function excluirEvento(id, options = { fecharApos: true }) {
+          if (!appState.hasIndexedDB) return;
+          const confirmar = window.confirm("Deseja realmente excluir este evento? Esta ação não pode ser desfeita.");
+          if (!confirmar) return;
+          try {
+            await db.delete(id);
+            const indice = (await db.get(INDEX_KEY)) || [];
+            const atualizado = indice.filter((item) => item.id !== id);
+            await db.put(atualizado, INDEX_KEY);
+            updateIndexList(atualizado);
+            if (appState.evento.id === id) {
+              appState.evento = createEmptyEvent();
+              appState.convitesAnalise = createConvitesAnalise();
+              setLastAction("Evento removido. Você está com um evento em branco.");
+            }
+            renderAll();
+            renderModal();
+            showToast("Evento excluído.", "info");
+            if (options.fecharApos) fecharModal();
+          } catch (error) {
+            console.error("Erro ao excluir", error);
+            showToast("Não foi possível excluir o evento.", "error");
+          }
+        }
+
+        function novoEvento() {
+          const possuiDados =
+            appState.evento.nome.trim() ||
+            appState.evento.local.trim() ||
+            appState.evento.mensagem.trim() ||
+            appState.evento.convidados.length;
+          if (possuiDados) {
+            const confirmar = window.confirm("Limpar o evento atual e começar um novo?");
+            if (!confirmar) return;
+          }
+          appState.evento = createEmptyEvent();
+          appState.convitesAnalise = createConvitesAnalise();
+          appState.lastAction = "Novo evento iniciado.";
+          renderAll();
+          showToast("Novo evento pronto para edição.", "info");
+          if (dom.nomeInput) dom.nomeInput.focus();
+        }
+
+        function exportarJSON() {
+          const data = JSON.stringify(appState.evento, null, 2);
+          const blob = new Blob([data], { type: "application/json" });
+          const url = URL.createObjectURL(blob);
+          const nomeArquivo = (appState.evento.nome || "evento").replace(/[^a-z0-9\-]/gi, "-").toLowerCase() || "evento";
+          const link = document.createElement("a");
+          link.href = url;
+          link.download = `${nomeArquivo}.json`;
+          document.body.appendChild(link);
+          link.click();
+          setTimeout(() => {
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+          }, 0);
+          showToast("JSON exportado com sucesso!", "success");
+        }
+
+        function limparLista() {
+          if (!appState.evento.convidados.length) return;
+          const confirmar = window.confirm("Deseja limpar todos os convidados deste evento?");
+          if (!confirmar) return;
+          appState.evento.convidados = [];
+          setLastAction("Lista de convidados limpa.");
+          renderConvidados();
+          renderResumo();
+        }
+
+        function removerConvidado(index) {
+          const removidos = appState.evento.convidados.splice(index, 1);
+          setLastAction(removidos.length ? `${removidos[0]} removido.` : "Convidado removido.");
+          renderConvidados();
+          renderResumo();
+        }
+
+        function atualizarConvitesBrutos(valor) {
+          appState.evento.convitesBrutos = valor;
+        }
+
+        function processarConvites(options = {}) {
+          const quiet = Boolean(options.quiet);
+          const texto =
+            typeof options.texto === "string"
+              ? options.texto
+              : dom.convitesTextarea
+              ? dom.convitesTextarea.value
+              : appState.evento.convitesBrutos || "";
+          if (!texto.trim()) {
+            if (!quiet) showToast("Cole ao menos uma linha para processar convites.", "error");
+            return [];
+          }
+          const { convites, analise } = analisarConvitesBrutos(texto);
+          appState.evento.convitesBrutos = texto;
+          appState.evento.convitesEstruturados = convites.map(mapConviteParaStorage);
+          appState.convitesAnalise = analise;
+          renderConvites();
+          if (quiet) {
+            renderResumo();
+          } else {
+            const mensagem = analise.processadas
+              ? `${analise.processadas} convite(s) estruturados${
+                  analise.ignoradas.length ? `; ${analise.ignoradas.length} linha(s) ignoradas.` : "."
+                }`
+              : "Não foi possível estruturar os convites. Revise as linhas destacadas.";
+            setLastAction(mensagem);
+            showToast(mensagem, analise.processadas ? "success" : "error");
+          }
+          return appState.evento.convitesEstruturados;
+        }
+
+        function limparConvites(options = {}) {
+          const quiet = Boolean(options.quiet);
+          const possuiDados =
+            (appState.evento.convitesBrutos && appState.evento.convitesBrutos.trim().length) ||
+            (appState.evento.convitesEstruturados && appState.evento.convitesEstruturados.length);
+          if (!possuiDados) {
+            if (dom.convitesTextarea) dom.convitesTextarea.value = "";
+            appState.evento.convitesBrutos = "";
+            appState.evento.convitesEstruturados = [];
+            appState.convitesAnalise = createConvitesAnalise();
+            renderConvites();
+            if (!quiet) showToast("Campo de convites já está vazio.", "info");
+            return;
+          }
+          if (!quiet) {
+            const confirmar = window.confirm("Deseja limpar os convites brutos e os resultados estruturados?");
+            if (!confirmar) return;
+          }
+          appState.evento.convitesBrutos = "";
+          appState.evento.convitesEstruturados = [];
+          appState.convitesAnalise = createConvitesAnalise();
+          if (dom.convitesTextarea) dom.convitesTextarea.value = "";
+          renderConvites();
+          if (quiet) {
+            renderResumo();
+          } else {
+            setLastAction("Convites limpos.");
+            showToast("Convites limpos.", "info");
+          }
+        }
+
+        function adicionarConvitesParaConvidados() {
+          const convites = Array.isArray(appState.evento.convitesEstruturados)
+            ? appState.evento.convitesEstruturados
+            : [];
+          if (!convites.length) {
+            showToast("Processe os convites antes de enviar os nomes para a lista.", "error");
+            if (dom.convitesTextarea) dom.convitesTextarea.focus();
+            return;
+          }
+          const nomes = [];
+          convites.forEach((convite) => {
+            if (convite.titular) nomes.push(convite.titular);
+            if (Array.isArray(convite.acompanhantes)) {
+              convite.acompanhantes.forEach((nome) => nomes.push(nome));
+            }
+          });
+          if (!nomes.length) {
+            showToast("Nenhum nome identificado nos convites processados.", "info");
+            return;
+          }
+          const existentes = new Set(appState.evento.convidados.map((nome) => nome.toLocaleLowerCase("pt-BR")));
+          const novos = [];
+          nomes.forEach((nome) => {
+            const formatado = toTitleCase(nome);
+            const chave = formatado.toLocaleLowerCase("pt-BR");
+            if (!existentes.has(chave)) {
+              existentes.add(chave);
+              novos.push(formatado);
+            }
+          });
+          if (!novos.length) {
+            showToast("Nenhum novo nome para adicionar.", "info");
+            return;
+          }
+          appState.evento.convidados = [...appState.evento.convidados, ...novos];
+          renderConvidados();
+          setLastAction(`${novos.length} nome(s) adicionados a partir dos convites.`);
+          showToast(`${novos.length} nome(s) adicionados à lista de convidados.`, "success");
+        }
+
+        function adicionarConvidados() {
+          const texto = dom.convidadosTextarea ? dom.convidadosTextarea.value : "";
+          if (!texto.trim()) {
+            showToast("Digite ou cole pelo menos um nome para adicionar.", "error");
+            return;
+          }
+          const novos = normalizeLista(texto, appState.evento.convidados);
+          if (!novos.length) {
+            showToast("Nenhum novo convidado para adicionar.", "info");
+            return;
+          }
+          appState.evento.convidados = [...appState.evento.convidados, ...novos];
+          if (dom.convidadosTextarea) dom.convidadosTextarea.value = "";
+          setLastAction(`${novos.length} convidado(s) adicionados.`);
+          renderConvidados();
+          renderResumo();
+        }
+
+        function atualizarCampoEvento(campo, valor) {
+          appState.evento = { ...appState.evento, [campo]: valor };
+          renderResumo();
+          updateMenuState();
+        }
+
+        function atualizarConvidado(index, valor, input) {
+          const atual = appState.evento.convidados[index];
+          const nome = toTitleCase(valor.trim());
+          if (!nome) {
+            const confirmar = window.confirm("Remover este convidado vazio?");
+            if (confirmar) {
+              removerConvidado(index);
+            } else if (input) {
+              input.value = atual;
+            }
+            return;
+          }
+          const lower = nome.toLocaleLowerCase("pt-BR");
+          const existe = appState.evento.convidados.some((item, idx) => idx !== index && item.toLocaleLowerCase("pt-BR") === lower);
+          if (existe) {
+            showToast("Este nome já está na lista.", "error");
+            if (input) input.value = atual;
+            return;
+          }
+          if (nome !== atual) {
+            appState.evento.convidados[index] = nome;
+            setLastAction(`Convidado ${index + 1} atualizado.`);
+            renderConvidados();
+            renderResumo();
+          } else if (input) {
+            input.value = atual;
+          }
+        }
+
+        function onMenuClick(event) {
+          const target = event.target.closest("button[data-action]");
+          if (!target) return;
+          const action = target.dataset.action;
+          switch (action) {
+            case "novo":
+              novoEvento();
+              break;
+            case "salvar":
+              salvarEvento();
+              break;
+            case "carregar":
+              abrirModalCarregar();
+              break;
+            case "excluir":
+              if (appState.evento.id) excluirEvento(appState.evento.id);
+              break;
+            case "exportar":
+              exportarJSON();
+              break;
+            default:
+              break;
+          }
+        }
+
+        function onConvitesActionClick(event) {
+          const target = event.target.closest("button[data-action]");
+          if (!target) return;
+          const action = target.dataset.action;
+          if (action === "processar-convites") {
+            processarConvites();
+          } else if (action === "limpar-convites") {
+            limparConvites();
+          } else if (action === "convites-para-convidados") {
+            adicionarConvitesParaConvidados();
+          }
+        }
+
+        function onConvidadosActionClick(event) {
+          const target = event.target.closest("button[data-action]");
+          if (!target) return;
+          const action = target.dataset.action;
+          if (action === "adicionar-convidados") {
+            adicionarConvidados();
+          } else if (action === "limpar-lista") {
+            limparLista();
+          }
+        }
+
+        function onGuestListClick(event) {
+          const target = event.target.closest("button[data-action='remover-convidado']");
+          if (!target) return;
+          const index = Number.parseInt(target.dataset.guestIndex || "", 10);
+          if (Number.isNaN(index)) return;
+          removerConvidado(index);
+        }
+
+        function onGuestListKeydown(event) {
+          if (event.key === "Enter" && event.target instanceof HTMLInputElement) {
+            event.preventDefault();
+            event.target.blur();
+          }
+        }
+
+        function onGuestListFocusOut(event) {
+          if (!(event.target instanceof HTMLInputElement)) return;
+          if (!event.target.dataset.guestIndex) return;
+          const index = Number.parseInt(event.target.dataset.guestIndex, 10);
+          if (Number.isNaN(index)) return;
+          atualizarConvidado(index, event.target.value, event.target);
+        }
+
+        function bindInputs() {
+          if (dom.nomeInput) dom.nomeInput.addEventListener("input", (event) => atualizarCampoEvento("nome", event.target.value));
+          if (dom.dataInput) dom.dataInput.addEventListener("input", (event) => atualizarCampoEvento("dataISO", event.target.value));
+          if (dom.localInput) dom.localInput.addEventListener("input", (event) => atualizarCampoEvento("local", event.target.value));
+          if (dom.mensagemInput)
+            dom.mensagemInput.addEventListener("input", (event) => atualizarCampoEvento("mensagem", event.target.value));
+        }
+
+        function bindUI() {
+          if (dom.menu) dom.menu.addEventListener("click", onMenuClick);
+          if (dom.convitesActions) dom.convitesActions.addEventListener("click", onConvitesActionClick);
+          if (dom.convidadosActions) dom.convidadosActions.addEventListener("click", onConvidadosActionClick);
+          if (dom.convidadosList) {
+            dom.convidadosList.addEventListener("click", onGuestListClick);
+            dom.convidadosList.addEventListener("keydown", onGuestListKeydown);
+            dom.convidadosList.addEventListener("focusout", onGuestListFocusOut);
+          }
+          if (dom.convitesTextarea) {
+            dom.convitesTextarea.addEventListener("input", (event) => atualizarConvitesBrutos(event.target.value));
+            dom.convitesTextarea.addEventListener("keydown", (event) => {
+              if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+                event.preventDefault();
+                processarConvites();
+              }
+            });
+          }
+          if (dom.convidadosTextarea) {
+            dom.convidadosTextarea.addEventListener("keydown", (event) => {
+              if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+                event.preventDefault();
+                adicionarConvidados();
+              }
+            });
+          }
+          bindInputs();
+        }
+
+        // [init]
+        async function init() {
+          bindUI();
+          renderAll();
+          if (appState.hasIndexedDB) {
+            await carregarIndice();
+          } else {
+            renderDadosEvento();
+            showToast("IndexedDB indisponível. Recursos de salvar/carregar estão desativados.", "error");
+          }
+        }
+
+        init();
+      })();
+    </script>
+  </body>
+</html>

--- a/shared/invite-processor.html
+++ b/shared/invite-processor.html
@@ -1,0 +1,773 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ferramenta – Processador de Convites</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
+        background: #f6f6f6;
+        color: #141414;
+      }
+
+      .ip-app,
+      .ip-app * {
+        box-sizing: border-box;
+      }
+
+      .ip-app {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 40px 20px 64px;
+      }
+
+      .ip-header {
+        background: #111;
+        color: #fff;
+        border-radius: 24px;
+        padding: 28px;
+        margin-bottom: 24px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .ip-header::before,
+      .ip-header::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 10px;
+        background-image: repeating-linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.36) 0,
+          rgba(255, 255, 255, 0.36) 6px,
+          transparent 6px,
+          transparent 12px
+        );
+        pointer-events: none;
+      }
+
+      .ip-header::before {
+        left: 0;
+      }
+
+      .ip-header::after {
+        right: 0;
+      }
+
+      .ip-header__top {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        gap: 20px;
+      }
+
+      .ip-title {
+        margin: 0;
+        font-size: clamp(1.6rem, 2vw + 1rem, 2.6rem);
+        letter-spacing: -0.01em;
+      }
+
+      .ip-description {
+        margin: 6px 0 0;
+        font-size: 1rem;
+        color: rgba(255, 255, 255, 0.75);
+        max-width: 560px;
+      }
+
+      .ip-actions {
+        margin-left: auto;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .ip-button {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        padding: 10px 18px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.1s ease;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.95rem;
+      }
+
+      .ip-button[data-variant="primary"] {
+        background: #f8f8f8;
+        color: #111;
+      }
+
+      .ip-button[data-variant="primary"]:hover,
+      .ip-button[data-variant="primary"]:focus-visible {
+        background: #fff;
+        outline: none;
+      }
+
+      .ip-button[data-variant="ghost"] {
+        background: rgba(255, 255, 255, 0.16);
+        color: #fff;
+        border: 1px solid rgba(255, 255, 255, 0.24);
+      }
+
+      .ip-button[data-variant="ghost"]:hover,
+      .ip-button[data-variant="ghost"]:focus-visible {
+        background: rgba(255, 255, 255, 0.28);
+        outline: none;
+      }
+
+      .ip-button:active {
+        transform: translateY(1px);
+      }
+
+      .ip-main {
+        display: grid;
+        gap: 18px;
+      }
+
+      .ip-card {
+        background: #fff;
+        border-radius: 24px;
+        padding: 28px;
+        position: relative;
+        box-shadow: 0 18px 40px rgba(17, 17, 17, 0.08);
+        overflow: hidden;
+      }
+
+      .ip-card::before,
+      .ip-card::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 12px;
+        background-image: repeating-linear-gradient(
+          180deg,
+          rgba(17, 17, 17, 0.18) 0,
+          rgba(17, 17, 17, 0.18) 6px,
+          transparent 6px,
+          transparent 12px
+        );
+        pointer-events: none;
+      }
+
+      .ip-card::before {
+        left: 0;
+      }
+
+      .ip-card::after {
+        right: 0;
+      }
+
+      .ip-card__title {
+        margin: 0 0 16px;
+        font-size: 1.3rem;
+        letter-spacing: -0.01em;
+      }
+
+      .ip-card__subtitle {
+        margin: 0 0 24px;
+        font-size: 0.95rem;
+        color: #4c4c4c;
+      }
+
+      .ip-field {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        margin-bottom: 16px;
+      }
+
+      .ip-label {
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: #2a2a2a;
+      }
+
+      .ip-textarea {
+        width: 100%;
+        min-height: 200px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        border: 1px solid rgba(17, 17, 17, 0.16);
+        font: inherit;
+        resize: vertical;
+        background: rgba(17, 17, 17, 0.02);
+      }
+
+      .ip-helper {
+        font-size: 0.9rem;
+        color: #5a5a5a;
+      }
+
+      .ip-helper strong {
+        font-weight: 600;
+      }
+
+      .ip-stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+      }
+
+      .ip-stat {
+        border-radius: 16px;
+        padding: 16px;
+        border: 1px solid rgba(17, 17, 17, 0.12);
+        background: rgba(17, 17, 17, 0.03);
+      }
+
+      .ip-stat__label {
+        display: block;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #6a6a6a;
+        margin-bottom: 6px;
+      }
+
+      .ip-stat__value {
+        font-size: 1.35rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
+      .ip-issues {
+        margin-top: 12px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        background: rgba(251, 191, 36, 0.16);
+        border: 1px solid rgba(217, 119, 6, 0.4);
+        color: #7c2d12;
+      }
+
+      .ip-issues__title {
+        margin: 0 0 8px;
+        font-weight: 700;
+        font-size: 1rem;
+      }
+
+      .ip-issues__list {
+        margin: 0;
+        padding-left: 20px;
+        font-size: 0.95rem;
+      }
+
+      .ip-table-wrap {
+        margin-top: 12px;
+        border-radius: 18px;
+        border: 1px solid rgba(17, 17, 17, 0.08);
+        overflow: hidden;
+      }
+
+      .ip-table-scroll {
+        overflow-x: auto;
+      }
+
+      table.ip-table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 720px;
+      }
+
+      .ip-table th,
+      .ip-table td {
+        padding: 12px 14px;
+        border-bottom: 1px solid rgba(17, 17, 17, 0.08);
+        text-align: left;
+        vertical-align: top;
+        font-size: 0.95rem;
+      }
+
+      .ip-table thead th {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #6a6a6a;
+        background: rgba(17, 17, 17, 0.04);
+      }
+
+      .ip-table tbody tr:nth-child(even) {
+        background: rgba(17, 17, 17, 0.02);
+      }
+
+      .ip-table tbody tr.ip-row--alert td,
+      .ip-table tbody tr.ip-row--alert th {
+        background: rgba(239, 68, 68, 0.08);
+      }
+
+      .ip-tag {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: rgba(239, 68, 68, 0.14);
+        color: #991b1b;
+        font-size: 0.75rem;
+        font-weight: 600;
+        margin: 0 6px 6px 0;
+      }
+
+      .ip-empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #5a5a5a;
+      }
+
+      .ip-toast {
+        position: fixed;
+        bottom: 24px;
+        right: 24px;
+        max-width: 320px;
+        padding: 14px 18px;
+        border-radius: 16px;
+        box-shadow: 0 16px 40px rgba(17, 17, 17, 0.22);
+        background: #111;
+        color: #fff;
+        font-size: 0.95rem;
+        opacity: 0;
+        transform: translateY(12px);
+        transition: opacity 0.25s ease, transform 0.25s ease;
+        z-index: 40;
+      }
+
+      .ip-toast[data-visible="true"] {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .ip-toast[data-variant="warning"] {
+        background: #f97316;
+      }
+
+      .ip-toast[data-variant="success"] {
+        background: #15803d;
+      }
+
+      @media (max-width: 720px) {
+        .ip-actions {
+          width: 100%;
+          justify-content: flex-start;
+        }
+        .ip-button {
+          flex: 1 1 auto;
+        }
+        .ip-table {
+          min-width: 600px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="ip-app">
+      <header class="ip-header">
+        <div class="ip-header__top">
+          <div>
+            <h1 class="ip-title">Processador de Convites</h1>
+            <p class="ip-description">
+              Cole convites bagunçados, normalize telefones e gere uma lista estruturada em segundos. Ideal para fluxos de RSVP
+              sem back-end.
+            </p>
+          </div>
+          <div class="ip-actions" data-role="actions">
+            <button type="button" class="ip-button" data-variant="primary" data-action="processar">Processar convites</button>
+            <button type="button" class="ip-button" data-variant="ghost" data-action="limpar">Limpar</button>
+            <button type="button" class="ip-button" data-variant="ghost" data-action="copiar-csv">Copiar CSV</button>
+            <button type="button" class="ip-button" data-variant="ghost" data-action="copiar-nomes">Copiar nomes</button>
+            <button type="button" class="ip-button" data-variant="ghost" data-action="baixar-json">Baixar JSON</button>
+          </div>
+        </div>
+      </header>
+
+      <main class="ip-main">
+        <section class="ip-card" aria-labelledby="ip-input-title">
+          <h2 class="ip-card__title" id="ip-input-title">Entrada rápida</h2>
+          <p class="ip-card__subtitle">
+            Cada linha representa um convite. O algoritmo entende telefones com ou sem código do país, convidados adicionais e
+            evita duplicados automaticamente.
+          </p>
+          <div class="ip-field">
+            <label class="ip-label" for="ip-textarea">Convites brutos</label>
+            <textarea
+              id="ip-textarea"
+              class="ip-textarea"
+              spellcheck="false"
+              placeholder="Maria Silva, João - (41) 98888-0000&#10;Pedro - 41 97777-1111 - Ana e Lucas&#10;..."
+            ></textarea>
+            <p class="ip-helper">
+              Exemplos aceitos: <strong>"Fabio 41 99999-0000 Lud e Leo"</strong>, <strong>"Marina, Gustavo - +55 11 98888-7766"</strong>,
+              <strong>"Roberta / Daniel 21 99999 0000"</strong>.
+            </p>
+          </div>
+        </section>
+
+        <section class="ip-card" aria-labelledby="ip-summary-title">
+          <h2 class="ip-card__title" id="ip-summary-title">Resumo</h2>
+          <div class="ip-stats" data-role="stats"></div>
+          <p class="ip-empty" data-role="stats-empty">Nenhum dado processado ainda.</p>
+          <div class="ip-issues" data-role="issues" hidden>
+            <h3 class="ip-issues__title">Linhas com alertas</h3>
+            <ul class="ip-issues__list" data-role="issues-list"></ul>
+          </div>
+        </section>
+
+        <section class="ip-card" aria-labelledby="ip-table-title">
+          <h2 class="ip-card__title" id="ip-table-title">Convites estruturados</h2>
+          <p class="ip-card__subtitle">Revise titulares, acompanhantes, telefones e avisos gerados automaticamente.</p>
+          <div class="ip-table-wrap" data-role="table-wrap" hidden>
+            <div class="ip-table-scroll">
+              <table class="ip-table" aria-describedby="ip-table-title">
+                <thead>
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Titular</th>
+                    <th scope="col">Acompanhantes</th>
+                    <th scope="col">Telefone</th>
+                    <th scope="col">Total</th>
+                    <th scope="col">Avisos</th>
+                  </tr>
+                </thead>
+                <tbody data-role="table-body"></tbody>
+              </table>
+            </div>
+          </div>
+          <p class="ip-empty" data-role="table-empty">Processar os convites para ver a tabela.</p>
+        </section>
+      </main>
+    </div>
+
+    <div class="ip-toast" role="status" aria-live="polite" data-role="toast"></div>
+
+    <script type="module">
+      import {
+        analyzeInvites,
+        invitesToCSV,
+        invitesToJSON,
+        createEmptyAnalysis,
+      } from "./inviteProcessor.js";
+
+      const dom = {
+        textarea: document.getElementById("ip-textarea"),
+        actions: document.querySelector("[data-role=\"actions\"]"),
+        stats: document.querySelector("[data-role=\"stats\"]"),
+        statsEmpty: document.querySelector("[data-role=\"stats-empty\"]"),
+        issues: document.querySelector("[data-role=\"issues\"]"),
+        issuesList: document.querySelector("[data-role=\"issues-list\"]"),
+        tableWrap: document.querySelector("[data-role=\"table-wrap\"]"),
+        tableBody: document.querySelector("[data-role=\"table-body\"]"),
+        tableEmpty: document.querySelector("[data-role=\"table-empty\"]"),
+        toast: document.querySelector("[data-role=\"toast\"]"),
+      };
+
+      const state = {
+        raw: "",
+        convites: [],
+        analise: createEmptyAnalysis(),
+      };
+
+      let toastTimer = null;
+
+      function escapeHtml(value) {
+        const text = value == null ? "" : String(value);
+        return text.replace(/[&<>"']/g, (char) => {
+          switch (char) {
+            case "&":
+              return "&amp;";
+            case "<":
+              return "&lt;";
+            case ">":
+              return "&gt;";
+            case '"':
+              return "&quot;";
+            case "'":
+              return "&#39;";
+            default:
+              return char;
+          }
+        });
+      }
+
+      function showToast(message, variant = "default") {
+        if (!dom.toast) return;
+        dom.toast.textContent = message;
+        dom.toast.dataset.variant = variant;
+        dom.toast.dataset.visible = "true";
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => {
+          dom.toast.dataset.visible = "false";
+          toastTimer = setTimeout(() => {
+            dom.toast.textContent = "";
+          }, 260);
+        }, 3200);
+      }
+
+      function copyToClipboard(text) {
+        if (!text) return Promise.reject(new Error("Nada para copiar"));
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          return navigator.clipboard.writeText(text);
+        }
+        return new Promise((resolve, reject) => {
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.setAttribute("readonly", "true");
+          textarea.style.position = "absolute";
+          textarea.style.left = "-9999px";
+          document.body.appendChild(textarea);
+          textarea.select();
+          try {
+            document.execCommand("copy");
+            resolve();
+          } catch (err) {
+            reject(err);
+          } finally {
+            document.body.removeChild(textarea);
+          }
+        });
+      }
+
+      function downloadFile(content, filename, type) {
+        const blob = new Blob([content], { type });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
+
+      function getAllNames(invites = []) {
+        const names = [];
+        invites.forEach((invite) => {
+          if (invite.titular) names.push(invite.titular);
+          if (Array.isArray(invite.acompanhantes)) {
+            invite.acompanhantes.forEach((nome) => names.push(nome));
+          }
+        });
+        return names.join("\n");
+      }
+
+      function renderStats() {
+        if (!dom.stats) return;
+        const { analise, convites } = state;
+        const totalPessoas = convites.reduce((acc, convite) => acc + (Number.isFinite(Number(convite.total)) ? Number(convite.total) : 1), 0);
+        const comTelefone = convites.filter((convite) => Boolean(convite.telefone)).length;
+        const items = [
+          { label: "Linhas informadas", value: analise.totalLinhas },
+          { label: "Convites válidos", value: analise.processadas },
+          { label: "Ignoradas", value: analise.ignoradas.length },
+          { label: "Duplicadas", value: analise.duplicadas.length },
+          { label: "Sem telefone", value: analise.semTelefone },
+          { label: "Com telefone", value: comTelefone },
+          { label: "Total estimado de pessoas", value: totalPessoas },
+        ];
+
+        const hasData = analise.totalLinhas > 0 || convites.length > 0;
+        dom.stats.hidden = !hasData;
+        dom.statsEmpty.hidden = hasData;
+
+        if (!hasData) return;
+
+        dom.stats.innerHTML = items
+          .map(
+            (item) => `
+              <div class="ip-stat">
+                <span class="ip-stat__label">${escapeHtml(item.label)}</span>
+                <span class="ip-stat__value">${escapeHtml(String(item.value ?? "0"))}</span>
+              </div>
+            `
+          )
+          .join("");
+      }
+
+      function renderIssues() {
+        if (!dom.issues || !dom.issuesList) return;
+        const { analise } = state;
+        const entries = [];
+
+        analise.ignoradas.forEach((item) => {
+          entries.push(`Linha ${item.linha}: ${escapeHtml(item.conteudo)}`);
+        });
+        analise.duplicadas.forEach((item) => {
+          entries.push(`Duplicado na linha ${item.linha}: ${escapeHtml(item.titular)}`);
+        });
+
+        if (!entries.length) {
+          dom.issues.hidden = true;
+          dom.issuesList.innerHTML = "";
+          return;
+        }
+
+        dom.issues.hidden = false;
+        dom.issuesList.innerHTML = entries.map((entry) => `<li>${entry}</li>`).join("");
+      }
+
+      function renderTable() {
+        if (!dom.tableBody || !dom.tableWrap || !dom.tableEmpty) return;
+        const { convites } = state;
+
+        if (!convites.length) {
+          dom.tableWrap.hidden = true;
+          dom.tableEmpty.hidden = false;
+          dom.tableBody.innerHTML = "";
+          return;
+        }
+
+        dom.tableWrap.hidden = false;
+        dom.tableEmpty.hidden = true;
+
+        dom.tableBody.innerHTML = convites
+          .map((convite, index) => {
+            const acompanhantes = convite.acompanhantes?.length
+              ? convite.acompanhantes.map((nome) => `<div>${escapeHtml(nome)}</div>`).join("")
+              : "—";
+            const avisos = convite.avisos?.length
+              ? convite.avisos.map((aviso) => `<span class=\"ip-tag\">${escapeHtml(aviso)}</span>`).join("")
+              : "—";
+            const telefone = convite.telefone ? escapeHtml(convite.telefone) : "—";
+            const classes = convite.avisos?.length ? "ip-row--alert" : "";
+            return `
+              <tr class="${classes}">
+                <th scope="row">${index + 1}</th>
+                <td>
+                  <div>${escapeHtml(convite.titular || "—")}</div>
+                  <small style="display:block;color:#6b7280;font-size:0.8rem;">Linha ${convite.linha ?? "—"}</small>
+                </td>
+                <td>${acompanhantes}</td>
+                <td>${telefone}</td>
+                <td>${escapeHtml(String(convite.total ?? "—"))}</td>
+                <td>${avisos}</td>
+              </tr>
+            `;
+          })
+          .join("");
+      }
+
+      function renderAll() {
+        renderStats();
+        renderIssues();
+        renderTable();
+      }
+
+      function processInput() {
+        const raw = dom.textarea.value || "";
+        state.raw = raw;
+        if (!raw.trim()) {
+          state.convites = [];
+          state.analise = createEmptyAnalysis();
+          renderAll();
+          showToast("Cole algumas linhas antes de processar.", "warning");
+          return;
+        }
+
+        const { convites, analise } = analyzeInvites(raw);
+        state.convites = convites;
+        state.analise = analise;
+        renderAll();
+        showToast(`Processamos ${convites.length} convite(s).`, "success");
+      }
+
+      function clearAll() {
+        dom.textarea.value = "";
+        state.raw = "";
+        state.convites = [];
+        state.analise = createEmptyAnalysis();
+        renderAll();
+        showToast("Entrada limpa.", "default");
+      }
+
+      async function handleCopyCSV() {
+        if (!state.convites.length) {
+          showToast("Nada para copiar. Procese os convites primeiro.", "warning");
+          return;
+        }
+        try {
+          const csv = invitesToCSV(state.convites);
+          await copyToClipboard(csv);
+          showToast("CSV copiado com sucesso!", "success");
+        } catch (err) {
+          showToast("Não foi possível copiar o CSV.", "warning");
+        }
+      }
+
+      async function handleCopyNames() {
+        if (!state.convites.length) {
+          showToast("Nada para copiar. Procese os convites primeiro.", "warning");
+          return;
+        }
+        try {
+          const names = getAllNames(state.convites);
+          await copyToClipboard(names);
+          showToast("Lista de nomes copiada!", "success");
+        } catch (err) {
+          showToast("Não foi possível copiar os nomes.", "warning");
+        }
+      }
+
+      function handleDownloadJSON() {
+        if (!state.convites.length) {
+          showToast("Nada para exportar. Procese os convites primeiro.", "warning");
+          return;
+        }
+        const json = invitesToJSON(state.convites);
+        const stamp = new Date().toISOString().slice(0, 10);
+        downloadFile(json, `convites-estruturados-${stamp}.json`, "application/json");
+        showToast("JSON baixado!", "success");
+      }
+
+      function handleAction(event) {
+        const button = event.target.closest("[data-action]");
+        if (!button) return;
+        const { action } = button.dataset;
+        switch (action) {
+          case "processar":
+            processInput();
+            break;
+          case "limpar":
+            clearAll();
+            break;
+          case "copiar-csv":
+            handleCopyCSV();
+            break;
+          case "copiar-nomes":
+            handleCopyNames();
+            break;
+          case "baixar-json":
+            handleDownloadJSON();
+            break;
+          default:
+            break;
+        }
+      }
+
+      function bindEvents() {
+        dom.actions?.addEventListener("click", handleAction);
+        dom.textarea?.addEventListener("keydown", (event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            event.preventDefault();
+            processInput();
+          }
+        });
+      }
+
+      function init() {
+        renderAll();
+        bindEvents();
+      }
+
+      init();
+    </script>
+  </body>
+</html>

--- a/shared/inviteProcessor.js
+++ b/shared/inviteProcessor.js
@@ -1,0 +1,235 @@
+// shared/inviteProcessor.js
+// Utilitário para analisar convites em texto livre e gerar estrutura padronizada.
+// Pode ser utilizado em apps Vanilla ou embutido em widgets Elementor.
+
+const PREPOSITIONS = new Set(["de", "da", "das", "do", "dos", "e", "ou"]);
+const PHONE_REGEX = /(?:\+?\d[\d\s().-]{6,}\d)/g;
+
+function createId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `invite-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createEmptyAnalysis() {
+  return {
+    totalLinhas: 0,
+    processadas: 0,
+    ignoradas: [],
+    duplicadas: [],
+    semTelefone: 0,
+  };
+}
+
+function digitsOnly(value = "") {
+  return String(value).replace(/\D/g, "");
+}
+
+export function normalizePhoneNumber(value = "") {
+  let digits = digitsOnly(value);
+  if (digits.length > 11) digits = digits.slice(-11);
+  if (digits.length < 10) return null;
+  return digits.length === 10
+    ? `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`
+    : `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+}
+
+export function toTitleCase(nome) {
+  if (!nome) return "";
+  const palavras = nome
+    .trim()
+    .split(/\s+/)
+    .map((palavra, indexPalavra) => {
+      const partes = palavra.split(/([-'])/).filter(Boolean);
+      return partes
+        .map((parte) => {
+          if (parte === "-" || parte === "'") return parte;
+          const lower = parte.toLocaleLowerCase("pt-BR");
+          const shouldKeepLower = indexPalavra > 0 && PREPOSITIONS.has(lower);
+          if (shouldKeepLower) return lower;
+          return lower.charAt(0).toLocaleUpperCase("pt-BR") + lower.slice(1);
+        })
+        .join("");
+    });
+  return palavras.join(" ");
+}
+
+function stripInviteNoise(text = "") {
+  return String(text)
+    .normalize("NFKC")
+    .replace(PHONE_REGEX, " ")
+    .replace(/\d{2,}/g, " ")
+    .replace(/[()._]+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+export function normalizeInviteName(value = "") {
+  const cleaned = stripInviteNoise(value);
+  if (!cleaned) return "";
+  return toTitleCase(cleaned);
+}
+
+function extractNamesSegment(segment = "") {
+  return String(segment)
+    .split(/[,;|/]+|\s+(?:e|&|com|\+|e\/ou)\s+/gi)
+    .map((parte) => normalizeInviteName(parte))
+    .filter(Boolean);
+}
+
+export function uniqueCaseInsensitive(list = []) {
+  const seen = new Set();
+  const result = [];
+  for (const item of list) {
+    const value = String(item || "").trim();
+    if (!value) continue;
+    const key = value.toLocaleLowerCase("pt-BR");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(value);
+  }
+  return result;
+}
+
+function extractPhoneFromLine(line = "") {
+  const matches = String(line).match(PHONE_REGEX) || [];
+  let best = null;
+  let bestDigits = "";
+  for (const candidate of matches) {
+    const candidateDigits = digitsOnly(candidate);
+    if (candidateDigits.length > bestDigits.length) {
+      best = candidate;
+      bestDigits = candidateDigits;
+    }
+  }
+  const telefone = best ? normalizePhoneNumber(best) : null;
+  const semTelefone = best ? String(line).replace(best, " ") : String(line).replace(PHONE_REGEX, " ");
+  return { semTelefone, telefone, digits: bestDigits };
+}
+
+export function parseInviteLine(linha = "") {
+  const original = String(linha).trim();
+  if (!original) return null;
+
+  const { semTelefone, telefone, digits } = extractPhoneFromLine(original);
+  const rawParts = semTelefone
+    .split(/[,;|]+|\s+-\s+|\s+–\s+/g)
+    .map((parte) => parte.trim())
+    .filter(Boolean);
+
+  const parts = rawParts.length ? rawParts : [semTelefone.trim() || original];
+  const titularSegment = parts[0] || "";
+  const titularTokens = extractNamesSegment(titularSegment);
+  const titular = titularTokens.length ? titularTokens[0] : normalizeInviteName(titularSegment);
+  const restanteTokens = parts.slice(1).flatMap((parte) => extractNamesSegment(parte));
+  const acompanhantes = uniqueCaseInsensitive([...titularTokens.slice(1), ...restanteTokens]);
+  const total = Math.max(1, 1 + acompanhantes.length);
+  const avisos = [];
+
+  if (!titular) {
+    avisos.push("Titular não identificado");
+  }
+  if (!telefone) {
+    if (digits && digits.length) {
+      avisos.push("Telefone incompleto");
+    } else {
+      avisos.push("Sem telefone");
+    }
+  }
+
+  return {
+    id: createId(),
+    linha: null,
+    linhaOriginal: original,
+    titular,
+    acompanhantes,
+    telefone,
+    total,
+    avisos: uniqueCaseInsensitive(avisos),
+  };
+}
+
+export function analyzeInvites(text = "") {
+  const linhas = String(text).replace(/\r\n?/g, "\n").split("\n");
+  const convites = [];
+  const ignoradas = [];
+  const duplicadas = [];
+  const vistos = new Map();
+  let semTelefone = 0;
+  let totalLinhas = 0;
+
+  linhas.forEach((linha, index) => {
+    const raw = linha.trim();
+    if (!raw) return;
+    totalLinhas += 1;
+    const convite = parseInviteLine(raw);
+    if (!convite || !convite.titular) {
+      ignoradas.push({ linha: index + 1, conteudo: raw });
+      return;
+    }
+
+    convite.linha = index + 1;
+    if (!convite.telefone) semTelefone += 1;
+
+    const chave = convite.titular.toLocaleLowerCase("pt-BR");
+    if (vistos.has(chave)) {
+      if (!convite.avisos.includes("Duplicado")) {
+        convite.avisos.push("Duplicado");
+      }
+      duplicadas.push({ linha: index + 1, titular: convite.titular, conteudo: raw });
+    } else {
+      vistos.set(chave, true);
+    }
+
+    convite.avisos = uniqueCaseInsensitive(convite.avisos);
+    convites.push(convite);
+  });
+
+  return {
+    convites,
+    analise: {
+      totalLinhas,
+      processadas: convites.length,
+      ignoradas,
+      duplicadas,
+      semTelefone,
+    },
+  };
+}
+
+export function invitesToCSV(invites = []) {
+  const esc = (s) => `"${String(s ?? "").replace(/"/g, '""')}"`;
+  const header = "seq,titular,acompanhantes,telefone,total,avisos";
+  const rows = invites.map((invite, index) => {
+    const acompanhantes = invite.acompanhantes?.length ? invite.acompanhantes.join(" + ") : "";
+    const avisos = invite.avisos?.length ? invite.avisos.join(" | ") : "";
+    return [
+      index + 1,
+      invite.titular || "",
+      acompanhantes,
+      invite.telefone || "",
+      invite.total ?? "",
+      avisos,
+    ]
+      .map(esc)
+      .join(",");
+  });
+  return [header, ...rows].join("\n");
+}
+
+export function invitesToJSON(invites = []) {
+  return JSON.stringify(invites, null, 2);
+}
+
+export default {
+  analyzeInvites,
+  parseInviteLine,
+  invitesToCSV,
+  invitesToJSON,
+  normalizeInviteName,
+  normalizePhoneNumber,
+  toTitleCase,
+  uniqueCaseInsensitive,
+  createEmptyAnalysis,
+};


### PR DESCRIPTION
## Summary
- create a standalone invite processor HTML tool in the shared folder with scoped styling, actions, stats, and table output
- add a reusable inviteProcessor module for parsing free-form invite lines, generating analysis, and exporting CSV/JSON

## Testing
- Not Run (static HTML/JS change)

------
https://chatgpt.com/codex/tasks/task_e_68d4155de1e8832085825b71d3b4b2a6