### PR TITLE
Add shared list helpers and CDN compatibility fixes

### DIFF
--- a/shared/LOG.md
+++ b/shared/LOG.md
@@ -6,3 +6,7 @@
 
 ## 2024-04-09
 - Extraído utilitários de normalização de nomes para `listUtils.js` para consumo compartilhado.
+
+## 2025-10-04
+- Reimplementadas `normalizeName` e `stripNumbersFromName` em `listUtils.js` usando exports ESM nomeados.
+- Adicionada camada de compatibilidade `higienizarLista.mjs` reexportando os novos utilitários e expondo `deriveTelefone`.

--- a/shared/README.md
+++ b/shared/README.md
@@ -6,7 +6,8 @@ Esta pasta contém os módulos compartilhados utilizados pelos widgets da ferram
 - `marcoBus.js`: barramento de eventos para comunicação entre widgets.
 - `projectStore.js`: camada de persistência e sincronização de projetos.
 - `inviteUtils.js`: utilitários usados por múltiplos widgets.
-- `listUtils.js`: helpers de normalização de nomes utilizados pelo módulo de convites.
+- `listUtils.js`: funções `normalizeName` e `stripNumbersFromName` para tratar nomes antes da criação dos convites.
+- `higienizarLista.mjs`: camada de compatibilidade que reexporta os utilitários de nomes e provê `deriveTelefone`.
 - `gestaoEventosApp.css`: estilos globais reutilizados.
 
 ## Boas práticas

--- a/shared/higienizarLista.mjs
+++ b/shared/higienizarLista.mjs
@@ -1,0 +1,65 @@
+// shared/higienizarLista.mjs
+// Compat layer para módulos que dependiam de higienização de listas no formato antigo.
+// Reexporta utilitários de nomes e expõe deriveTelefone usado pelo mini-app de fornecedores.
+
+import { normalizeName, stripNumbersFromName } from "./listUtils.js";
+
+const COUNTRY_CODE = "55";
+
+function onlyDigits(value = "") {
+  return String(value ?? "").replace(/\D/g, "");
+}
+
+function trimBrazilDigits(digits = "") {
+  if (!digits) return "";
+  if (digits.startsWith(COUNTRY_CODE) && digits.length > 11) {
+    return digits.slice(-11);
+  }
+  if (digits.length > 11) {
+    return digits.slice(-11);
+  }
+  return digits;
+}
+
+function formatNational(digits = "") {
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+  if (digits.length === 11) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+  }
+  return "";
+}
+
+/**
+ * Deriva representações nacionais e E.164 a partir de possíveis números brasileiros.
+ * Prioriza candidatos com maior quantidade de dígitos válidos.
+ * @param {{ possiveisNumeros?: string[] }} [input]
+ * @returns {{ e164: string, nacional: string, tipo: 'fixo'|'celular'|null }|null}
+ */
+export function deriveTelefone(input = {}) {
+  const candidatos = Array.isArray(input?.possiveisNumeros) ? input.possiveisNumeros : [];
+  let melhor = null;
+  for (const candidato of candidatos) {
+    const somenteDigitos = trimBrazilDigits(onlyDigits(candidato));
+    if (somenteDigitos.length < 10) continue;
+    if (!melhor || somenteDigitos.length > melhor.digitos.length) {
+      melhor = { original: candidato, digitos: somenteDigitos };
+    }
+  }
+  if (!melhor) return null;
+
+  const digitos = melhor.digitos;
+  const nacional = formatNational(digitos);
+  const tipo = digitos.length === 11 ? "celular" : digitos.length === 10 ? "fixo" : null;
+  const e164 = digitos ? `+${COUNTRY_CODE}${digitos}` : null;
+  return { e164, nacional, tipo };
+}
+
+export { normalizeName, stripNumbersFromName };
+
+export default {
+  deriveTelefone,
+  normalizeName,
+  stripNumbersFromName,
+};

--- a/shared/listUtils.js
+++ b/shared/listUtils.js
@@ -3,31 +3,42 @@
 // Mantém compatibilidade com consumidores em ES Modules via import relativo.
 
 const LOWERCASE_WORDS = new Set(["da", "de", "do", "das", "dos", "e"]);
+const WORD_JOINERS = new Set(["-", "'"]);
+
+function toLowerSafe(segment = "") {
+  return segment.toLocaleLowerCase("pt-BR");
+}
 
 function capitalizeSegment(segment = "", force = false) {
   if (!segment) return "";
-  const lower = segment.toLocaleLowerCase("pt-BR");
+  const lower = toLowerSafe(segment);
   if (!force && LOWERCASE_WORDS.has(lower)) {
     return lower;
   }
-  return lower.replace(/^[\p{L}]/u, (c) => c.toLocaleUpperCase("pt-BR"));
+  return lower.replace(/^[\p{L}]/u, (char) => char.toLocaleUpperCase("pt-BR"));
 }
 
-function titleCase(word = "", isFirst = false) {
+function titleCaseWord(word = "", isFirstWord = false) {
   if (!word) return "";
   const segments = word.split(/([-'])/u);
   return segments
-    .map((segment, idx) => {
-      if (segment === "-" || segment === "'") {
+    .map((segment, index) => {
+      if (WORD_JOINERS.has(segment)) {
         return segment;
       }
-      const prev = segments[idx - 1];
-      const force = (isFirst && idx === 0) || prev === "-" || prev === "'";
+      const previous = segments[index - 1];
+      const force = (isFirstWord && index === 0) || WORD_JOINERS.has(previous);
       return capitalizeSegment(segment, force);
     })
     .join("");
 }
 
+/**
+ * Remove sequências numéricas com pelo menos dois dígitos de um nome.
+ * Substitui os números por espaços e normaliza múltiplos espaços consecutivos.
+ * @param {string} value
+ * @returns {string}
+ */
 export function stripNumbersFromName(value = "") {
   return String(value ?? "")
     .replace(/\d{2,}/g, " ")
@@ -35,16 +46,21 @@ export function stripNumbersFromName(value = "") {
     .trim();
 }
 
+/**
+ * Normaliza um nome próprio para "Title Case" preservando conectores comuns.
+ * - Mantém preposições em minúsculas quando não iniciam o nome.
+ * - Força maiúsculas após hífen ou apóstrofo (ex: "D'Ávila").
+ * @param {string} value
+ * @returns {string}
+ */
 export function normalizeName(value = "") {
   const cleaned = stripNumbersFromName(value);
   if (!cleaned) return "";
 
-  const parts = cleaned
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part, index) => titleCase(part, index === 0));
-
-  return parts.join(" ");
+  const words = cleaned.split(/\s+/u).filter(Boolean);
+  return words
+    .map((word, index) => titleCaseWord(word, index === 0))
+    .join(" ");
 }
 
 export default {

--- a/tools/gestao-de-convidados/app.html
+++ b/tools/gestao-de-convidados/app.html
@@ -334,9 +334,17 @@
     const PATH_FORNEC = "/tools/gestao-de-fornecedores/fornecedores.minapp.js"; // MiniApp fornecedores (tools minúsculo)
 
     const CANDIDATES = [
+      (() => {
+        try {
+          const current = new URL(window.location.href);
+          return current.origin.startsWith("http") ? current.origin : null;
+        } catch {
+          return null;
+        }
+      })(),
       "https://cdn.jsdelivr.net/gh/fabiocolletto/Projeto-marco@main",
       "https://rawcdn.githack.com/fabiocolletto/Projeto-marco/main"
-    ];
+    ].filter(Boolean);
     async function tryImport(url){
       try{ return await import(url); }
       catch(e1){ try{ return await import(url+(url.includes('?')?'&':'?')+'t='+Date.now()); } catch(e2){ return null; }


### PR DESCRIPTION
## Summary
- rewrite shared list normalization helpers as ES modules and document them
- add a higienizarLista compatibility module that re-exports the new helpers and derives Brazilian phone formats
- make the event management app prefer the current origin before the CDN fallback when importing shared modules

## Testing
- node --input-type=module -e "import('file:///workspace/Projeto-marco/shared/inviteUtils.js')"
- node --input-type=module -e "import('file:///workspace/Projeto-marco/shared/listUtils.js')"
- browser_container.run_playwright_script (chromium) to load tools/gestao-de-convidados/app.html and widget-shell.html

------
https://chatgpt.com/codex/tasks/task_e_68e07d4620d483208739a815dda5987a