### PR TITLE
Restore invite list utilities and cover mini-app

### DIFF
--- a/tests/unit/inviteUtils.test.mjs
+++ b/tests/unit/inviteUtils.test.mjs
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeName,
+  stripNumbersFromName,
+  parseInviteLine,
+  parseInvites,
+  invitesToCSV,
+} from '../../tools/shared/inviteUtils.mjs';
+import { normalizeName as normalizeOnly, stripNumbersFromName as stripOnly } from '../../tools/shared/listUtils.mjs';
+
+test('stripNumbersFromName remove sequências numéricas longas', () => {
+  const input = 'Ana 11987654321 Lima 55';
+  const output = stripOnly(input);
+  assert.equal(output, 'Ana Lima');
+  assert.equal(stripNumbersFromName('Sr. 5 João 44'), 'Sr. 5 João');
+});
+
+test('normalizeName aplica caixa apropriada preservando conectores', () => {
+  const input = '  maria   das   dores  ';
+  assert.equal(normalizeOnly(input), 'Maria das Dores');
+  assert.equal(normalizeName('joão da silva'), 'João da Silva');
+  assert.equal(normalizeName('ANA VON TRAPP'), 'Ana von Trapp');
+});
+
+test('parseInviteLine identifica titular, acompanhantes e telefone', () => {
+  const line = 'Maria da Silva, João, Ana  +55 (11) 99876-5432';
+  const invite = parseInviteLine(line);
+  assert.ok(invite, 'deve retornar um convite válido');
+  assert.equal(invite?.titular, 'Maria da Silva');
+  assert.deepEqual(invite?.acompanhantes, ['João', 'Ana']);
+  assert.equal(invite?.telefone, '(11) 99876-5432');
+  assert.equal(invite?.total, 3);
+});
+
+test('parseInvites converte múltiplas linhas em convites estruturados', () => {
+  const text = `Carlos 11988887777; Bia\n\nFernanda dos Santos, +55 21 99887-7766, Paulo`;
+  const invites = parseInvites(text);
+  assert.equal(invites.length, 2);
+  assert.equal(invites[0].titular, 'Carlos');
+  assert.deepEqual(invites[0].acompanhantes, ['Bia']);
+  assert.equal(invites[0].telefone, '(11) 98888-7777');
+  assert.equal(invites[1].titular, 'Fernanda dos Santos');
+  assert.deepEqual(invites[1].acompanhantes, ['Paulo']);
+  assert.equal(invites[1].telefone, '(21) 99887-7766');
+});
+
+test('invitesToCSV gera saída com cabeçalho e dados normalizados', () => {
+  const sample = parseInvites('Clara, José 11 91234-5678');
+  const csv = invitesToCSV(sample);
+  const lines = csv.split('\n');
+  assert.equal(lines[0], 'seq,titular,acompanhantes,telefone,total');
+  assert.match(lines[1], /^"1","Clara","José","\(11\) 91234-5678","2"$/);
+});

--- a/tests/visual/eventos.spec.ts
+++ b/tests/visual/eventos.spec.ts
@@ -140,6 +140,18 @@ test.describe('Eventos — fluxo visual', () => {
       contentType: 'image/png',
     });
 
+    await page.locator('[data-open="#secConvidados"]').click();
+    const guestsPanel = page.locator('#secConvidados');
+    await expect(guestsPanel).toHaveJSProperty('open', true);
+    const guestApp = page.locator('#convidados_host .ac-convidados');
+    await expect(guestApp).toBeVisible();
+    const guestRows = page.locator('#convidados_host .row');
+    const initialGuests = await guestRows.count();
+    await page.locator('#convidados_host #btnAdd').click();
+    await expect(guestRows).toHaveCount(initialGuests + 1);
+    await page.keyboard.press('Escape');
+    await expect(guestsPanel).toHaveJSProperty('open', false);
+
     await page.evaluate(() => {
       const ready = document.getElementById('chipReady');
       const saving = document.getElementById('chipSaving');

--- a/tools/shared/inviteUtils.mjs
+++ b/tools/shared/inviteUtils.mjs
@@ -1,4 +1,4 @@
-// shared/inviteUtils.js
+// shared/inviteUtils.mjs
 // Converte LINHAS em "convites" estruturados (titular, acompanhantes, telefone, total).
 // Regras:
 // - Cada **linha** = 1 convite.
@@ -6,7 +6,7 @@
 // - Telefone pode estar em qualquer lugar na linha; é detectado e padronizado (BR 10/11 dígitos).
 // - Sequências com 2+ dígitos não são consideradas parte do nome.
 
-import { normalizeName, stripNumbersFromName } from "./listUtils.js";
+import { normalizeName, stripNumbersFromName } from "./listUtils.mjs";
 
 // Telefones soltos: aceita +55, DDD, espaços, hífens e parênteses
 const PHONE_RE = /(?:\+?\d[\d\s().-]{6,}\d)/g;
@@ -86,3 +86,5 @@ export function invitesToCSV(invites = []) {
   });
   return [header, ...rows].join("\n");
 }
+
+export { normalizeName, stripNumbersFromName };

--- a/tools/shared/listUtils.mjs
+++ b/tools/shared/listUtils.mjs
@@ -1,0 +1,54 @@
+/**
+ * Remove sequências de números (2+ dígitos) e sinais típicos de telefone
+ * preservando espaçamentos simples.
+ * @param {string} input
+ * @returns {string}
+ */
+export function stripNumbersFromName(input = "") {
+  const cleaned = String(input ?? "")
+    // remove blocos de números com 2+ dígitos
+    .replace(/\d{2,}/g, " ")
+    // remove símbolos comuns de telefone que podem sobrar
+    .replace(/[()+\-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned;
+}
+
+const LOWER_WORDS = new Set([
+  "da",
+  "das",
+  "de",
+  "del",
+  "dela",
+  "dellas",
+  "do",
+  "dos",
+  "e",
+  "el",
+  "la",
+  "le",
+  "van",
+  "von",
+]);
+
+/**
+ * Normaliza o nome deixando apenas espaços simples e capitalizando palavras.
+ * Conectores comuns (de/da/do...) permanecem em minúsculas, exceto no início.
+ * @param {string} input
+ * @returns {string}
+ */
+export function normalizeName(input = "") {
+  const base = stripNumbersFromName(input).trim();
+  if (!base) return "";
+  return base
+    .split(/\s+/g)
+    .map((part, index) => {
+      const lower = part.toLowerCase();
+      if (index > 0 && LOWER_WORDS.has(lower)) {
+        return lower;
+      }
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- add shared list utilities module exposing name normalization helpers
- point invite utility module at the restored helpers and re-export them
- cover invite parsing helpers with unit tests and extend the visual flow test to validate the guests mini-app mounts

## Testing
- `node --test tests/unit/inviteUtils.test.mjs`
- `npm run test:visual` *(fails: page.waitForFunction timeout while waiting for sharedStore due to existing module import error)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f73a7cd0832086f613de031feb71