### PR TITLE
feat: redesign dashboard onboarding and navigation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,8 +15,12 @@
                 "@sveltejs/adapter-auto": "^6.1.0",
                 "@sveltejs/kit": "^2.43.2",
                 "@sveltejs/vite-plugin-svelte": "^6.2.0",
+                "@tailwindcss/forms": "^0.5.9",
+                "autoprefixer": "^10.4.20",
+                "postcss": "^8.4.49",
                 "svelte": "^5.39.5",
                 "svelte-check": "^4.3.2",
+                "tailwindcss": "^3.4.17",
                 "typescript": "^5.9.2",
                 "vite": "^7.1.7"
         },

--- a/apps/web/postcss.config.cjs
+++ b/apps/web/postcss.config.cjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+module.exports = config;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,377 +1,65 @@
-:global(body) {
-  margin: 0;
-  font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
-  background: #f3f6fb;
-  color: #1f2937;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-:global(*),
-:global(*::before),
-:global(*::after) {
-  box-sizing: border-box;
-}
-
-main.ac {
-  padding: 24px;
-  min-height: 100vh;
-}
-
-main.ac .container {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.card {
-  background: #ffffff;
-  border-radius: 20px;
-  padding: 24px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.row {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.select-block {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.app-title {
-  margin: 0;
-  font-size: 1.85rem;
-  color: #0b65c2;
-}
-
-h2 {
-  margin: 0;
-  font-size: 1.4rem;
-  color: #334155;
-}
-
-.small {
-  font-size: 0.85rem;
-}
-
-.muted {
-  color: #64748b;
-}
-
-button {
-  font: inherit;
-}
-
-.btn {
-  border-radius: 12px;
-  padding: 8px 16px;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid transparent;
-  background: #0b65c2;
-  color: #ffffff;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.btn--ghost {
-  background: #ffffff;
-  color: #0b65c2;
-  border-color: #cbd5f5;
-}
-
-.btn--ghost.danger {
-  color: #b91c1c;
-  border-color: #fca5a5;
-}
-
-.btn:hover,
-.btn:focus-visible {
-  background: #0b65c2;
-  color: #ffffff;
-  box-shadow: 0 0 0 2px rgba(11, 101, 194, 0.2);
-  outline: none;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.75rem;
-  padding: 4px 12px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: #e2e8f0;
-  color: #1f2937;
-}
-
-.pillok {
-  background: #ecfdf5;
-  border-color: rgba(34, 197, 94, 0.35);
-  color: #047857;
-}
-
-.pillwarn {
-  background: #fff7ed;
-  border-color: rgba(249, 115, 22, 0.35);
-  color: #a16207;
-}
-
-.pillsaving {
-  background: #e0f2fe;
-  border-color: rgba(14, 165, 233, 0.35);
-  color: #0c4a6e;
-}
-
-.badge-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.badge {
-  position: relative;
-  border: 1px solid #dbe4f3;
-  border-radius: 16px;
-  padding: 16px;
-  background: #f8fafc;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.badge h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: #0b65c2;
-}
-
-.badge .actions {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-}
-
-.badge .edit-btn {
-  border: 1px solid #cbd5e1;
-  border-radius: 10px;
-  background: #ffffff;
-  padding: 4px 8px;
-  cursor: pointer;
-}
-
-.kv {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 4px 12px;
-  margin: 0;
-}
-
-.kv dt {
-  font-weight: 600;
-  color: #475569;
-}
-
-.kv dd {
-  margin: 0;
-  color: #1f2937;
-}
-
-.details-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 16px;
-  border: 1px solid #dbe4f3;
-  border-radius: 16px;
-  background: #f9fafb;
-}
-
-details {
-  border-radius: 16px;
-}
-
-details > summary {
-  list-style: none;
-  display: none;
-}
-
-details[open] {
-  box-shadow: 0 0 0 1px #dbeafe inset;
-  background: #f8fafc;
-}
-
-.twocol {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.threecol {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.field label {
-  font-weight: 600;
-  color: #334155;
-}
-
-input,
-select {
-  font: inherit;
-  border: 1px solid #cbd5e1;
-  border-radius: 10px;
-  padding: 8px 10px;
-  background: #ffffff;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-input:focus,
-select:focus {
-  outline: none;
-  border-color: #38bdf8;
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
-}
-
-.close-hint {
-  font-size: 0.8rem;
-  color: #64748b;
-}
-
-.hdr-sync {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.hdr-sync .small-label {
-  font-size: 0.8rem;
-  color: #555;
-}
-
-.hdr-sync .badge {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  border: 1px solid #ccc;
-  border-radius: 12px;
-  padding: 2px 8px;
-  background: #fff;
-}
-
-.hdr-sync .badge.active {
-  border-color: #ffa245;
-  background: #fff7ed;
-  box-shadow: 0 0 0 1px #ffa245 inset;
-}
-
-.mini-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
-}
-
-.mini.kpi {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: 160px;
-  border: 1px solid #dbe4f3;
-  border-radius: 16px;
-  background: #ffffff;
-  padding: 20px;
-  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
-}
-
-.progress {
-  width: 100%;
-}
-
-.progress__track {
-  width: 100%;
-  height: 8px;
-  border-radius: 6px;
-  background: #eef2f6;
-}
-
-.progress__bar {
-  height: 100%;
-  border-radius: 6px;
-  background: #0b65c2;
-  transition: width 0.25s ease;
-}
-
-.hbar-legend {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 8px;
-  font-size: 0.85rem;
-  color: #475569;
-}
-
-.progress--segments .progress__track {
-  display: flex;
-  gap: 2px;
-  align-items: center;
-  background: transparent;
-}
-
-.progress--segments .seg {
-  height: 10px;
-  border-radius: 4px;
-  background: #0b65c2;
-  flex: 0 0 auto;
-}
-
-@media (max-width: 768px) {
-  main.ac {
-    padding: 16px;
+@layer base {
+  :root {
+    --color-surface: 255 255 255;
+    --color-surface-muted: 243 246 251;
+    --color-brand: 11 101 194;
+    --color-brand-foreground: 255 255 255;
+    --color-ink: 31 41 55;
+    --color-ink-muted: 100 116 139;
+    --color-success: 16 185 129;
+    --color-warning: 245 158 11;
+    --color-danger: 220 38 38;
+    --color-accent: 14 165 233;
   }
 
-  .row {
-    flex-direction: column;
-    align-items: flex-start;
+  body {
+    @apply bg-surface-muted text-ink font-sans antialiased;
   }
 
-  .select-block {
-    width: 100%;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply text-ink font-semibold;
+  }
+
+  button {
+    font: inherit;
   }
 }
 
-/* ===== KPIs / MiniApps ===== */
-#cardIndicadores .mini.kpi{position:relative;display:flex;flex-direction:column;justify-content:center;min-height:150px}
-#cardIndicadores .mini.kpi .label{font-weight:600;margin-bottom:8px;display:flex;align-items:center;justify-content:flex-start}
-#cardIndicadores .mini.kpi .label .title{color:#0b65c2}
-#cardIndicadores .mini.kpi .label h3{margin:0 48px 2px 0;font-size:14px;line-height:1.2;color:#0b65c2;display:flex;align-items:center}
-#cardIndicadores .mini.kpi.active{border-color:#ffa245;background:#fff7ed;box-shadow:0 0 0 1px #ffa245 inset}
-#cardIndicadores #secTarefas[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-#cardIndicadores #secFornecedores[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-#cardIndicadores #secConvidados[open] .details-wrap{border:1px solid #ffa245;border-radius:12px;background:#fff7ed;padding:12px}
-#cardIndicadores .mini.kpi .actions{position:absolute;top:10px;right:10px}
-#cardIndicadores .mini.kpi .edit-btn{border:1px solid #cccccc;background:#ffffff;border-radius:10px;padding:4px 8px;cursor:pointer;line-height:1}
-#cardIndicadores .progress.progress--lg .progress__track{height:10px;border-radius:6px;background:#eef2f6}
-#cardIndicadores .progress.progress--lg .progress__bar{height:10px;border-radius:6px;background:#0b65c2;transition:width .25s ease}
-#cardIndicadores .hbar-legend{display:flex;justify-content:space-between;gap:8px;margin-top:8px;font-size:.875rem;color:#555}
-#cardIndicadores .progress--segments .progress__track{display:flex;gap:2px;align-items:center}
-#cardIndicadores .progress--segments .seg{height:10px;border-radius:4px;background:#0b65c2;flex:0 0 auto}
-#cardIndicadores .muted{opacity:.75}
-#cardIndicadores details>summary{display:none}
-@media (max-width:640px){#cardIndicadores .mini.kpi{min-height:140px}}
+@layer components {
+  .card {
+    @apply rounded-2xl bg-surface shadow-card ring-1 ring-black/5;
+  }
+
+  .chip {
+    @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium;
+  }
+
+  .chip--success {
+    @apply bg-success/10 text-success;
+  }
+
+  .chip--warning {
+    @apply bg-warning/10 text-warning;
+  }
+
+  .chip--info {
+    @apply bg-accent/10 text-accent;
+  }
+
+  #panel-overview .active {
+    @apply border-brand/60 bg-brand/5 ring-2 ring-brand/30;
+  }
+
+  #hdr_sync_badge.active {
+    @apply ring-2 ring-brand/40;
+  }
+}

--- a/apps/web/src/lib/components/DashboardBadges.svelte
+++ b/apps/web/src/lib/components/DashboardBadges.svelte
@@ -1,25 +1,50 @@
-<div class="badge-grid" aria-label="Resumo do evento">
-  <div class="badge" id="badgeEvento">
-    <h3>Evento</h3>
-    <div><dl class="kv" id="kvEvento"></dl></div>
-    <div class="actions">
-      <button class="edit-btn" data-open="#secEvento" aria-label="Editar">✎</button>
-    </div>
-  </div>
+<script lang="ts">
+  import { openPanel } from '$lib/stores/ui';
+</script>
 
-  <div class="badge" id="badgeAnfitriao">
-    <h3>Anfitrião</h3>
-    <div><dl class="kv" id="kvAnfitriao"></dl></div>
-    <div class="actions">
-      <button class="edit-btn" data-open="#secAnfitriao" aria-label="Editar">✎</button>
+<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3" aria-label="Resumo do evento">
+  <article class="relative flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="badgeEvento">
+    <div class="flex items-start justify-between gap-2">
+      <h3 class="text-lg font-semibold text-ink">Evento</h3>
+      <button
+        class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+        data-open="evento"
+        aria-label="Editar evento"
+        on:click={() => openPanel('evento')}
+      >
+        Editar
+      </button>
     </div>
-  </div>
+    <dl class="grid gap-2 text-sm text-ink-muted" id="kvEvento"></dl>
+  </article>
 
-  <div class="badge" id="badgeCerimonial">
-    <h3>Cerimonialista</h3>
-    <div><dl class="kv" id="kvCerimonial"></dl></div>
-    <div class="actions">
-      <button class="edit-btn" data-open="#secCerimonial" aria-label="Editar">✎</button>
+  <article class="relative flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="badgeAnfitriao">
+    <div class="flex items-start justify-between gap-2">
+      <h3 class="text-lg font-semibold text-ink">Anfitrião</h3>
+      <button
+        class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+        data-open="anfitriao"
+        aria-label="Editar anfitrião"
+        on:click={() => openPanel('anfitriao')}
+      >
+        Editar
+      </button>
     </div>
-  </div>
+    <dl class="grid gap-2 text-sm text-ink-muted" id="kvAnfitriao"></dl>
+  </article>
+
+  <article class="relative flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="badgeCerimonial">
+    <div class="flex items-start justify-between gap-2">
+      <h3 class="text-lg font-semibold text-ink">Cerimonialista</h3>
+      <button
+        class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+        data-open="cerimonial"
+        aria-label="Editar cerimonialista"
+        on:click={() => openPanel('cerimonial')}
+      >
+        Editar
+      </button>
+    </div>
+    <dl class="grid gap-2 text-sm text-ink-muted" id="kvCerimonial"></dl>
+  </article>
 </div>

--- a/apps/web/src/lib/components/DashboardHeader.svelte
+++ b/apps/web/src/lib/components/DashboardHeader.svelte
@@ -1,38 +1,57 @@
-<div class="row" style="align-items:flex-start; gap:16px">
-  <div>
-    <h1 class="app-title">Gestão de eventos</h1>
-    <h2 id="evTitle">—</h2>
-    <div class="small muted" id="updatedWrap">
-      Atualizado: <span id="updatedAt">—</span>
-      <span id="storageWarn" class="pill pillwarn" style="display:none;margin-left:8px">Modo temporário (sem persistência)</span>
+<div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+  <div class="space-y-2">
+    <h1 class="text-3xl font-semibold text-brand">Gestão de eventos</h1>
+    <h2 id="evTitle" class="text-xl font-semibold text-ink">—</h2>
+    <div class="flex flex-wrap items-center gap-2 text-sm text-ink-muted" id="updatedWrap">
+      <span>
+        Atualizado: <span id="updatedAt">—</span>
+      </span>
+      <span id="storageWarn" class="chip chip--warning" style="display:none">Modo temporário (sem persistência)</span>
     </div>
   </div>
 
-  <div class="select-block" style="margin-left:auto; min-width:min(520px, 100%)">
-    <label class="small" for="switchEvent">Selecionar evento</label>
-    <select id="switchEvent"></select>
+  <div class="w-full space-y-3 lg:max-w-md">
+    <div class="space-y-1">
+      <label class="text-xs font-medium text-ink-muted" for="switchEvent">Selecionar evento</label>
+      <select
+        id="switchEvent"
+        class="form-select w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm shadow-inner focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
+      ></select>
+    </div>
 
-    <div class="row" id="hdrControlsRow" style="align-items:center; gap:8px; flex-wrap:wrap">
-      <button id="btnNew" class="btn btn--ghost" type="button">Novo</button>
-      <button id="btnDelete" class="btn btn--ghost danger" type="button">Excluir</button>
-      <span id="chipReady" class="pill pillok">Pronto</span>
-      <span id="chipDirty" class="pill pillwarn" style="display:none">Edição não salva</span>
-      <span id="chipSaving" class="pill pillsaving" style="display:none">Salvando…</span>
+    <div class="flex flex-wrap items-center gap-2" id="hdrControlsRow">
+      <button
+        id="btnNew"
+        class="rounded-xl border border-brand/20 bg-brand/10 px-4 py-2 text-sm font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+        type="button"
+      >
+        Novo evento
+      </button>
+      <button
+        id="btnDelete"
+        class="rounded-xl border border-danger/20 bg-danger/5 px-4 py-2 text-sm font-semibold text-danger transition hover:bg-danger hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/50"
+        type="button"
+      >
+        Excluir
+      </button>
+      <span id="chipReady" class="chip chip--success">Pronto</span>
+      <span id="chipDirty" class="chip chip--warning" style="display:none">Edição não salva</span>
+      <span id="chipSaving" class="chip chip--info" style="display:none">Salvando…</span>
 
-      <div class="hdr-sync" id="hdr_sync_wrap">
-        <span class="small-label">Sincronização</span>
-        <div class="badge" id="hdr_sync_badge">
-          <span id="hdr_sync_status">Desativado</span>
+      <div class="flex flex-col gap-1 rounded-xl bg-surface-muted/80 px-3 py-2 text-sm" id="hdr_sync_wrap">
+        <span class="text-xs font-semibold uppercase tracking-wide text-ink-muted">Sincronização</span>
+        <div class="flex items-center justify-between gap-3 rounded-lg bg-surface px-3 py-2 shadow-inner" id="hdr_sync_badge">
+          <span id="hdr_sync_status" class="font-semibold text-ink">Desativado</span>
           <button
-            class="edit-btn"
-            data-open="#secSync"
+            class="rounded-md border border-transparent bg-brand/10 px-2 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+            data-open="sync"
             aria-label="Abrir painel de sincronização"
             title="Abrir painel de sincronização"
           >
-            ✎
+            Ajustar
           </button>
         </div>
-        <span id="hdr_sync_detail" class="small muted">—</span>
+        <span id="hdr_sync_detail" class="text-xs text-ink-muted">—</span>
       </div>
     </div>
   </div>

--- a/apps/web/src/lib/components/DashboardIndicators.svelte
+++ b/apps/web/src/lib/components/DashboardIndicators.svelte
@@ -1,85 +1,191 @@
 <script lang="ts">
   import SyncPanel from './SyncPanel.svelte';
+  import { activePanel, openPanel } from '$lib/stores/ui';
 </script>
 
-<section class="card" id="cardIndicadores">
-  <h2>Indicadores do evento</h2>
-  <div class="mini-grid">
-    <div class="mini kpi" id="kpi_tasks">
-      <div class="label"><h3 class="title" id="kpi_task_title">Tarefas</h3></div>
-      <div class="actions">
-        <button class="edit-btn" data-open="#secTarefas" aria-label="Editar tarefas" title="Abrir painel de tarefas">✎</button>
-      </div>
-      <div class="progress progress--lg">
-        <div class="progress__track"><div id="kpi_task_bar" class="progress__bar" style="width:0%"></div></div>
-      </div>
-      <div class="hbar-legend">
-        <span id="kpi_task_lbl1">0 concluídas — 0%</span><span id="kpi_task_lbl2">Total: 0</span>
-      </div>
-    </div>
-
-    <div class="mini kpi" id="kpi_for">
-      <div class="label"><h3 class="title" id="kpi_for_title">Fornecedores</h3></div>
-      <div class="actions">
-        <button class="edit-btn" data-open="#secFornecedores" aria-label="Editar fornecedores" title="Abrir painel de fornecedores">✎</button>
-      </div>
-      <div class="progress progress--lg">
-        <div class="progress__track"><div id="kpi_for_bar" class="progress__bar" style="width:0%"></div></div>
-      </div>
-      <div class="hbar-legend">
-        <span id="kpi_for_lbl1">R$ 0,00 pagos — 0%</span><span id="kpi_for_lbl2">Total: R$ 0,00</span>
-      </div>
-    </div>
-
-    <div class="mini kpi" id="kpi_guests">
-      <div class="label"><h3 class="title" id="kpi_guest_title">Convidados &amp; Convites</h3></div>
-      <div class="actions">
-        <button class="edit-btn" data-open="#secConvidados" aria-label="Editar convidados" title="Abrir painel de convidados">✎</button>
-      </div>
-      <div class="progress progress--lg">
-        <div class="progress__track"><div id="kpi_guest_bar" class="progress__bar" style="width:0%"></div></div>
-      </div>
-      <div class="hbar-legend">
-        <span id="kpi_guest_lbl1">0 confirmados — 0%</span><span id="kpi_guest_lbl2">Total: 0</span>
-      </div>
-      <div class="progress progress--lg progress--segments" aria-label="Distribuição por mesas/grupos">
-        <div class="progress__track" id="kpi_guest_bands"></div>
-      </div>
-      <div class="small muted" id="kpi_guest_legend"></div>
-    </div>
+<section
+  class="card space-y-6"
+  id="panel-overview"
+  data-panel="overview"
+  hidden={$activePanel !== 'overview'}
+>
+  <div class="flex flex-col gap-2">
+    <h2 class="text-xl font-semibold text-ink">Indicadores do evento</h2>
+    <p class="text-sm text-ink-muted">
+      Acompanhe o andamento geral e acesse rapidamente os módulos para atualizar os dados.
+    </p>
   </div>
 
-  <details id="secTarefas">
-    <summary>Tarefas</summary>
-    <div class="details-wrap">
-      <div id="tasks_host"></div>
-      <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
-    </div>
-  </details>
-
-  <details id="secFornecedores">
-    <summary>Fornecedores</summary>
-    <div class="details-wrap">
-      <div id="fornecedores_host"></div>
-      <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
-    </div>
-  </details>
-
-  <details id="secConvidados">
-    <summary>Convidados &amp; Convites</summary>
-    <div class="details-wrap">
-      <div id="convidados_host"></div>
-      <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
-    </div>
-  </details>
-
-  <details id="secSync">
-    <summary>Sincronização</summary>
-    <div class="details-wrap">
-      <div id="sync_host">
-        <SyncPanel />
+  <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+    <article class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="kpi_tasks">
+      <header class="flex items-start justify-between gap-2">
+        <h3 class="text-base font-semibold text-ink" id="kpi_task_title">Tarefas</h3>
+        <button
+          class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+          data-open="tarefas"
+          on:click={() => openPanel('tarefas')}
+        >
+          Abrir módulo
+        </button>
+      </header>
+      <div class="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+        <div id="kpi_task_bar" class="h-full rounded-full bg-brand transition-all duration-300" style="width:0%"></div>
       </div>
-      <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
+      <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-ink-muted">
+        <span id="kpi_task_lbl1">0 concluídas — 0%</span>
+        <span id="kpi_task_lbl2">Total: 0</span>
+      </div>
+    </article>
+
+    <article class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="kpi_for">
+      <header class="flex items-start justify-between gap-2">
+        <h3 class="text-base font-semibold text-ink" id="kpi_for_title">Fornecedores</h3>
+        <button
+          class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+          data-open="fornecedores"
+          on:click={() => openPanel('fornecedores')}
+        >
+          Abrir módulo
+        </button>
+      </header>
+      <div class="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+        <div id="kpi_for_bar" class="h-full rounded-full bg-brand transition-all duration-300" style="width:0%"></div>
+      </div>
+      <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-ink-muted">
+        <span id="kpi_for_lbl1">R$ 0,00 pagos — 0%</span>
+        <span id="kpi_for_lbl2">Total: R$ 0,00</span>
+      </div>
+    </article>
+
+    <article class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm" id="kpi_guests">
+      <header class="flex items-start justify-between gap-2">
+        <h3 class="text-base font-semibold text-ink" id="kpi_guest_title">Convidados &amp; Convites</h3>
+        <button
+          class="rounded-lg border border-transparent bg-brand/10 px-3 py-1 text-xs font-semibold text-brand transition hover:bg-brand hover:text-brand-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+          data-open="convidados"
+          on:click={() => openPanel('convidados')}
+        >
+          Abrir módulo
+        </button>
+      </header>
+      <div class="h-2 w-full overflow-hidden rounded-full bg-slate-200">
+        <div id="kpi_guest_bar" class="h-full rounded-full bg-brand transition-all duration-300" style="width:0%"></div>
+      </div>
+      <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-ink-muted">
+        <span id="kpi_guest_lbl1">0 confirmados — 0%</span>
+        <span id="kpi_guest_lbl2">Total: 0</span>
+      </div>
+      <div class="space-y-2" aria-label="Distribuição por mesas/grupos">
+        <div class="flex h-3 overflow-hidden rounded-full bg-slate-200" id="kpi_guest_bands"></div>
+        <div class="text-xs text-ink-muted" id="kpi_guest_legend"></div>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section
+  class="card space-y-4"
+  id="panel-tarefas"
+  data-panel="tarefas"
+  hidden={$activePanel !== 'tarefas'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Checklist de tarefas</h2>
+      <p class="text-sm text-ink-muted">Organize responsabilidades, prazos e acompanhe o andamento da equipe.</p>
     </div>
-  </details>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
+  <div id="tasks_host" class="min-h-[260px]"></div>
+</section>
+
+<section
+  class="card space-y-4"
+  id="panel-fornecedores"
+  data-panel="fornecedores"
+  hidden={$activePanel !== 'fornecedores'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Fornecedores</h2>
+      <p class="text-sm text-ink-muted">Centralize contratos, pagamentos e contatos essenciais.</p>
+    </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
+  <div id="fornecedores_host" class="min-h-[260px]"></div>
+</section>
+
+<section
+  class="card space-y-4"
+  id="panel-convidados"
+  data-panel="convidados"
+  hidden={$activePanel !== 'convidados'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Convidados e convites</h2>
+      <p class="text-sm text-ink-muted">Gerencie RSVP, mesas, grupos e envios de convites.</p>
+    </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
+  <div id="convidados_host" class="min-h-[260px]"></div>
+</section>
+
+<section
+  class="card space-y-4"
+  id="panel-mensagens"
+  data-panel="mensagens"
+  hidden={$activePanel !== 'mensagens'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Mensagens</h2>
+      <p class="text-sm text-ink-muted">Integre a comunicação do evento com templates e histórico compartilhado.</p>
+    </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
+  <div id="mensagens_host" class="min-h-[260px]"></div>
+</section>
+
+<section
+  class="card space-y-4"
+  id="panel-sync"
+  data-panel="sync"
+  hidden={$activePanel !== 'sync'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Sincronização</h2>
+      <p class="text-sm text-ink-muted">Conecte-se a provedores para salvar snapshots e restaurar dados.</p>
+    </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
+  <div id="sync_host" class="space-y-4">
+    <SyncPanel />
+  </div>
 </section>

--- a/apps/web/src/lib/components/DashboardNavigation.svelte
+++ b/apps/web/src/lib/components/DashboardNavigation.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { activePanel, openPanel, panelDefinitions } from '$lib/stores/ui';
+  import type { PanelId } from '$lib/stores/ui';
+
+  const selectPanel = (panel: PanelId) => () => openPanel(panel);
+</script>
+
+<nav
+  aria-label="Seções do dashboard"
+  class="card flex gap-2 overflow-x-auto bg-surface p-3 lg:flex-col lg:overflow-visible lg:p-4"
+>
+  {#each panelDefinitions as panel}
+    {#if panel.id !== 'overview'}
+      <button
+        type="button"
+        data-open={panel.id}
+        class={`group flex min-w-[200px] flex-1 flex-col gap-1 rounded-xl px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 lg:min-w-0 ${
+          $activePanel === panel.id
+            ? 'bg-brand/5 ring-1 ring-brand/40'
+            : 'hover:bg-surface-muted'
+        }`}
+        aria-current={$activePanel === panel.id ? 'page' : undefined}
+        on:click={selectPanel(panel.id)}
+      >
+        <span class="flex items-center gap-2 text-sm font-semibold text-ink">
+          <span aria-hidden="true">{panel.icon}</span>
+          {panel.label}
+        </span>
+        <span class="text-xs text-ink-muted/80">{panel.description}</span>
+      </button>
+    {:else}
+      <button
+        type="button"
+        class={`group flex min-w-[200px] flex-1 flex-col gap-1 rounded-xl px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 lg:min-w-0 ${
+          $activePanel === 'overview'
+            ? 'bg-brand text-brand-foreground shadow-inner'
+            : 'bg-surface-muted text-ink hover:bg-brand/10'
+        }`}
+        data-open="overview"
+        aria-current={$activePanel === 'overview' ? 'page' : undefined}
+        on:click={selectPanel('overview')}
+      >
+        <span class="flex items-center gap-2 text-sm font-semibold">
+          <span aria-hidden="true">{panel.icon}</span>
+          {panel.label}
+        </span>
+        <span class="text-xs opacity-80">{panel.description}</span>
+      </button>
+    {/if}
+  {/each}
+</nav>

--- a/apps/web/src/lib/components/DashboardSummaryPanels.svelte
+++ b/apps/web/src/lib/components/DashboardSummaryPanels.svelte
@@ -1,45 +1,83 @@
-<details id="secEvento">
-  <summary>Evento</summary>
-  <div class="details-wrap">
-    <div class="twocol">
-      <div class="field">
-        <label for="evento-nome"><span class="small">Nome do evento</span></label>
-        <input id="evento-nome" data-bind="evento.nome" type="text" />
-      </div>
-      <div class="field">
-        <label for="evento-tipo"><span class="small">Tipo</span></label>
-        <select id="evento-tipo" data-bind="evento.tipo">
-          <option value=""></option>
-          <option>Casamento</option>
-          <option>Aniversário</option>
-          <option>Formatura</option>
-          <option>Debutante</option>
-          <option>Corporativo</option>
-          <option>Batizado</option>
-          <option>Chá de Panela</option>
-          <option>Chá de Bebê</option>
-          <option>Bodas</option>
-          <option>Outro</option>
-        </select>
-      </div>
+<script lang="ts">
+  import { activePanel, openPanel } from '$lib/stores/ui';
+</script>
+
+<section
+  class="card space-y-6"
+  id="panel-evento"
+  data-panel="evento"
+  hidden={$activePanel !== 'evento'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Informações do evento</h2>
+      <p class="text-sm text-ink-muted">Defina nome, tipo, data e endereço do encontro.</p>
     </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="ev-datetime"><span class="small">Quando</span></label>
-        <input id="ev-datetime" type="datetime-local" />
-      </div>
-      <div class="field">
-        <label for="evento-local"><span class="small">Local</span></label>
-        <input id="evento-local" data-bind="evento.local" type="text" />
-      </div>
-    </div>
+  <div class="grid gap-4 md:grid-cols-2">
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-nome">
+      Nome do evento
+      <input
+        id="evento-nome"
+        data-bind="evento.nome"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-tipo">
+      Tipo
+      <select
+        id="evento-tipo"
+        data-bind="evento.tipo"
+        class="form-select rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      >
+        <option value=""></option>
+        <option>Casamento</option>
+        <option>Aniversário</option>
+        <option>Formatura</option>
+        <option>Debutante</option>
+        <option>Corporativo</option>
+        <option>Batizado</option>
+        <option>Chá de Panela</option>
+        <option>Chá de Bebê</option>
+        <option>Bodas</option>
+        <option>Outro</option>
+      </select>
+    </label>
+  </div>
 
-    <div><strong class="small">Endereço do evento</strong></div>
+  <div class="grid gap-4 md:grid-cols-2">
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="ev-datetime">
+      Quando
+      <input
+        id="ev-datetime"
+        type="datetime-local"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-local">
+      Local
+      <input
+        id="evento-local"
+        data-bind="evento.local"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+  </div>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="evento-endereco-cep"><span class="small">CEP</span></label>
+  <div class="space-y-3 rounded-2xl bg-surface-muted/80 p-4">
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-muted">Endereço do evento</h3>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-cep">
+        CEP
         <input
           id="evento-endereco-cep"
           data-bind="evento.endereco.cep"
@@ -47,68 +85,129 @@
           inputmode="numeric"
           maxlength="9"
           data-cep="evento.endereco"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
         />
-      </div>
-      <div class="field">
-        <label for="evento-endereco-logradouro"><span class="small">Logradouro</span></label>
-        <input id="evento-endereco-logradouro" data-bind="evento.endereco.logradouro" type="text" />
-      </div>
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-logradouro">
+        Logradouro
+        <input
+          id="evento-endereco-logradouro"
+          data-bind="evento.endereco.logradouro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="threecol">
-      <div class="field">
-        <label for="evento-endereco-numero"><span class="small">Número</span></label>
-        <input id="evento-endereco-numero" data-bind="evento.endereco.numero" type="text" />
-      </div>
-      <div class="field">
-        <label for="evento-endereco-bairro"><span class="small">Bairro</span></label>
-        <input id="evento-endereco-bairro" data-bind="evento.endereco.bairro" type="text" />
-      </div>
-      <div class="field">
-        <label for="evento-endereco-cidade"><span class="small">Cidade</span></label>
-        <input id="evento-endereco-cidade" data-bind="evento.endereco.cidade" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-3">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-numero">
+        Número
+        <input
+          id="evento-endereco-numero"
+          data-bind="evento.endereco.numero"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-bairro">
+        Bairro
+        <input
+          id="evento-endereco-bairro"
+          data-bind="evento.endereco.bairro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-cidade">
+        Cidade
+        <input
+          id="evento-endereco-cidade"
+          data-bind="evento.endereco.cidade"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="evento-endereco-uf"><span class="small">UF</span></label>
-        <input id="evento-endereco-uf" data-bind="evento.endereco.uf" type="text" maxlength="2" />
-      </div>
-      <div class="field">
-        <label for="evento-endereco-complemento"><span class="small">Complemento / Referência</span></label>
-        <input id="evento-endereco-complemento" data-bind="evento.endereco.complemento" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-uf">
+        UF
+        <input
+          id="evento-endereco-uf"
+          data-bind="evento.endereco.uf"
+          type="text"
+          maxlength="2"
+          class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="evento-endereco-complemento">
+        Complemento / Referência
+        <input
+          id="evento-endereco-complemento"
+          data-bind="evento.endereco.complemento"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
-
-    <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
   </div>
-</details>
+</section>
 
-<details id="secAnfitriao">
-  <summary>Anfitrião</summary>
-  <div class="details-wrap">
-    <div class="twocol">
-      <div class="field">
-        <label for="anfitriao-nome"><span class="small">Nome</span></label>
-        <input id="anfitriao-nome" data-bind="evento.anfitriao.nome" type="text" />
-      </div>
-      <div class="field">
-        <label for="anfitriao-telefone"><span class="small">Telefone</span></label>
-        <input id="anfitriao-telefone" data-bind="evento.anfitriao.telefone" type="text" />
-      </div>
+<section
+  class="card space-y-6"
+  id="panel-anfitriao"
+  data-panel="anfitriao"
+  hidden={$activePanel !== 'anfitriao'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Dados do anfitrião</h2>
+      <p class="text-sm text-ink-muted">Preencha os contatos principais e endereços para correspondências.</p>
     </div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
+  </div>
 
-    <div class="field">
-      <label for="anfitriao-rede"><span class="small">Rede social / contato</span></label>
-      <input id="anfitriao-rede" data-bind="evento.anfitriao.redeSocial" type="text" />
-    </div>
+  <div class="grid gap-4 md:grid-cols-2">
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="anfitriao-nome">
+      Nome
+      <input
+        id="anfitriao-nome"
+        data-bind="evento.anfitriao.nome"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="anfitriao-telefone">
+      Telefone
+      <input
+        id="anfitriao-telefone"
+        data-bind="evento.anfitriao.telefone"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+  </div>
 
-    <div><strong class="small">Endereço para correspondência</strong></div>
+  <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="anfitriao-rede">
+    Rede social / contato
+    <input
+      id="anfitriao-rede"
+      data-bind="evento.anfitriao.redeSocial"
+      type="text"
+      class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+    />
+  </label>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="correspondencia-cep"><span class="small">CEP</span></label>
+  <div class="space-y-3 rounded-2xl bg-surface-muted/80 p-4">
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-muted">Endereço para correspondência</h3>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-cep">
+        CEP
         <input
           id="correspondencia-cep"
           data-bind="evento.anfitriao.endCorrespondencia.cep"
@@ -116,45 +215,78 @@
           inputmode="numeric"
           maxlength="9"
           data-cep="evento.anfitriao.endCorrespondencia"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
         />
-      </div>
-      <div class="field">
-        <label for="correspondencia-logradouro"><span class="small">Logradouro</span></label>
-        <input id="correspondencia-logradouro" data-bind="evento.anfitriao.endCorrespondencia.logradouro" type="text" />
-      </div>
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-logradouro">
+        Logradouro
+        <input
+          id="correspondencia-logradouro"
+          data-bind="evento.anfitriao.endCorrespondencia.logradouro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="threecol">
-      <div class="field">
-        <label for="correspondencia-numero"><span class="small">Número</span></label>
-        <input id="correspondencia-numero" data-bind="evento.anfitriao.endCorrespondencia.numero" type="text" />
-      </div>
-      <div class="field">
-        <label for="correspondencia-bairro"><span class="small">Bairro</span></label>
-        <input id="correspondencia-bairro" data-bind="evento.anfitriao.endCorrespondencia.bairro" type="text" />
-      </div>
-      <div class="field">
-        <label for="correspondencia-cidade"><span class="small">Cidade</span></label>
-        <input id="correspondencia-cidade" data-bind="evento.anfitriao.endCorrespondencia.cidade" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-3">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-numero">
+        Número
+        <input
+          id="correspondencia-numero"
+          data-bind="evento.anfitriao.endCorrespondencia.numero"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-bairro">
+        Bairro
+        <input
+          id="correspondencia-bairro"
+          data-bind="evento.anfitriao.endCorrespondencia.bairro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-cidade">
+        Cidade
+        <input
+          id="correspondencia-cidade"
+          data-bind="evento.anfitriao.endCorrespondencia.cidade"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="correspondencia-uf"><span class="small">UF</span></label>
-        <input id="correspondencia-uf" data-bind="evento.anfitriao.endCorrespondencia.uf" type="text" maxlength="2" />
-      </div>
-      <div class="field">
-        <label for="correspondencia-complemento"><span class="small">Complemento</span></label>
-        <input id="correspondencia-complemento" data-bind="evento.anfitriao.endCorrespondencia.complemento" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-uf">
+        UF
+        <input
+          id="correspondencia-uf"
+          data-bind="evento.anfitriao.endCorrespondencia.uf"
+          type="text"
+          maxlength="2"
+          class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="correspondencia-complemento">
+        Complemento
+        <input
+          id="correspondencia-complemento"
+          data-bind="evento.anfitriao.endCorrespondencia.complemento"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
+  </div>
 
-    <div><strong class="small">Endereço para entrega de presentes</strong></div>
-
-    <div class="twocol">
-      <div class="field">
-        <label for="entrega-cep"><span class="small">CEP</span></label>
+  <div class="space-y-3 rounded-2xl bg-surface-muted/80 p-4">
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-muted">Endereço para entrega de presentes</h3>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-cep">
+        CEP
         <input
           id="entrega-cep"
           data-bind="evento.anfitriao.endEntrega.cep"
@@ -162,63 +294,121 @@
           inputmode="numeric"
           maxlength="9"
           data-cep="evento.anfitriao.endEntrega"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
         />
-      </div>
-      <div class="field">
-        <label for="entrega-logradouro"><span class="small">Logradouro</span></label>
-        <input id="entrega-logradouro" data-bind="evento.anfitriao.endEntrega.logradouro" type="text" />
-      </div>
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-logradouro">
+        Logradouro
+        <input
+          id="entrega-logradouro"
+          data-bind="evento.anfitriao.endEntrega.logradouro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="threecol">
-      <div class="field">
-        <label for="entrega-numero"><span class="small">Número</span></label>
-        <input id="entrega-numero" data-bind="evento.anfitriao.endEntrega.numero" type="text" />
-      </div>
-      <div class="field">
-        <label for="entrega-bairro"><span class="small">Bairro</span></label>
-        <input id="entrega-bairro" data-bind="evento.anfitriao.endEntrega.bairro" type="text" />
-      </div>
-      <div class="field">
-        <label for="entrega-cidade"><span class="small">Cidade</span></label>
-        <input id="entrega-cidade" data-bind="evento.anfitriao.endEntrega.cidade" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-3">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-numero">
+        Número
+        <input
+          id="entrega-numero"
+          data-bind="evento.anfitriao.endEntrega.numero"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-bairro">
+        Bairro
+        <input
+          id="entrega-bairro"
+          data-bind="evento.anfitriao.endEntrega.bairro"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-cidade">
+        Cidade
+        <input
+          id="entrega-cidade"
+          data-bind="evento.anfitriao.endEntrega.cidade"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
 
-    <div class="twocol">
-      <div class="field">
-        <label for="entrega-uf"><span class="small">UF</span></label>
-        <input id="entrega-uf" data-bind="evento.anfitriao.endEntrega.uf" type="text" maxlength="2" />
-      </div>
-      <div class="field">
-        <label for="entrega-complemento"><span class="small">Complemento</span></label>
-        <input id="entrega-complemento" data-bind="evento.anfitriao.endEntrega.complemento" type="text" />
-      </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-uf">
+        UF
+        <input
+          id="entrega-uf"
+          data-bind="evento.anfitriao.endEntrega.uf"
+          type="text"
+          maxlength="2"
+          class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+        />
+      </label>
+      <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="entrega-complemento">
+        Complemento
+        <input
+          id="entrega-complemento"
+          data-bind="evento.anfitriao.endEntrega.complemento"
+          type="text"
+          class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+        />
+      </label>
     </div>
-
-    <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
   </div>
-</details>
+</section>
 
-<details id="secCerimonial">
-  <summary>Cerimonialista</summary>
-  <div class="details-wrap">
-    <div class="twocol">
-      <div class="field">
-        <label for="cerimonial-nome"><span class="small">Nome</span></label>
-        <input id="cerimonial-nome" data-bind="cerimonialista.nomeCompleto" type="text" />
-      </div>
-      <div class="field">
-        <label for="cerimonial-telefone"><span class="small">Telefone</span></label>
-        <input id="cerimonial-telefone" data-bind="cerimonialista.telefone" type="text" />
-      </div>
+<section
+  class="card space-y-6"
+  id="panel-cerimonial"
+  data-panel="cerimonial"
+  hidden={$activePanel !== 'cerimonial'}
+>
+  <div class="flex items-start justify-between">
+    <div>
+      <h2 class="text-xl font-semibold text-ink">Cerimonialista</h2>
+      <p class="text-sm text-ink-muted">Guarde os contatos da equipe responsável pelo cerimonial.</p>
     </div>
-
-    <div class="field">
-      <label for="cerimonial-rede"><span class="small">Rede social</span></label>
-      <input id="cerimonial-rede" data-bind="cerimonialista.redeSocial" type="text" />
-    </div>
-
-    <div class="close-hint">Pressione <strong>Esc</strong> ou clique no lápis novamente para fechar.</div>
+    <button
+      class="rounded-lg border border-transparent bg-surface-muted px-3 py-1 text-xs font-semibold text-ink transition hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+      on:click={() => openPanel('overview')}
+    >
+      Voltar
+    </button>
   </div>
-</details>
+
+  <div class="grid gap-4 md:grid-cols-2">
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="cerimonial-nome">
+      Nome
+      <input
+        id="cerimonial-nome"
+        data-bind="cerimonialista.nomeCompleto"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+    <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="cerimonial-telefone">
+      Telefone
+      <input
+        id="cerimonial-telefone"
+        data-bind="cerimonialista.telefone"
+        type="text"
+        class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+      />
+    </label>
+  </div>
+
+  <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="cerimonial-rede">
+    Rede social
+    <input
+      id="cerimonial-rede"
+      data-bind="cerimonialista.redeSocial"
+      type="text"
+      class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+    />
+  </label>
+</section>

--- a/apps/web/src/lib/components/OnboardingWizard.svelte
+++ b/apps/web/src/lib/components/OnboardingWizard.svelte
@@ -1,0 +1,649 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { projectData } from '$lib/data/projects';
+  import {
+    closeOnboarding,
+    onboardingState,
+    openPanel,
+    type PanelId,
+  } from '$lib/stores/ui';
+
+  interface TaskTemplate {
+    id: string;
+    title: string;
+    description: string;
+    category: string;
+  }
+
+  const TASK_TEMPLATES: TaskTemplate[] = [
+    {
+      id: 'briefing',
+      title: 'Reunião inicial com anfitrião',
+      description: 'Mapeie expectativas, orçamento e estilo do evento.',
+      category: 'Planejamento',
+    },
+    {
+      id: 'orcamento',
+      title: 'Definir orçamento macro',
+      description: 'Distribua valores por categoria (local, buffet, decoração).',
+      category: 'Planejamento',
+    },
+    {
+      id: 'checklist-fornecedores',
+      title: 'Listar fornecedores prioritários',
+      description: 'Buffet, espaço, decoração, fotografia e entretenimento.',
+      category: 'Fornecedores',
+    },
+    {
+      id: 'comunicacao',
+      title: 'Planejar comunicação com convidados',
+      description: 'Defina canais, templates e cronograma de convites.',
+      category: 'Comunicação',
+    },
+    {
+      id: 'cronograma',
+      title: 'Criar cronograma do dia do evento',
+      description: 'Inclua horários-chave, entradas e alinhamentos com equipe.',
+      category: 'Operacional',
+    },
+  ];
+
+  interface DraftAddress {
+    cep: string;
+    logradouro: string;
+    numero: string;
+    bairro: string;
+    cidade: string;
+    uf: string;
+    complemento: string;
+  }
+
+  const emptyAddress = (): DraftAddress => ({
+    cep: '',
+    logradouro: '',
+    numero: '',
+    bairro: '',
+    cidade: '',
+    uf: '',
+    complemento: '',
+  });
+
+  interface WizardDraft {
+    nome: string;
+    tipo: string;
+    datetime: string;
+    local: string;
+    endereco: DraftAddress;
+    anfitriao: {
+      nome: string;
+      telefone: string;
+      redeSocial: string;
+      correspondencia: DraftAddress;
+      entrega: DraftAddress;
+    };
+    cerimonialista: {
+      nome: string;
+      telefone: string;
+      redeSocial: string;
+    };
+  }
+
+  let step = 0;
+  let busy = false;
+  let error: string | null = null;
+
+  let draft: WizardDraft = {
+    nome: '',
+    tipo: '',
+    datetime: '',
+    local: '',
+    endereco: emptyAddress(),
+    anfitriao: {
+      nome: '',
+      telefone: '',
+      redeSocial: '',
+      correspondencia: emptyAddress(),
+      entrega: emptyAddress(),
+    },
+    cerimonialista: {
+      nome: '',
+      telefone: '',
+      redeSocial: '',
+    },
+  };
+
+  let checklist = TASK_TEMPLATES.map((task) => ({ ...task, selected: true }));
+
+  const totalSteps = 3;
+
+  const isLastStep = () => step === totalSteps - 1;
+  const isFirstStep = () => step === 0;
+
+  const isStepValid = (): boolean => {
+    if (step === 0) {
+      return Boolean(draft.nome.trim());
+    }
+    return true;
+  };
+
+  const goToStep = (target: number) => {
+    if (target < 0 || target >= totalSteps) return;
+    step = target;
+  };
+
+  const next = () => {
+    if (!isStepValid()) return;
+    goToStep(step + 1);
+  };
+
+  const prev = () => {
+    goToStep(step - 1);
+  };
+
+  const close = () => {
+    if (busy) return;
+    closeOnboarding();
+  };
+
+  const syncFromStore = () => {
+    step = Math.min(totalSteps - 1, Math.max(0, $onboardingState.step ?? 0));
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (! $onboardingState.open) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  onMount(() => {
+    const unsubscribe = onboardingState.subscribe(() => syncFromStore());
+    syncFromStore();
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      unsubscribe();
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
+  const selectedTasks = () =>
+    checklist
+      .filter((item) => item.selected)
+      .map((item) => ({
+        titulo: item.title,
+        descricao: item.description,
+        categoria: item.category,
+        status: 'todo',
+        responsavel: '',
+        prazo: '',
+        done: false,
+      }));
+
+  async function handleCreate() {
+    if (busy) return;
+    busy = true;
+    error = null;
+    try {
+      const [data, horaRaw] = draft.datetime ? draft.datetime.split('T') : ['', ''];
+      const hora = (horaRaw ?? '').slice(0, 5);
+
+      const record = await projectData.createProject({
+        evento: {
+          nome: draft.nome.trim(),
+          tipo: draft.tipo,
+          data: data ?? '',
+          hora,
+          local: draft.local,
+          endereco: { ...draft.endereco },
+          anfitriao: {
+            nome: draft.anfitriao.nome,
+            telefone: draft.anfitriao.telefone,
+            redeSocial: draft.anfitriao.redeSocial,
+            endCorrespondencia: { ...draft.anfitriao.correspondencia },
+            endEntrega: { ...draft.anfitriao.entrega },
+          },
+        },
+        cerimonialista: {
+          nomeCompleto: draft.cerimonialista.nome,
+          telefone: draft.cerimonialista.telefone,
+          redeSocial: draft.cerimonialista.redeSocial,
+        },
+        checklist: selectedTasks(),
+        fornecedores: [],
+        convidados: [],
+        tipos: [],
+        modelos: {},
+        vars: {},
+        updatedAt: Date.now(),
+      });
+
+      window.dispatchEvent(
+        new CustomEvent('ac:onboarding:complete', {
+          detail: {
+            record,
+            focus: 'tarefas' as PanelId,
+          },
+        })
+      );
+      closeOnboarding();
+      openPanel('tarefas');
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Não foi possível criar o evento. Tente novamente.';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+{#if $onboardingState.open}
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10">
+    <div
+      class="relative w-full max-w-3xl rounded-3xl bg-surface p-6 shadow-2xl ring-1 ring-black/10"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+    >
+      <button
+        class="absolute right-4 top-4 rounded-full bg-surface-muted p-2 text-sm font-semibold text-ink-muted transition hover:bg-surface"
+        type="button"
+        on:click={close}
+        aria-label="Fechar wizard"
+      >
+        ✕
+      </button>
+
+      <header class="mb-6 space-y-2">
+        <div class="flex items-center justify-between">
+          <h1 id="onboarding-title" class="text-2xl font-semibold text-ink">Configurar novo evento</h1>
+          <span class="text-sm font-medium text-ink-muted">Etapa {step + 1} de {totalSteps}</span>
+        </div>
+        <p class="text-sm text-ink-muted">
+          Preencha os campos essenciais para começar com recomendações e um checklist personalizado.
+        </p>
+        <div class="h-2 w-full overflow-hidden rounded-full bg-surface-muted">
+          <div class="h-full rounded-full bg-brand transition-all" style={`width:${((step + 1) / totalSteps) * 100}%`}></div>
+        </div>
+      </header>
+
+      <div class="space-y-6">
+        {#if step === 0}
+          <section class="space-y-4">
+            <h2 class="text-lg font-semibold text-ink">Detalhes básicos do evento</h2>
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-name">
+                Nome do evento
+                <input
+                  id="wizard-event-name"
+                  type="text"
+                  bind:value={draft.nome}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  placeholder="Ex.: Casamento Ana & Bruno"
+                  required
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-type">
+                Tipo do evento
+                <select
+                  id="wizard-event-type"
+                  bind:value={draft.tipo}
+                  class="form-select rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                >
+                  <option value=""></option>
+                  <option>Casamento</option>
+                  <option>Aniversário</option>
+                  <option>Formatura</option>
+                  <option>Debutante</option>
+                  <option>Corporativo</option>
+                  <option>Batizado</option>
+                  <option>Chá de Panela</option>
+                  <option>Chá de Bebê</option>
+                  <option>Bodas</option>
+                  <option>Outro</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-datetime">
+                Data e horário (opcional)
+                <input
+                  id="wizard-event-datetime"
+                  type="datetime-local"
+                  bind:value={draft.datetime}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-location">
+                Local
+                <input
+                  id="wizard-event-location"
+                  type="text"
+                  bind:value={draft.local}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  placeholder="Espaço, salão ou endereço resumido"
+                />
+              </label>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-cep">
+                CEP
+                <input
+                  id="wizard-event-cep"
+                  type="text"
+                  bind:value={draft.endereco.cep}
+                  maxlength="9"
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-logradouro">
+                Logradouro
+                <input
+                  id="wizard-event-logradouro"
+                  type="text"
+                  bind:value={draft.endereco.logradouro}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-3">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-numero">
+                Número
+                <input
+                  id="wizard-event-numero"
+                  type="text"
+                  bind:value={draft.endereco.numero}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-bairro">
+                Bairro
+                <input
+                  id="wizard-event-bairro"
+                  type="text"
+                  bind:value={draft.endereco.bairro}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-cidade">
+                Cidade
+                <input
+                  id="wizard-event-cidade"
+                  type="text"
+                  bind:value={draft.endereco.cidade}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-uf">
+                UF
+                <input
+                  id="wizard-event-uf"
+                  type="text"
+                  maxlength="2"
+                  bind:value={draft.endereco.uf}
+                  class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-event-complemento">
+                Complemento
+                <input
+                  id="wizard-event-complemento"
+                  type="text"
+                  bind:value={draft.endereco.complemento}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+            </div>
+          </section>
+        {:else if step === 1}
+          <section class="space-y-4">
+            <h2 class="text-lg font-semibold text-ink">Contatos e equipe</h2>
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-host-nome">
+                Nome do anfitrião
+                <input
+                  id="wizard-host-nome"
+                  type="text"
+                  bind:value={draft.anfitriao.nome}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-host-telefone">
+                Telefone
+                <input
+                  id="wizard-host-telefone"
+                  type="text"
+                  bind:value={draft.anfitriao.telefone}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+            </div>
+            <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-host-rede">
+              Rede social / contato
+              <input
+                id="wizard-host-rede"
+                type="text"
+                bind:value={draft.anfitriao.redeSocial}
+                class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+              />
+            </label>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <div class="space-y-3 rounded-2xl bg-surface-muted/60 p-4">
+                <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-muted">Correspondência</h3>
+                <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-corr-cep">
+                  CEP
+                  <input
+                    id="wizard-corr-cep"
+                    type="text"
+                    maxlength="9"
+                    bind:value={draft.anfitriao.correspondencia.cep}
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  />
+                </label>
+                <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-corr-logradouro">
+                  Logradouro
+                  <input
+                    id="wizard-corr-logradouro"
+                    type="text"
+                    bind:value={draft.anfitriao.correspondencia.logradouro}
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  />
+                </label>
+                <div class="grid gap-3 md:grid-cols-3">
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Número"
+                    bind:value={draft.anfitriao.correspondencia.numero}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Bairro"
+                    bind:value={draft.anfitriao.correspondencia.bairro}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Cidade"
+                    bind:value={draft.anfitriao.correspondencia.cidade}
+                  />
+                </div>
+                <div class="grid gap-3 md:grid-cols-2">
+                  <input
+                    class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+                    placeholder="UF"
+                    maxlength="2"
+                    bind:value={draft.anfitriao.correspondencia.uf}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Complemento"
+                    bind:value={draft.anfitriao.correspondencia.complemento}
+                  />
+                </div>
+              </div>
+              <div class="space-y-3 rounded-2xl bg-surface-muted/60 p-4">
+                <h3 class="text-sm font-semibold uppercase tracking-wide text-ink-muted">Entrega de presentes</h3>
+                <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-entrega-cep">
+                  CEP
+                  <input
+                    id="wizard-entrega-cep"
+                    type="text"
+                    maxlength="9"
+                    bind:value={draft.anfitriao.entrega.cep}
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  />
+                </label>
+                <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-entrega-logradouro">
+                  Logradouro
+                  <input
+                    id="wizard-entrega-logradouro"
+                    type="text"
+                    bind:value={draft.anfitriao.entrega.logradouro}
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  />
+                </label>
+                <div class="grid gap-3 md:grid-cols-3">
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Número"
+                    bind:value={draft.anfitriao.entrega.numero}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Bairro"
+                    bind:value={draft.anfitriao.entrega.bairro}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Cidade"
+                    bind:value={draft.anfitriao.entrega.cidade}
+                  />
+                </div>
+                <div class="grid gap-3 md:grid-cols-2">
+                  <input
+                    class="form-input rounded-xl border-slate-300 uppercase focus:border-brand focus:ring-brand"
+                    placeholder="UF"
+                    maxlength="2"
+                    bind:value={draft.anfitriao.entrega.uf}
+                  />
+                  <input
+                    class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                    placeholder="Complemento"
+                    bind:value={draft.anfitriao.entrega.complemento}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2">
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-cerimonial-nome">
+                Cerimonialista (opcional)
+                <input
+                  id="wizard-cerimonial-nome"
+                  type="text"
+                  bind:value={draft.cerimonialista.nome}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                  placeholder="Nome completo"
+                />
+              </label>
+              <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-cerimonial-telefone">
+                Telefone do cerimonial
+                <input
+                  id="wizard-cerimonial-telefone"
+                  type="text"
+                  bind:value={draft.cerimonialista.telefone}
+                  class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+                />
+              </label>
+            </div>
+            <label class="flex flex-col gap-1 text-sm font-medium text-ink" for="wizard-cerimonial-rede">
+              Rede social do cerimonial
+              <input
+                id="wizard-cerimonial-rede"
+                type="text"
+                bind:value={draft.cerimonialista.redeSocial}
+                class="form-input rounded-xl border-slate-300 focus:border-brand focus:ring-brand"
+              />
+            </label>
+          </section>
+        {:else}
+          <section class="space-y-4">
+            <h2 class="text-lg font-semibold text-ink">Monte o checklist inicial</h2>
+            <p class="text-sm text-ink-muted">
+              Selecione os itens que melhor representam as atividades iniciais do evento. Você poderá ajustar tudo depois.
+            </p>
+            <div class="grid gap-3 md:grid-cols-2">
+              {#each checklist as item (item.id)}
+                <label class="flex h-full flex-col justify-between gap-3 rounded-2xl border border-slate-200 bg-surface p-4 shadow-sm">
+                  <div class="flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      bind:checked={item.selected}
+                      class="mt-1 h-4 w-4 rounded border-slate-300 text-brand focus:ring-brand"
+                    />
+                    <div class="space-y-1">
+                      <h3 class="text-sm font-semibold text-ink">{item.title}</h3>
+                      <p class="text-xs text-ink-muted">{item.description}</p>
+                    </div>
+                  </div>
+                  <span class="text-xs font-medium uppercase tracking-wide text-brand">{item.category}</span>
+                </label>
+              {/each}
+            </div>
+            {#if selectedTasks().length === 0}
+              <p class="rounded-xl bg-warning/10 px-4 py-2 text-sm text-warning">
+                Selecione pelo menos um item para iniciar o checklist do evento.
+              </p>
+            {/if}
+          </section>
+        {/if}
+      </div>
+
+      {#if error}
+        <div class="mt-4 rounded-xl bg-danger/10 px-4 py-2 text-sm text-danger">{error}</div>
+      {/if}
+
+      <footer class="mt-6 flex items-center justify-between">
+        <div class="text-xs text-ink-muted">
+          Você poderá editar qualquer informação após criar o evento.
+        </div>
+        <div class="flex items-center gap-3">
+          {#if !isFirstStep()}
+            <button
+              type="button"
+              class="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-ink transition hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+              on:click={prev}
+              disabled={busy}
+            >
+              Voltar
+            </button>
+          {/if}
+          {#if !isLastStep()}
+            <button
+              type="button"
+              class="rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground transition hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:opacity-60"
+              on:click={next}
+              disabled={busy || !isStepValid()}
+            >
+              Avançar
+            </button>
+          {:else}
+            <button
+              type="button"
+              class="rounded-xl bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground transition hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:opacity-60"
+              on:click={handleCreate}
+              disabled={busy || selectedTasks().length === 0}
+            >
+              {busy ? 'Criando...' : 'Criar evento com checklist'}
+            </button>
+          {/if}
+        </div>
+      </footer>
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/stores/ui.ts
+++ b/apps/web/src/lib/stores/ui.ts
@@ -1,0 +1,74 @@
+import { writable } from 'svelte/store';
+
+export type PanelId =
+  | 'overview'
+  | 'evento'
+  | 'anfitriao'
+  | 'cerimonial'
+  | 'tarefas'
+  | 'fornecedores'
+  | 'convidados'
+  | 'mensagens'
+  | 'sync';
+
+export interface PanelDefinition {
+  id: PanelId;
+  label: string;
+  description: string;
+  icon?: string;
+}
+
+export const panelDefinitions: PanelDefinition[] = [
+  { id: 'overview', label: 'Visão geral', description: 'Resumo e indicadores', icon: '📊' },
+  { id: 'evento', label: 'Evento', description: 'Detalhes principais', icon: '🎉' },
+  { id: 'anfitriao', label: 'Anfitrião', description: 'Informações de contato', icon: '🤝' },
+  { id: 'cerimonial', label: 'Cerimonial', description: 'Equipe de apoio', icon: '📝' },
+  { id: 'tarefas', label: 'Tarefas', description: 'Checklist colaborativo', icon: '✅' },
+  { id: 'fornecedores', label: 'Fornecedores', description: 'Contratos e pagamentos', icon: '🏷️' },
+  { id: 'convidados', label: 'Convidados', description: 'Listas e convites', icon: '💌' },
+  { id: 'mensagens', label: 'Mensagens', description: 'Comunicação centralizada', icon: '💬' },
+  { id: 'sync', label: 'Sincronização', description: 'Backups e integrações', icon: '☁️' },
+];
+
+const createPanelStore = () => {
+  const { subscribe, set, update } = writable<PanelId>('overview');
+
+  return {
+    subscribe,
+    open(panel: PanelId) {
+      update((current) => (current === panel ? 'overview' : panel));
+    },
+    set(panel: PanelId) {
+      set(panel);
+    },
+    reset() {
+      set('overview');
+    },
+  };
+};
+
+const panelStore = createPanelStore();
+
+export const activePanel = { subscribe: panelStore.subscribe };
+export const openPanel = (panel: PanelId) => panelStore.open(panel);
+export const setPanel = (panel: PanelId) => panelStore.set(panel);
+export const closePanel = () => panelStore.reset();
+
+interface OnboardingState {
+  open: boolean;
+  step: number;
+}
+
+const onboardingStore = writable<OnboardingState>({ open: false, step: 0 });
+
+export const onboardingState = {
+  subscribe: onboardingStore.subscribe,
+};
+
+export function openOnboarding(step = 0): void {
+  onboardingStore.set({ open: true, step });
+}
+
+export function closeOnboarding(): void {
+  onboardingStore.set({ open: false, step: 0 });
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -4,6 +4,9 @@
   import DashboardBadges from '$lib/components/DashboardBadges.svelte';
   import DashboardSummaryPanels from '$lib/components/DashboardSummaryPanels.svelte';
   import DashboardIndicators from '$lib/components/DashboardIndicators.svelte';
+  import DashboardNavigation from '$lib/components/DashboardNavigation.svelte';
+  import OnboardingWizard from '$lib/components/OnboardingWizard.svelte';
+  import { activePanel } from '$lib/stores/ui';
   import { initDashboard } from '$lib/dashboard/initDashboard';
 
   onMount(() => {
@@ -15,14 +18,34 @@
   <title>Gerenciar Eventos — AC (v2) + Mini‑Apps (fallback Safari)</title>
 </svelte:head>
 
-<main class="ac">
-  <div class="container">
-    <section class="card" id="cardResumo">
-      <DashboardHeader />
-      <DashboardBadges />
-      <DashboardSummaryPanels />
-    </section>
+<main class="min-h-screen bg-surface-muted">
+  <div class="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10">
+    <DashboardHeader />
 
-    <DashboardIndicators />
+    <div class="grid gap-6 lg:grid-cols-[280px,1fr]">
+      <DashboardNavigation />
+
+      <div class="flex flex-col gap-6">
+        <section
+          class="card space-y-6"
+          id="panel-overview-summary"
+          data-panel="overview"
+          hidden={$activePanel !== 'overview'}
+        >
+          <div class="flex flex-col gap-2">
+            <h2 class="text-xl font-semibold text-ink">Resumo rápido</h2>
+            <p class="text-sm text-ink-muted">
+              Informações principais do evento atualizadas em tempo real.
+            </p>
+          </div>
+          <DashboardBadges />
+        </section>
+
+        <DashboardSummaryPanels />
+        <DashboardIndicators />
+      </div>
+    </div>
   </div>
+
+  <OnboardingWizard />
 </main>

--- a/apps/web/tailwind.config.cjs
+++ b/apps/web/tailwind.config.cjs
@@ -1,0 +1,47 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+const forms = require('@tailwindcss/forms');
+
+const withOpacity = (variable) => ({ opacityValue }) => {
+  if (opacityValue === undefined) {
+    return `rgb(var(${variable}))`;
+  }
+  return `rgb(var(${variable}) / ${opacityValue})`;
+};
+
+module.exports = {
+  content: ['./src/**/*.{html,js,svelte,ts}'],
+  theme: {
+    extend: {
+      colors: {
+        surface: {
+          DEFAULT: withOpacity('--color-surface'),
+          muted: withOpacity('--color-surface-muted'),
+        },
+        brand: {
+          DEFAULT: withOpacity('--color-brand'),
+          foreground: withOpacity('--color-brand-foreground'),
+        },
+        ink: {
+          DEFAULT: withOpacity('--color-ink'),
+          muted: withOpacity('--color-ink-muted'),
+        },
+        success: withOpacity('--color-success'),
+        warning: withOpacity('--color-warning'),
+        danger: withOpacity('--color-danger'),
+        accent: withOpacity('--color-accent'),
+      },
+      borderRadius: {
+        xl: '1.25rem',
+      },
+      boxShadow: {
+        card: '0 20px 45px rgba(15, 23, 42, 0.08)',
+      },
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    forms({ strategy: 'class' }),
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,12 @@
         "@sveltejs/adapter-auto": "^6.1.0",
         "@sveltejs/kit": "^2.43.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
+        "@tailwindcss/forms": "^0.5.9",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
         "svelte": "^5.39.5",
         "svelte-check": "^4.3.2",
+        "tailwindcss": "^3.4.17",
         "typescript": "^5.9.2",
         "vite": "^7.1.7"
       }
@@ -61,6 +65,19 @@
     "node_modules/@ac/data": {
       "resolved": "packages/data",
       "link": true
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.10",
@@ -504,6 +521,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -597,6 +632,55 @@
     "node_modules/@marco/platform": {
       "resolved": "packages/platform",
       "link": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.55.1",
@@ -1034,6 +1118,19 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1074,6 +1171,73 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -1090,6 +1254,44 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1098,6 +1300,36 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.11.tgz",
+      "integrity": "sha512-i+sRXGhz4+QW8aACZ3+r1GAKMt0wlFpeA8M5rOQd0HEYw9zhDrlx9Wc8uQ0IdXakjJRthzglEwfB/yqIjO6iDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -1139,6 +1371,63 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1177,6 +1466,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001747",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001747.tgz",
+      "integrity": "sha512-mzFa2DGIhuc5490Nd/G31xN1pnBnYMadtkyTjefPI7wzypqgCEpeWu9bJr0OnDsyKrW75zA9ZAt7pbQFmwLsQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1201,6 +1521,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/content-disposition": {
@@ -1251,6 +1601,34 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/debug": {
@@ -1316,6 +1694,20 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1330,10 +1722,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.230.tgz",
+      "integrity": "sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1415,6 +1828,16 @@
         "@esbuild/win32-arm64": "0.25.10",
         "@esbuild/win32-ia32": "0.25.10",
         "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1581,6 +2004,46 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1597,6 +2060,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -1632,6 +2108,23 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1639,6 +2132,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -1722,6 +2229,40 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gopd": {
@@ -1812,6 +2353,78 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1820,6 +2433,39 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/kleur": {
@@ -1832,12 +2478,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.19",
@@ -1876,6 +2549,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -1883,6 +2566,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -1918,6 +2628,42 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -1943,6 +2689,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1972,6 +2730,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1979,6 +2764,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -2005,6 +2800,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2012,6 +2814,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2038,6 +2874,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/playwright": {
@@ -2101,6 +2957,140 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2129,6 +3119,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2153,6 +3164,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2167,6 +3188,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2175,6 +3217,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -2217,6 +3270,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.52.4",
         "@rollup/rollup-win32-x64-msvc": "4.52.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sade": {
@@ -2334,6 +3411,29 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -2406,6 +3506,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2438,6 +3551,146 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svelte": {
@@ -2490,6 +3743,131 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
+      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2505,6 +3883,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2525,6 +3916,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -2596,6 +3994,44 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2741,6 +4177,120 @@
     "node_modules/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",


### PR DESCRIPTION
## Summary
- integrate Tailwind-based design tokens and navigation store to modernize the dashboard experience
- add an onboarding wizard that guides event setup before persisting new projects and seeds initial checklists
- refactor dashboard layout with sidebar navigation, responsive cards, and a dedicated messages host while preserving mini-app mounting logic

## Testing
- `npm --workspace web run check` *(fails: existing TypeScript issues in shared packages such as projectStore.ts and syncClient.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e11ae5dc8c83208163e3cbcc9cccd2