### PR TITLE
feat(web): create AppBase layout scaffolding

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,23 +1,16 @@
+@import './lib/styles/tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --color-surface: 255 255 255;
-    --color-surface-muted: 243 246 251;
-    --color-brand: 11 101 194;
-    --color-brand-foreground: 255 255 255;
-    --color-ink: 31 41 55;
-    --color-ink-muted: 100 116 139;
-    --color-success: 16 185 129;
-    --color-warning: 245 158 11;
-    --color-danger: 220 38 38;
-    --color-accent: 14 165 233;
-  }
-
   body {
-    @apply bg-surface-muted text-ink font-sans antialiased;
+    background-color: var(--app-body-background);
+    color: var(--app-body-text-color);
+    font-family: var(--app-body-font-family);
+    font-weight: var(--app-body-font-weight);
+    @apply antialiased;
   }
 
   h1,
@@ -26,7 +19,8 @@
   h4,
   h5,
   h6 {
-    @apply text-ink font-semibold;
+    color: var(--app-heading-text-color);
+    font-weight: var(--app-heading-font-weight);
   }
 
   button {

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -5,7 +5,7 @@
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 %sveltekit.head%
         </head>
-        <body data-sveltekit-preload-data="hover">
-                <div style="display: contents">%sveltekit.body%</div>
+        <body class="app-base-body" data-sveltekit-preload-data="hover">
+                <div class="app-base-root">%sveltekit.body%</div>
         </body>
 </html>

--- a/apps/web/src/lib/layout/AppBaseLayout.svelte
+++ b/apps/web/src/lib/layout/AppBaseLayout.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  let { class: className = '', top, nav, workspace, app, children } = $props();
+</script>
+
+<div class={`app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink ${className}`.trim()}>
+  <header class="app-base-layout__top border-b border-surface-muted bg-surface px-6 py-4 shadow-sm">
+    {@render top?.()}
+  </header>
+
+  <div class="app-base-layout__canvas flex min-h-0 flex-1 overflow-hidden">
+    <nav class="app-base-layout__nav w-72 shrink-0 border-r border-surface-muted bg-surface px-4 py-6">
+      {@render nav?.()}
+    </nav>
+
+    <main class="app-base-layout__workspace flex-1 overflow-hidden bg-surface px-6 py-6">
+      {#if workspace}
+        {@render workspace()}
+      {:else}
+        <div class="app-base-layout__app h-full overflow-auto">
+          {#if app}
+            {@render app()}
+          {:else}
+            {@render children?.()}
+          {/if}
+        </div>
+      {/if}
+    </main>
+  </div>
+</div>

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -1,0 +1,20 @@
+:root {
+  --color-surface: 255 255 255;
+  --color-surface-muted: 243 246 251;
+  --color-brand: 11 101 194;
+  --color-brand-foreground: 255 255 255;
+  --color-ink: 31 41 55;
+  --color-ink-muted: 100 116 139;
+  --color-success: 16 185 129;
+  --color-warning: 245 158 11;
+  --color-danger: 220 38 38;
+  --color-accent: 14 165 233;
+
+  --app-body-font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --app-body-font-weight: 400;
+  --app-body-text-color: rgb(var(--color-ink));
+  --app-body-background: rgb(var(--color-surface-muted));
+  --app-heading-font-weight: 600;
+  --app-heading-text-color: rgb(var(--color-ink));
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
         import '../app.css';
+        import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
         import favicon from '$lib/assets/favicon.svg';
 
         let { children } = $props();
@@ -9,4 +10,6 @@
         <link rel="icon" href={favicon} />
 </svelte:head>
 
-{@render children?.()}
+<AppBaseLayout>
+        {@render children?.()}
+</AppBaseLayout>


### PR DESCRIPTION
## Summary
- add an AppBaseLayout component with named slots to host the shell header, navigation, and workspace areas
- wrap the root layout with the new scaffold and tweak the HTML shell while keeping a dedicated app slot for feature modules
- centralize global typography and color settings into reusable CSS tokens consumed by the app styles

## Testing
- npm run test:visual *(fails: ReferenceError: exports is not defined in tests/fixtures/wedding.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e1293d72ec8320a6374b880f9e4e67