### PR TITLE
feat: add app base widget library build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "build:widget": "vite build --mode widget",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/apps/web/src/app-base-widget.ts
+++ b/apps/web/src/app-base-widget.ts
@@ -1,0 +1,87 @@
+import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
+import './app.css';
+
+type ModuleRequest = {
+  id: string;
+};
+
+export type ModuleManifest = {
+  id: string;
+  url: string;
+  displayName?: string;
+  [key: string]: unknown;
+};
+
+declare global {
+  interface WindowEventMap {
+    'app-base:register-manifest': CustomEvent<ModuleManifest>;
+    'app-base:request-module': CustomEvent<ModuleRequest>;
+    'app-base:module-pending': CustomEvent<{
+      id: string;
+      manifest: ModuleManifest;
+    }>;
+  }
+}
+
+const manifestRegistry = new Map<string, ModuleManifest>();
+
+const ensureRoot = () => {
+  const rootId = 'app-base-widget-root';
+  const existing = document.getElementById(rootId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const element = document.createElement('div');
+  element.id = rootId;
+  document.body.appendChild(element);
+
+  return element;
+};
+
+const appBaseWidget = typeof document !== 'undefined'
+  ? new AppBaseLayout({
+      target: ensureRoot()
+    })
+  : undefined;
+
+const handleManifestRegistration = (event: WindowEventMap['app-base:register-manifest']) => {
+  const manifest = event.detail;
+
+  if (!manifest?.id || !manifest.url) {
+    console.warn('[AppBaseWidget] Manifesto inválido recebido.', manifest);
+    return;
+  }
+
+  manifestRegistry.set(manifest.id, manifest);
+};
+
+const handleModuleRequest = (event: WindowEventMap['app-base:request-module']) => {
+  const { id } = event.detail ?? {};
+
+  if (!id) {
+    console.warn('[AppBaseWidget] Solicitação de módulo sem identificador.', event.detail);
+    return;
+  }
+
+  const manifest = manifestRegistry.get(id);
+
+  if (!manifest) {
+    console.warn(`[AppBaseWidget] Nenhum manifesto encontrado para o módulo "${id}".`);
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent('app-base:module-pending', {
+      detail: { id, manifest }
+    })
+  );
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('app-base:register-manifest', handleManifestRegistration);
+  window.addEventListener('app-base:request-module', handleModuleRequest);
+}
+
+export { appBaseWidget, manifestRegistry };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,18 +1,60 @@
-// @ts-nocheck
 import { sveltekit } from '@sveltejs/kit/vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-        plugins: [sveltekit()],
-        resolve: {
-                alias: {
-                        '@tools': path.resolve('../..', 'tools')
-                }
-        },
-        server: {
-                fs: {
-                        allow: [path.resolve('..'), path.resolve('../..')]
-                }
+const widgetBuild = {
+  lib: {
+    entry: path.resolve('src', 'app-base-widget.ts'),
+    name: 'AppBaseWidget',
+    fileName: (format: string) => (format === 'es' ? 'app-base-widget.js' : 'app-base-widget.umd.js'),
+    formats: ['es', 'umd'] as const
+  },
+  cssCodeSplit: false,
+  rollupOptions: {
+    output: {
+      assetFileNames: (assetInfo: { name?: string }) => {
+        if (assetInfo.name?.endsWith('.css')) {
+          return 'app-base-widget.css';
         }
+
+        return 'assets/[name]-[hash][extname]';
+      }
+    }
+  }
+} satisfies NonNullable<Parameters<typeof defineConfig>[0]>['build'];
+
+export default defineConfig(({ mode }) => {
+  const isWidgetBuild = mode === 'widget';
+
+  return {
+    plugins: isWidgetBuild
+      ? [
+          svelte({
+            extensions: ['.svelte']
+          })
+        ]
+      : [sveltekit()],
+    resolve: {
+      alias: {
+        '@tools': path.resolve('../..', 'tools'),
+        ...(isWidgetBuild
+          ? {
+              $lib: path.resolve('src/lib')
+            }
+          : {})
+      }
+    },
+    server: {
+      fs: {
+        allow: [path.resolve('..'), path.resolve('../..')]
+      }
+    },
+    build: isWidgetBuild
+      ? {
+          ...widgetBuild,
+          emptyOutDir: true
+        }
+      : undefined
+  };
 });


### PR DESCRIPTION
## Summary
- add a Svelte entrypoint that mounts `AppBaseLayout` with empty slots and manifest listeners for future module loading
- configure Vite to emit a widget-oriented library bundle with fixed JS/CSS filenames and expose a dedicated build script

## Testing
- npm run build:widget --workspace web
- npm run test:visual *(fails: existing SvelteKit template requires `%sveltekit.body%` in src/app.html)*
- npm run lint --workspace web *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e174b7b4448320823b7a3779fe52c7