### PR TITLE
Add widget build script generating standalone HTML snippet

### DIFF
--- a/apps/web/src/app-base-widget.ts
+++ b/apps/web/src/app-base-widget.ts
@@ -30,11 +30,13 @@ const ensureRoot = () => {
   const existing = document.getElementById(rootId);
 
   if (existing) {
+    existing.classList.add('app-base-widget');
     return existing;
   }
 
   const element = document.createElement('div');
   element.id = rootId;
+  element.classList.add('app-base-widget');
   document.body.appendChild(element);
 
   return element;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -5,7 +5,7 @@
 @tailwind utilities;
 
 @layer base {
-  body {
+  :where(.app-base-body, #app-base-widget-root) {
     background-color: var(--app-body-background);
     color: var(--app-body-text-color);
     font-family: var(--app-body-font-family);
@@ -13,47 +13,55 @@
     @apply antialiased;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  :where(
+      .app-base-body h1,
+      .app-base-body h2,
+      .app-base-body h3,
+      .app-base-body h4,
+      .app-base-body h5,
+      .app-base-body h6,
+      #app-base-widget-root h1,
+      #app-base-widget-root h2,
+      #app-base-widget-root h3,
+      #app-base-widget-root h4,
+      #app-base-widget-root h5,
+      #app-base-widget-root h6
+    ) {
     color: var(--app-heading-text-color);
     font-weight: var(--app-heading-font-weight);
   }
 
-  button {
+  :where(.app-base-body button, #app-base-widget-root button) {
     font: inherit;
   }
 }
 
 @layer components {
-  .card {
+  :where(.app-base-root, #app-base-widget-root) .card {
     @apply rounded-2xl bg-surface shadow-card ring-1 ring-black/5;
   }
 
-  .chip {
+  :where(.app-base-root, #app-base-widget-root) .chip {
     @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium;
   }
 
-  .chip--success {
+  :where(.app-base-root, #app-base-widget-root) .chip--success {
     @apply bg-success/10 text-success;
   }
 
-  .chip--warning {
+  :where(.app-base-root, #app-base-widget-root) .chip--warning {
     @apply bg-warning/10 text-warning;
   }
 
-  .chip--info {
+  :where(.app-base-root, #app-base-widget-root) .chip--info {
     @apply bg-accent/10 text-accent;
   }
 
-  #panel-overview .active {
+  :where(.app-base-root #panel-overview .active, #app-base-widget-root #panel-overview .active) {
     @apply border-brand/60 bg-brand/5 ring-2 ring-brand/30;
   }
 
-  #hdr_sync_badge.active {
+  :where(.app-base-root #hdr_sync_badge.active, #app-base-widget-root #hdr_sync_badge.active) {
     @apply ring-2 ring-brand/40;
   }
 }

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root, #app-base-widget-root) {
   --color-surface: 255 255 255;
   --color-surface-muted: 243 246 251;
   --color-brand: 11 101 194;

--- a/dist/app-base-widget.html
+++ b/dist/app-base-widget.html
@@ -1,0 +1,1202 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :where(:root,#app-base-widget-root){--color-surface: 255 255 255;--color-surface-muted: 243 246 251;--color-brand: 11 101 194;--color-brand-foreground: 255 255 255;--color-ink: 31 41 55;--color-ink-muted: 100 116 139;--color-success: 16 185 129;--color-warning: 245 158 11;--color-danger: 220 38 38;--color-accent: 14 165 233;--app-body-font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;--app-body-font-weight: 400;--app-body-text-color: rgb(var(--color-ink));--app-body-background: rgb(var(--color-surface-muted));--app-heading-font-weight: 600;--app-heading-text-color: rgb(var(--color-ink))}*,:before,:after{--tw-border-spacing-x: 0;--tw-border-spacing-y: 0;--tw-translate-x: 0;--tw-translate-y: 0;--tw-rotate: 0;--tw-skew-x: 0;--tw-skew-y: 0;--tw-scale-x: 1;--tw-scale-y: 1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness: proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width: 0px;--tw-ring-offset-color: #fff;--tw-ring-color: rgb(59 130 246 / .5);--tw-ring-offset-shadow: 0 0 #0000;--tw-ring-shadow: 0 0 #0000;--tw-shadow: 0 0 #0000;--tw-shadow-colored: 0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }::backdrop{--tw-border-spacing-x: 0;--tw-border-spacing-y: 0;--tw-translate-x: 0;--tw-translate-y: 0;--tw-rotate: 0;--tw-skew-x: 0;--tw-skew-y: 0;--tw-scale-x: 1;--tw-scale-y: 1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness: proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width: 0px;--tw-ring-offset-color: #fff;--tw-ring-color: rgb(59 130 246 / .5);--tw-ring-offset-shadow: 0 0 #0000;--tw-ring-shadow: 0 0 #0000;--tw-shadow: 0 0 #0000;--tw-shadow-colored: 0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }*,:before,:after{box-sizing:border-box;border-width:0;border-style:solid;border-color:#e5e7eb}:before,:after{--tw-content: ""}html,:host{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;-o-tab-size:4;tab-size:4;font-family:Inter,ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol,"Noto Color Emoji";font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;letter-spacing:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}button,input:where([type=button]),input:where([type=reset]),input:where([type=submit]){-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dl,dd,h1,h2,h3,h4,h5,h6,hr,figure,p,pre{margin:0}fieldset{margin:0;padding:0}legend{padding:0}ol,ul,menu{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::-moz-placeholder,textarea::-moz-placeholder{opacity:1;color:#9ca3af}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}button,[role=button]{cursor:pointer}:disabled{cursor:default}img,svg,video,canvas,audio,iframe,embed,object{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]:where(:not([hidden=until-found])){display:none}:where(.app-base-body,#app-base-widget-root){background-color:var(--app-body-background);color:var(--app-body-text-color);font-family:var(--app-body-font-family);font-weight:var(--app-body-font-weight);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}:where(.app-base-body h1,.app-base-body h2,.app-base-body h3,.app-base-body h4,.app-base-body h5,.app-base-body h6,#app-base-widget-root h1,#app-base-widget-root h2,#app-base-widget-root h3,#app-base-widget-root h4,#app-base-widget-root h5,#app-base-widget-root h6){color:var(--app-heading-text-color);font-weight:var(--app-heading-font-weight)}:where(.app-base-body button,#app-base-widget-root button){font:inherit}.form-input,.form-textarea,.form-select,.form-multiselect{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-color:#fff;border-color:#6b7280;border-width:1px;border-radius:0;padding:.5rem .75rem;font-size:1rem;line-height:1.5rem;--tw-shadow: 0 0 #0000}.form-input:focus,.form-textarea:focus,.form-select:focus,.form-multiselect:focus{outline:2px solid transparent;outline-offset:2px;--tw-ring-inset: var(--tw-empty, );--tw-ring-offset-width: 0px;--tw-ring-offset-color: #fff;--tw-ring-color: #2563eb;--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow);border-color:#2563eb}.form-input::-moz-placeholder,.form-textarea::-moz-placeholder{color:#6b7280;opacity:1}.form-input::placeholder,.form-textarea::placeholder{color:#6b7280;opacity:1}.form-input::-webkit-datetime-edit-fields-wrapper{padding:0}.form-input::-webkit-date-and-time-value{min-height:1.5em;text-align:inherit}.form-input::-webkit-datetime-edit{display:inline-flex}.form-input::-webkit-datetime-edit,.form-input::-webkit-datetime-edit-year-field,.form-input::-webkit-datetime-edit-month-field,.form-input::-webkit-datetime-edit-day-field,.form-input::-webkit-datetime-edit-hour-field,.form-input::-webkit-datetime-edit-minute-field,.form-input::-webkit-datetime-edit-second-field,.form-input::-webkit-datetime-edit-millisecond-field,.form-input::-webkit-datetime-edit-meridiem-field{padding-top:0;padding-bottom:0}.form-select{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");background-position:right .5rem center;background-repeat:no-repeat;background-size:1.5em 1.5em;padding-right:2.5rem;-webkit-print-color-adjust:exact;print-color-adjust:exact}.form-select:where([size]:not([size="1"])){background-image:initial;background-position:initial;background-repeat:unset;background-size:initial;padding-right:.75rem;-webkit-print-color-adjust:unset;print-color-adjust:unset}:where(.app-base-root,#app-base-widget-root) .card{border-radius:1rem;--tw-bg-opacity: 1;background-color:rgb(var(--color-surface) / var(--tw-bg-opacity, 1));--tw-shadow: 0 20px 45px rgba(15, 23, 42, .08);--tw-shadow-colored: 0 20px 45px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow);--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 #0000);--tw-ring-color: rgb(0 0 0 / .05)}:where(.app-base-root,#app-base-widget-root) .chip{display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;padding:.25rem .75rem;font-size:.75rem;line-height:1rem;font-weight:500}:where(.app-base-root,#app-base-widget-root) .chip--success{background-color:rgb(var(--color-success) / .1);--tw-text-opacity: 1;color:rgb(var(--color-success) / var(--tw-text-opacity, 1))}:where(.app-base-root,#app-base-widget-root) .chip--warning{background-color:rgb(var(--color-warning) / .1);--tw-text-opacity: 1;color:rgb(var(--color-warning) / var(--tw-text-opacity, 1))}:where(.app-base-root,#app-base-widget-root) .chip--info{background-color:rgb(var(--color-accent) / .1);--tw-text-opacity: 1;color:rgb(var(--color-accent) / var(--tw-text-opacity, 1))}:where(.app-base-root #panel-overview .active,#app-base-widget-root #panel-overview .active){border-color:rgb(var(--color-brand) / .6);background-color:rgb(var(--color-brand) / .05);--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 #0000);--tw-ring-color: rgb(var(--color-brand) / .3)}:where(.app-base-root #hdr_sync_badge.active,#app-base-widget-root #hdr_sync_badge.active){--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 #0000);--tw-ring-color: rgb(var(--color-brand) / .4)}.fixed{position:fixed}.absolute{position:absolute}.relative{position:relative}.inset-0{inset:0}.right-4{right:1rem}.top-4{top:1rem}.z-50{z-index:50}.mb-6{margin-bottom:1.5rem}.mt-1{margin-top:.25rem}.mt-4{margin-top:1rem}.mt-6{margin-top:1.5rem}.flex{display:flex}.grid{display:grid}.h-2{height:.5rem}.h-4{height:1rem}.h-full{height:100%}.min-h-0{min-height:0px}.min-h-screen{min-height:100vh}.w-4{width:1rem}.w-72{width:18rem}.w-full{width:100%}.max-w-3xl{max-width:48rem}.flex-1{flex:1 1 0%}.shrink-0{flex-shrink:0}.grid-rows-\[auto\,1fr\]{grid-template-rows:auto 1fr}.flex-col{flex-direction:column}.items-start{align-items:flex-start}.items-center{align-items:center}.justify-center{justify-content:center}.justify-between{justify-content:space-between}.gap-1{gap:.25rem}.gap-3{gap:.75rem}.gap-4{gap:1rem}.space-y-1>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(.25rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.25rem * var(--tw-space-y-reverse))}.space-y-2>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(.5rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.5rem * var(--tw-space-y-reverse))}.space-y-3>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(.75rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.75rem * var(--tw-space-y-reverse))}.space-y-4>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(1rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(1rem * var(--tw-space-y-reverse))}.space-y-6>:not([hidden])~:not([hidden]){--tw-space-y-reverse: 0;margin-top:calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(1.5rem * var(--tw-space-y-reverse))}.overflow-auto{overflow:auto}.overflow-hidden{overflow:hidden}.rounded{border-radius:.25rem}.rounded-2xl{border-radius:1rem}.rounded-3xl{border-radius:1.5rem}.rounded-full{border-radius:9999px}.rounded-xl{border-radius:1.25rem}.border{border-width:1px}.border-b{border-bottom-width:1px}.border-r{border-right-width:1px}.border-slate-200{--tw-border-opacity: 1;border-color:rgb(226 232 240 / var(--tw-border-opacity, 1))}.border-slate-300{--tw-border-opacity: 1;border-color:rgb(203 213 225 / var(--tw-border-opacity, 1))}.border-surface-muted{--tw-border-opacity: 1;border-color:rgb(var(--color-surface-muted) / var(--tw-border-opacity, 1))}.bg-black\/40{background-color:#0006}.bg-brand{--tw-bg-opacity: 1;background-color:rgb(var(--color-brand) / var(--tw-bg-opacity, 1))}.bg-danger\/10{background-color:rgb(var(--color-danger) / .1)}.bg-surface{--tw-bg-opacity: 1;background-color:rgb(var(--color-surface) / var(--tw-bg-opacity, 1))}.bg-surface-muted{--tw-bg-opacity: 1;background-color:rgb(var(--color-surface-muted) / var(--tw-bg-opacity, 1))}.bg-surface-muted\/60{background-color:rgb(var(--color-surface-muted) / .6)}.bg-warning\/10{background-color:rgb(var(--color-warning) / .1)}.p-2{padding:.5rem}.p-4{padding:1rem}.p-6{padding:1.5rem}.px-4{padding-left:1rem;padding-right:1rem}.px-6{padding-left:1.5rem;padding-right:1.5rem}.py-10{padding-top:2.5rem;padding-bottom:2.5rem}.py-2{padding-top:.5rem;padding-bottom:.5rem}.py-4{padding-top:1rem;padding-bottom:1rem}.py-6{padding-top:1.5rem;padding-bottom:1.5rem}.text-2xl{font-size:1.5rem;line-height:2rem}.text-lg{font-size:1.125rem;line-height:1.75rem}.text-sm{font-size:.875rem;line-height:1.25rem}.text-xs{font-size:.75rem;line-height:1rem}.font-medium{font-weight:500}.font-semibold{font-weight:600}.uppercase{text-transform:uppercase}.tracking-wide{letter-spacing:.025em}.text-brand{--tw-text-opacity: 1;color:rgb(var(--color-brand) / var(--tw-text-opacity, 1))}.text-brand-foreground{--tw-text-opacity: 1;color:rgb(var(--color-brand-foreground) / var(--tw-text-opacity, 1))}.text-danger{--tw-text-opacity: 1;color:rgb(var(--color-danger) / var(--tw-text-opacity, 1))}.text-ink{--tw-text-opacity: 1;color:rgb(var(--color-ink) / var(--tw-text-opacity, 1))}.text-ink-muted{--tw-text-opacity: 1;color:rgb(var(--color-ink-muted) / var(--tw-text-opacity, 1))}.text-warning{--tw-text-opacity: 1;color:rgb(var(--color-warning) / var(--tw-text-opacity, 1))}.shadow-2xl{--tw-shadow: 0 25px 50px -12px rgb(0 0 0 / .25);--tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.shadow-sm{--tw-shadow: 0 1px 2px 0 rgb(0 0 0 / .05);--tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)}.outline{outline-style:solid}.ring-1{--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 #0000)}.ring-black\/10{--tw-ring-color: rgb(0 0 0 / .1)}.filter{filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}.transition{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.hover\:bg-brand\/90:hover{background-color:rgb(var(--color-brand) / .9)}.hover\:bg-surface:hover{--tw-bg-opacity: 1;background-color:rgb(var(--color-surface) / var(--tw-bg-opacity, 1))}.hover\:bg-surface-muted:hover{--tw-bg-opacity: 1;background-color:rgb(var(--color-surface-muted) / var(--tw-bg-opacity, 1))}.focus\:border-brand:focus{--tw-border-opacity: 1;border-color:rgb(var(--color-brand) / var(--tw-border-opacity, 1))}.focus\:ring-brand:focus{--tw-ring-opacity: 1;--tw-ring-color: rgb(var(--color-brand) / var(--tw-ring-opacity, 1))}.focus-visible\:outline-none:focus-visible{outline:2px solid transparent;outline-offset:2px}.focus-visible\:ring-2:focus-visible{--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 #0000)}.focus-visible\:ring-brand\/60:focus-visible{--tw-ring-color: rgb(var(--color-brand) / .6)}.disabled\:opacity-60:disabled{opacity:.6}@media (min-width: 768px){.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}}
+    </style>
+  </head>
+  <body>
+    <div id="app-base-widget-root" class="app-base-widget"></div>
+    <script type="module">
+      typeof window < "u" && ((window.__svelte ??= {}).v ??= /* @__PURE__ */ new Set()).add("5");
+      const ce = 2, vt = Symbol(), Mt = !1;
+      var ve = Array.prototype.indexOf, Nt = Object.defineProperty;
+      const et = () => {
+      };
+      function _e(t) {
+        for (var e = 0; e < t.length; e++)
+          t[e]();
+      }
+      function Lt() {
+        var t, e, n = new Promise((r, l) => {
+          t = r, e = l;
+        });
+        return { promise: n, resolve: t, reject: e };
+      }
+      const E = 2, qt = 4, Pt = 8, K = 16, D = 32, z = 64, jt = 128, T = 256, it = 512, m = 1024, y = 2048, O = 4096, I = 8192, G = 16384, Ut = 32768, _t = 65536, de = 1 << 18, dt = 1 << 19, pe = 1 << 20, gt = 1 << 21, yt = 1 << 22, q = 1 << 23, nt = new class extends Error {
+        name = "StaleReactionError";
+        message = "The reaction that called `getAbortSignal()` was re-run or destroyed";
+      }();
+      function he() {
+        throw new Error("https://svelte.dev/e/async_derived_orphan");
+      }
+      function me() {
+        throw new Error("https://svelte.dev/e/effect_update_depth_exceeded");
+      }
+      function Bt(t) {
+        return t === this.v;
+      }
+      let we = !1, N = null;
+      function ft(t) {
+        N = t;
+      }
+      function ge(t, e = !1, n) {
+        N = {
+          p: N,
+          c: null,
+          e: null,
+          s: t,
+          x: null,
+          l: null
+        };
+      }
+      function be(t) {
+        var e = (
+          /** @type {ComponentContext} */
+          N
+        ), n = e.e;
+        if (n !== null) {
+          e.e = null;
+          for (var r of n)
+            Ue(r);
+        }
+        return N = e.p, /** @type {T} */
+        {};
+      }
+      function Ee() {
+        return !0;
+      }
+      let W = [];
+      function ye() {
+        var t = W;
+        W = [], _e(t);
+      }
+      function xe(t) {
+        if (W.length === 0) {
+          var e = W;
+          queueMicrotask(() => {
+            e === W && ye();
+          });
+        }
+        W.push(t);
+      }
+      const ke = /* @__PURE__ */ new WeakMap();
+      function Te(t) {
+        var e = c;
+        if (e === null)
+          return v.f |= q, t;
+        if ((e.f & Ut) === 0) {
+          if ((e.f & jt) === 0)
+            throw !e.parent && t instanceof Error && Wt(t), t;
+          e.b.error(t);
+        } else
+          ut(t, e);
+      }
+      function ut(t, e) {
+        for (; e !== null; ) {
+          if ((e.f & jt) !== 0)
+            try {
+              e.b.error(t);
+              return;
+            } catch (n) {
+              t = n;
+            }
+          e = e.parent;
+        }
+        throw t instanceof Error && Wt(t), t;
+      }
+      function Wt(t) {
+        const e = ke.get(t);
+        e && (Nt(t, "message", {
+          value: e.message
+        }), Nt(t, "stack", {
+          value: e.stack
+        }));
+      }
+      const st = /* @__PURE__ */ new Set();
+      let h = null, At = /* @__PURE__ */ new Set(), C = [], xt = null, bt = !1;
+      class L {
+        /**
+         * The current values of any sources that are updated in this batch
+         * They keys of this map are identical to `this.#previous`
+         * @type {Map<Source, any>}
+         */
+        current = /* @__PURE__ */ new Map();
+        /**
+         * The values of any sources that are updated in this batch _before_ those updates took place.
+         * They keys of this map are identical to `this.#current`
+         * @type {Map<Source, any>}
+         */
+        #n = /* @__PURE__ */ new Map();
+        /**
+         * When the batch is committed (and the DOM is updated), we need to remove old branches
+         * and append new ones by calling the functions added inside (if/each/key/etc) blocks
+         * @type {Set<() => void>}
+         */
+        #r = /* @__PURE__ */ new Set();
+        /**
+         * The number of async effects that are currently in flight
+         */
+        #t = 0;
+        /**
+         * A deferred that resolves when the batch is committed, used with `settled()`
+         * TODO replace with Promise.withResolvers once supported widely enough
+         * @type {{ promise: Promise<void>, resolve: (value?: any) => void, reject: (reason: unknown) => void } | null}
+         */
+        #f = null;
+        /**
+         * Async effects inside a newly-created `<svelte:boundary>`
+         * — these do not prevent the batch from committing
+         * @type {Effect[]}
+         */
+        #l = [];
+        /**
+         * Template effects and `$effect.pre` effects, which run when
+         * a batch is committed
+         * @type {Effect[]}
+         */
+        #a = [];
+        /**
+         * The same as `#render_effects`, but for `$effect` (which runs after)
+         * @type {Effect[]}
+         */
+        #e = [];
+        /**
+         * Block effects, which may need to re-run on subsequent flushes
+         * in order to update internal sources (e.g. each block items)
+         * @type {Effect[]}
+         */
+        #s = [];
+        /**
+         * Deferred effects (which run after async work has completed) that are DIRTY
+         * @type {Effect[]}
+         */
+        #u = [];
+        /**
+         * Deferred effects that are MAYBE_DIRTY
+         * @type {Effect[]}
+         */
+        #o = [];
+        /**
+         * A set of branches that still exist, but will be destroyed when this batch
+         * is committed — we skip over these during `process`
+         * @type {Set<Effect>}
+         */
+        skipped_effects = /* @__PURE__ */ new Set();
+        /**
+         *
+         * @param {Effect[]} root_effects
+         */
+        process(e) {
+          C = [];
+          var n = L.apply(this);
+          for (const a of e)
+            this.#c(a);
+          if (this.#t === 0) {
+            this.#v();
+            var r = this.#a, l = this.#e;
+            this.#a = [], this.#e = [], this.#s = [], h = null, Ct(r), Ct(l), this.#f?.resolve();
+          } else
+            this.#i(this.#a), this.#i(this.#e), this.#i(this.#s);
+          n();
+          for (const a of this.#l)
+            lt(a);
+          this.#l = [];
+        }
+        /**
+         * Traverse the effect tree, executing effects or stashing
+         * them for later execution as appropriate
+         * @param {Effect} root
+         */
+        #c(e) {
+          e.f ^= m;
+          for (var n = e.first; n !== null; ) {
+            var r = n.f, l = (r & (D | z)) !== 0, a = l && (r & m) !== 0, s = a || (r & I) !== 0 || this.skipped_effects.has(n);
+            if (!s && n.fn !== null) {
+              l ? n.f ^= m : (r & qt) !== 0 ? this.#e.push(n) : (r & m) === 0 && ((r & yt) !== 0 && n.b?.is_pending() ? this.#l.push(n) : pt(n) && ((n.f & K) !== 0 && this.#s.push(n), lt(n)));
+              var i = n.first;
+              if (i !== null) {
+                n = i;
+                continue;
+              }
+            }
+            var f = n.parent;
+            for (n = n.next; n === null && f !== null; )
+              n = f.next, f = f.parent;
+          }
+        }
+        /**
+         * @param {Effect[]} effects
+         */
+        #i(e) {
+          for (const n of e)
+            ((n.f & y) !== 0 ? this.#u : this.#o).push(n), g(n, m);
+          e.length = 0;
+        }
+        /**
+         * Associate a change to a given source with the current
+         * batch, noting its previous and current values
+         * @param {Source} source
+         * @param {any} value
+         */
+        capture(e, n) {
+          this.#n.has(e) || this.#n.set(e, n), this.current.set(e, e.v);
+        }
+        activate() {
+          h = this;
+        }
+        deactivate() {
+          h = null;
+          for (const e of At)
+            if (At.delete(e), e(), h !== null)
+              break;
+        }
+        flush() {
+          if (C.length > 0) {
+            if (this.activate(), Re(), h !== null && h !== this)
+              return;
+          } else this.#t === 0 && this.#v();
+          this.deactivate();
+        }
+        /**
+         * Append and remove branches to/from the DOM
+         */
+        #v() {
+          for (const e of this.#r)
+            e();
+          if (this.#r.clear(), st.size > 1) {
+            this.#n.clear();
+            let e = !0;
+            for (const n of st) {
+              if (n === this) {
+                e = !1;
+                continue;
+              }
+              for (const [r, l] of this.current) {
+                if (n.current.has(r))
+                  if (e)
+                    n.current.set(r, l);
+                  else
+                    continue;
+                Vt(r);
+              }
+              if (C.length > 0) {
+                h = n;
+                const r = L.apply(n);
+                for (const l of C)
+                  n.#c(l);
+                C = [], r();
+              }
+            }
+            h = null;
+          }
+          st.delete(this);
+        }
+        increment() {
+          this.#t += 1;
+        }
+        decrement() {
+          if (this.#t -= 1, this.#t === 0) {
+            for (const e of this.#u)
+              g(e, y), P(e);
+            for (const e of this.#o)
+              g(e, O), P(e);
+            this.flush();
+          } else
+            this.deactivate();
+        }
+        /** @param {() => void} fn */
+        add_callback(e) {
+          this.#r.add(e);
+        }
+        settled() {
+          return (this.#f ??= Lt()).promise;
+        }
+        static ensure() {
+          if (h === null) {
+            const e = h = new L();
+            st.add(h), L.enqueue(() => {
+              h === e && e.flush();
+            });
+          }
+          return h;
+        }
+        /** @param {() => void} task */
+        static enqueue(e) {
+          xe(e);
+        }
+        /**
+         * @param {Batch} current_batch
+         */
+        static apply(e) {
+          return et;
+        }
+      }
+      function Re() {
+        var t = V;
+        bt = !0;
+        try {
+          var e = 0;
+          for (It(!0); C.length > 0; ) {
+            var n = L.ensure();
+            if (e++ > 1e3) {
+              var r, l;
+              Ne();
+            }
+            n.process(C), S.clear();
+          }
+        } finally {
+          bt = !1, It(t), xt = null;
+        }
+      }
+      function Ne() {
+        try {
+          me();
+        } catch (t) {
+          ut(t, xt);
+        }
+      }
+      let M = null;
+      function Ct(t) {
+        var e = t.length;
+        if (e !== 0) {
+          for (var n = 0; n < e; ) {
+            var r = t[n++];
+            if ((r.f & (G | I)) === 0 && pt(r) && (M = [], lt(r), r.deps === null && r.first === null && r.nodes_start === null && (r.teardown === null && r.ac === null ? $t(r) : r.fn = null), M?.length > 0)) {
+              S.clear();
+              for (const l of M)
+                lt(l);
+              M = [];
+            }
+          }
+          M = null;
+        }
+      }
+      function Vt(t) {
+        if (t.reactions !== null)
+          for (const e of t.reactions) {
+            const n = e.f;
+            (n & E) !== 0 ? Vt(
+              /** @type {Derived} */
+              e
+            ) : (n & (yt | K)) !== 0 && (g(e, y), P(
+              /** @type {Effect} */
+              e
+            ));
+          }
+      }
+      function P(t) {
+        for (var e = xt = t; e.parent !== null; ) {
+          e = e.parent;
+          var n = e.f;
+          if (bt && e === c && (n & K) !== 0)
+            return;
+          if ((n & (z | D)) !== 0) {
+            if ((n & m) === 0) return;
+            e.f ^= m;
+          }
+        }
+        C.push(e);
+      }
+      function Ae(t, e, n) {
+        const r = Fe;
+        if (e.length === 0) {
+          n(t.map(r));
+          return;
+        }
+        var l = h, a = (
+          /** @type {Effect} */
+          c
+        ), s = Ce();
+        Promise.all(e.map((i) => /* @__PURE__ */ Se(i))).then((i) => {
+          l?.activate(), s();
+          try {
+            n([...t.map(r), ...i]);
+          } catch (f) {
+            (a.f & G) === 0 && ut(f, a);
+          }
+          l?.deactivate(), Yt();
+        }).catch((i) => {
+          ut(i, a);
+        });
+      }
+      function Ce() {
+        var t = c, e = v, n = N, r = h;
+        return function() {
+          H(t), Y(e), ft(n), r?.activate();
+        };
+      }
+      function Yt() {
+        H(null), Y(null), ft(null);
+      }
+      // @__NO_SIDE_EFFECTS__
+      function Fe(t) {
+        var e = E | y, n = v !== null && (v.f & E) !== 0 ? (
+          /** @type {Derived} */
+          v
+        ) : null;
+        return c === null || n !== null && (n.f & T) !== 0 ? e |= T : c.f |= dt, {
+          ctx: N,
+          deps: null,
+          effects: null,
+          equals: Bt,
+          f: e,
+          fn: t,
+          reactions: null,
+          rv: 0,
+          v: (
+            /** @type {V} */
+            vt
+          ),
+          wv: 0,
+          parent: n ?? c,
+          ac: null
+        };
+      }
+      // @__NO_SIDE_EFFECTS__
+      function Se(t, e) {
+        let n = (
+          /** @type {Effect | null} */
+          c
+        );
+        n === null && he();
+        var r = (
+          /** @type {Boundary} */
+          n.b
+        ), l = (
+          /** @type {Promise<V>} */
+          /** @type {unknown} */
+          void 0
+        ), a = De(
+          /** @type {V} */
+          vt
+        ), s = !v, i = /* @__PURE__ */ new Map();
+        return Be(() => {
+          var f = Lt();
+          l = f.promise;
+          try {
+            Promise.resolve(t()).then(f.resolve, f.reject);
+          } catch (_) {
+            f.reject(_);
+          }
+          var o = (
+            /** @type {Batch} */
+            h
+          ), d = r.is_pending();
+          s && (r.update_pending_count(1), d || (o.increment(), i.get(o)?.reject(nt), i.set(o, f)));
+          const x = (_, u = void 0) => {
+            d || o.activate(), u ? u !== nt && (a.f |= q, Ft(a, u)) : ((a.f & q) !== 0 && (a.f ^= q), Ft(a, _)), s && (r.update_pending_count(-1), d || o.decrement()), Yt();
+          };
+          f.promise.then(x, (_) => x(null, _ || "unknown"));
+        }), je(() => {
+          for (const f of i.values())
+            f.reject(nt);
+        }), new Promise((f) => {
+          function o(d) {
+            function x() {
+              d === l ? f(a) : o(l);
+            }
+            d.then(x, x);
+          }
+          o(l);
+        });
+      }
+      function Ht(t) {
+        var e = t.effects;
+        if (e !== null) {
+          t.effects = null;
+          for (var n = 0; n < e.length; n += 1)
+            J(
+              /** @type {Effect} */
+              e[n]
+            );
+        }
+      }
+      function Ie(t) {
+        for (var e = t.parent; e !== null; ) {
+          if ((e.f & E) === 0)
+            return (
+              /** @type {Effect} */
+              e
+            );
+          e = e.parent;
+        }
+        return null;
+      }
+      function kt(t) {
+        var e, n = c;
+        H(Ie(t));
+        try {
+          Ht(t), e = ae(t);
+        } finally {
+          H(n);
+        }
+        return e;
+      }
+      function Kt(t) {
+        var e = kt(t);
+        if (t.equals(e) || (t.v = e, t.wv = re()), !at) {
+          var n = (F || (t.f & T) !== 0) && t.deps !== null ? O : m;
+          g(t, n);
+        }
+      }
+      const S = /* @__PURE__ */ new Map();
+      function De(t, e) {
+        var n = {
+          f: 0,
+          // TODO ideally we could skip this altogether, but it causes type errors
+          v: t,
+          reactions: null,
+          equals: Bt,
+          rv: 0,
+          wv: 0
+        };
+        return n;
+      }
+      function Ft(t, e) {
+        if (!t.equals(e)) {
+          var n = t.v;
+          at ? S.set(t, e) : S.set(t, n), t.v = e;
+          var r = L.ensure();
+          r.capture(t, n), (t.f & E) !== 0 && ((t.f & y) !== 0 && kt(
+            /** @type {Derived} */
+            t
+          ), g(t, (t.f & T) === 0 ? m : O)), t.wv = re(), zt(t, y), c !== null && (c.f & m) !== 0 && (c.f & (D | z)) === 0 && (k === null ? Ge([t]) : k.push(t));
+        }
+        return e;
+      }
+      function zt(t, e) {
+        var n = t.reactions;
+        if (n !== null)
+          for (var r = n.length, l = 0; l < r; l++) {
+            var a = n[l], s = a.f, i = (s & y) === 0;
+            i && g(a, e), (s & E) !== 0 ? zt(
+              /** @type {Derived} */
+              a,
+              O
+            ) : i && ((s & K) !== 0 && M !== null && M.push(
+              /** @type {Effect} */
+              a
+            ), P(
+              /** @type {Effect} */
+              a
+            ));
+          }
+      }
+      var Oe, Me, Le;
+      function Gt(t = "") {
+        return document.createTextNode(t);
+      }
+      // @__NO_SIDE_EFFECTS__
+      function Tt(t) {
+        return Me.call(t);
+      }
+      // @__NO_SIDE_EFFECTS__
+      function Rt(t) {
+        return Le.call(t);
+      }
+      function U(t, e) {
+        return /* @__PURE__ */ Tt(t);
+      }
+      function mt(t, e = !1) {
+        {
+          var n = (
+            /** @type {DocumentFragment} */
+            /* @__PURE__ */ Tt(
+              /** @type {Node} */
+              t
+            )
+          );
+          return n instanceof Comment && n.data === "" ? /* @__PURE__ */ Rt(n) : n;
+        }
+      }
+      function St(t, e = 1, n = !1) {
+        let r = t;
+        for (; e--; )
+          r = /** @type {TemplateNode} */
+          /* @__PURE__ */ Rt(r);
+        return r;
+      }
+      function qe() {
+        return !1;
+      }
+      function Zt(t) {
+        var e = v, n = c;
+        Y(null), H(null);
+        try {
+          return t();
+        } finally {
+          Y(e), H(n);
+        }
+      }
+      function Pe(t, e) {
+        var n = e.last;
+        n === null ? e.last = e.first = t : (n.next = t, t.prev = n, e.last = t);
+      }
+      function Z(t, e, n, r = !0) {
+        var l = c;
+        l !== null && (l.f & I) !== 0 && (t |= I);
+        var a = {
+          ctx: N,
+          deps: null,
+          nodes_start: null,
+          nodes_end: null,
+          f: t | y,
+          first: null,
+          fn: e,
+          last: null,
+          next: null,
+          parent: l,
+          b: l && l.b,
+          prev: null,
+          teardown: null,
+          transitions: null,
+          wv: 0,
+          ac: null
+        };
+        if (n)
+          try {
+            lt(a), a.f |= Ut;
+          } catch (f) {
+            throw J(a), f;
+          }
+        else e !== null && P(a);
+        if (r) {
+          var s = a;
+          if (n && s.deps === null && s.teardown === null && s.nodes_start === null && s.first === s.last && // either `null`, or a singular child
+          (s.f & dt) === 0 && (s = s.first), s !== null && (s.parent = l, l !== null && Pe(s, l), v !== null && (v.f & E) !== 0 && (t & z) === 0)) {
+            var i = (
+              /** @type {Derived} */
+              v
+            );
+            (i.effects ??= []).push(s);
+          }
+        }
+        return a;
+      }
+      function je(t) {
+        const e = Z(Pt, null, !1);
+        return g(e, m), e.teardown = t, e;
+      }
+      function Ue(t) {
+        return Z(qt | pe, t, !1);
+      }
+      function Be(t) {
+        return Z(yt | dt, t, !0);
+      }
+      function We(t, e = [], n = []) {
+        Ae(e, n, (r) => {
+          Z(Pt, () => t(...r.map(Je)), !0);
+        });
+      }
+      function Jt(t, e = 0) {
+        var n = Z(K | e, t, !0);
+        return n;
+      }
+      function Et(t, e = !0) {
+        return Z(D | dt, t, !0, e);
+      }
+      function Qt(t) {
+        var e = t.teardown;
+        if (e !== null) {
+          const n = at, r = v;
+          Dt(!0), Y(null);
+          try {
+            e.call(null);
+          } finally {
+            Dt(n), Y(r);
+          }
+        }
+      }
+      function Xt(t, e = !1) {
+        var n = t.first;
+        for (t.first = t.last = null; n !== null; ) {
+          const l = n.ac;
+          l !== null && Zt(() => {
+            l.abort(nt);
+          });
+          var r = n.next;
+          (n.f & z) !== 0 ? n.parent = null : J(n, e), n = r;
+        }
+      }
+      function Ve(t) {
+        for (var e = t.first; e !== null; ) {
+          var n = e.next;
+          (e.f & D) === 0 && J(e), e = n;
+        }
+      }
+      function J(t, e = !0) {
+        var n = !1;
+        (e || (t.f & de) !== 0) && t.nodes_start !== null && t.nodes_end !== null && (Ye(
+          t.nodes_start,
+          /** @type {TemplateNode} */
+          t.nodes_end
+        ), n = !0), Xt(t, e && !n), ct(t, 0), g(t, G);
+        var r = t.transitions;
+        if (r !== null)
+          for (const a of r)
+            a.stop();
+        Qt(t);
+        var l = t.parent;
+        l !== null && l.first !== null && $t(t), t.next = t.prev = t.teardown = t.ctx = t.deps = t.fn = t.nodes_start = t.nodes_end = t.ac = null;
+      }
+      function Ye(t, e) {
+        for (; t !== null; ) {
+          var n = t === e ? null : (
+            /** @type {TemplateNode} */
+            /* @__PURE__ */ Rt(t)
+          );
+          t.remove(), t = n;
+        }
+      }
+      function $t(t) {
+        var e = t.parent, n = t.prev, r = t.next;
+        n !== null && (n.next = r), r !== null && (r.prev = n), e !== null && (e.first === t && (e.first = r), e.last === t && (e.last = n));
+      }
+      function He(t, e) {
+        var n = [];
+        te(t, n, !0), Ke(n, () => {
+          J(t), e && e();
+        });
+      }
+      function Ke(t, e) {
+        var n = t.length;
+        if (n > 0) {
+          var r = () => --n || e();
+          for (var l of t)
+            l.out(r);
+        } else
+          e();
+      }
+      function te(t, e, n) {
+        if ((t.f & I) === 0) {
+          if (t.f ^= I, t.transitions !== null)
+            for (const s of t.transitions)
+              (s.is_global || n) && e.push(s);
+          for (var r = t.first; r !== null; ) {
+            var l = r.next, a = (r.f & _t) !== 0 || (r.f & D) !== 0;
+            te(r, e, a ? n : !1), r = l;
+          }
+        }
+      }
+      function ze(t) {
+        ee(t, !0);
+      }
+      function ee(t, e) {
+        if ((t.f & I) !== 0) {
+          t.f ^= I, (t.f & m) === 0 && (g(t, y), P(t));
+          for (var n = t.first; n !== null; ) {
+            var r = n.next, l = (n.f & _t) !== 0 || (n.f & D) !== 0;
+            ee(n, l ? e : !1), n = r;
+          }
+          if (t.transitions !== null)
+            for (const a of t.transitions)
+              (a.is_global || e) && a.in();
+        }
+      }
+      let V = !1;
+      function It(t) {
+        V = t;
+      }
+      let at = !1;
+      function Dt(t) {
+        at = t;
+      }
+      let v = null, B = !1;
+      function Y(t) {
+        v = t;
+      }
+      let c = null;
+      function H(t) {
+        c = t;
+      }
+      let rt = null, w = null, b = 0, k = null;
+      function Ge(t) {
+        k = t;
+      }
+      let ne = 1, ot = 0, F = !1;
+      function re() {
+        return ++ne;
+      }
+      function pt(t) {
+        var e = t.f;
+        if ((e & y) !== 0)
+          return !0;
+        if ((e & O) !== 0) {
+          var n = t.deps, r = (e & T) !== 0;
+          if (n !== null) {
+            var l, a, s = (e & it) !== 0, i = r && c !== null && !F, f = n.length;
+            if ((s || i) && (c === null || (c.f & G) === 0)) {
+              var o = (
+                /** @type {Derived} */
+                t
+              ), d = o.parent;
+              for (l = 0; l < f; l++)
+                a = n[l], (s || !a?.reactions?.includes(o)) && (a.reactions ??= []).push(o);
+              s && (o.f ^= it), i && d !== null && (d.f & T) === 0 && (o.f ^= T);
+            }
+            for (l = 0; l < f; l++)
+              if (a = n[l], pt(
+                /** @type {Derived} */
+                a
+              ) && Kt(
+                /** @type {Derived} */
+                a
+              ), a.wv > t.wv)
+                return !0;
+          }
+          (!r || c !== null && !F) && g(t, m);
+        }
+        return !1;
+      }
+      function le(t, e, n = !0) {
+        var r = t.reactions;
+        if (r !== null && !rt?.includes(t))
+          for (var l = 0; l < r.length; l++) {
+            var a = r[l];
+            (a.f & E) !== 0 ? le(
+              /** @type {Derived} */
+              a,
+              e,
+              !1
+            ) : e === a && (n ? g(a, y) : (a.f & m) !== 0 && g(a, O), P(
+              /** @type {Effect} */
+              a
+            ));
+          }
+      }
+      function ae(t) {
+        var e = w, n = b, r = k, l = v, a = F, s = rt, i = N, f = B, o = t.f;
+        w = /** @type {null | Value[]} */
+        null, b = 0, k = null, F = (o & T) !== 0 && (B || !V || v === null), v = (o & (D | z)) === 0 ? t : null, rt = null, ft(t.ctx), B = !1, ++ot, t.ac !== null && (Zt(() => {
+          t.ac.abort(nt);
+        }), t.ac = null);
+        try {
+          t.f |= gt;
+          var d = (
+            /** @type {Function} */
+            t.fn
+          ), x = d(), _ = t.deps;
+          if (w !== null) {
+            var u;
+            if (ct(t, b), _ !== null && b > 0)
+              for (_.length = b + w.length, u = 0; u < w.length; u++)
+                _[b + u] = w[u];
+            else
+              t.deps = _ = w;
+            if (!F || // Deriveds that already have reactions can cleanup, so we still add them as reactions
+            (o & E) !== 0 && /** @type {import('#client').Derived} */
+            t.reactions !== null)
+              for (u = b; u < _.length; u++)
+                (_[u].reactions ??= []).push(t);
+          } else _ !== null && b < _.length && (ct(t, b), _.length = b);
+          if (Ee() && k !== null && !B && _ !== null && (t.f & (E | O | y)) === 0)
+            for (u = 0; u < /** @type {Source[]} */
+            k.length; u++)
+              le(
+                k[u],
+                /** @type {Effect} */
+                t
+              );
+          return l !== null && l !== t && (ot++, k !== null && (r === null ? r = k : r.push(.../** @type {Source[]} */
+          k))), (t.f & q) !== 0 && (t.f ^= q), x;
+        } catch (p) {
+          return Te(p);
+        } finally {
+          t.f ^= gt, w = e, b = n, k = r, v = l, F = a, rt = s, ft(i), B = f;
+        }
+      }
+      function Ze(t, e) {
+        let n = e.reactions;
+        if (n !== null) {
+          var r = ve.call(n, t);
+          if (r !== -1) {
+            var l = n.length - 1;
+            l === 0 ? n = e.reactions = null : (n[r] = n[l], n.pop());
+          }
+        }
+        n === null && (e.f & E) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
+        // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
+        // allows us to skip the expensive work of disconnecting and immediately reconnecting it
+        (w === null || !w.includes(e)) && (g(e, O), (e.f & (T | it)) === 0 && (e.f ^= it), Ht(
+          /** @type {Derived} **/
+          e
+        ), ct(
+          /** @type {Derived} **/
+          e,
+          0
+        ));
+      }
+      function ct(t, e) {
+        var n = t.deps;
+        if (n !== null)
+          for (var r = e; r < n.length; r++)
+            Ze(t, n[r]);
+      }
+      function lt(t) {
+        var e = t.f;
+        if ((e & G) === 0) {
+          g(t, m);
+          var n = c, r = V;
+          c = t, V = !0;
+          try {
+            (e & K) !== 0 ? Ve(t) : Xt(t), Qt(t);
+            var l = ae(t);
+            t.teardown = typeof l == "function" ? l : null, t.wv = ne;
+            var a;
+            Mt && we && (t.f & y) !== 0 && t.deps;
+          } finally {
+            V = r, c = n;
+          }
+        }
+      }
+      function Je(t) {
+        var e = t.f, n = (e & E) !== 0;
+        if (v !== null && !B) {
+          var r = c !== null && (c.f & G) !== 0;
+          if (!r && !rt?.includes(t)) {
+            var l = v.deps;
+            if ((v.f & gt) !== 0)
+              t.rv < ot && (t.rv = ot, w === null && l !== null && l[b] === t ? b++ : w === null ? w = [t] : (!F || !w.includes(t)) && w.push(t));
+            else {
+              (v.deps ??= []).push(t);
+              var a = t.reactions;
+              a === null ? t.reactions = [v] : a.includes(v) || a.push(v);
+            }
+          }
+        } else if (n && /** @type {Derived} */
+        t.deps === null && /** @type {Derived} */
+        t.effects === null) {
+          var s = (
+            /** @type {Derived} */
+            t
+          ), i = s.parent;
+          i !== null && (i.f & T) === 0 && (s.f ^= T);
+        }
+        if (at) {
+          if (S.has(t))
+            return S.get(t);
+          if (n) {
+            s = /** @type {Derived} */
+            t;
+            var f = s.v;
+            return ((s.f & m) === 0 && s.reactions !== null || se(s)) && (f = kt(s)), S.set(s, f), f;
+          }
+        } else n && (s = /** @type {Derived} */
+        t, pt(s) && Kt(s));
+        if ((t.f & q) !== 0)
+          throw t.v;
+        return t.v;
+      }
+      function se(t) {
+        if (t.v === vt) return !0;
+        if (t.deps === null) return !1;
+        for (const e of t.deps)
+          if (S.has(e) || (e.f & E) !== 0 && se(
+            /** @type {Derived} */
+            e
+          ))
+            return !0;
+        return !1;
+      }
+      const Qe = -7169;
+      function g(t, e) {
+        t.f = t.f & Qe | e;
+      }
+      function Xe(t) {
+        var e = document.createElement("template");
+        return e.innerHTML = t.replaceAll("<!>", "<!---->"), e.content;
+      }
+      function ie(t, e) {
+        var n = (
+          /** @type {Effect} */
+          c
+        );
+        n.nodes_start === null && (n.nodes_start = t, n.nodes_end = e);
+      }
+      // @__NO_SIDE_EFFECTS__
+      function fe(t, e) {
+        var n = (e & ce) !== 0, r, l = !t.startsWith("<!>");
+        return () => {
+          r === void 0 && (r = Xe(l ? t : "<!>" + t), r = /** @type {Node} */
+          /* @__PURE__ */ Tt(r));
+          var a = (
+            /** @type {TemplateNode} */
+            n || Oe ? document.importNode(r, !0) : r.cloneNode(!0)
+          );
+          return ie(a, a), a;
+        };
+      }
+      function wt() {
+        var t = document.createDocumentFragment(), e = document.createComment(""), n = Gt();
+        return t.append(e, n), ie(e, n), t;
+      }
+      function $(t, e) {
+        t !== null && t.before(
+          /** @type {Node} */
+          e
+        );
+      }
+      function tt(t, e, ...n) {
+        var r = t, l = et, a;
+        Jt(() => {
+          l !== (l = e()) && (a && (J(a), a = null), a = Et(() => (
+            /** @type {SnippetFn} */
+            l(r, ...n)
+          )));
+        }, _t);
+      }
+      function Ot(t, e, n = !1) {
+        var r = t, l = null, a = null, s = vt, i = n ? _t : 0, f = !1;
+        const o = (u, p = !0) => {
+          f = !0, _(p, u);
+        };
+        var d = null;
+        function x() {
+          d !== null && (d.lastChild.remove(), r.before(d), d = null);
+          var u = s ? l : a, p = s ? a : l;
+          u && ze(u), p && He(p, () => {
+            s ? a = null : l = null;
+          });
+        }
+        const _ = (u, p) => {
+          if (s !== (s = u)) {
+            var j = qe(), Q = r;
+            if (j && (d = document.createDocumentFragment(), d.append(Q = Gt())), s ? l ??= p && Et(() => p(Q)) : a ??= p && Et(() => p(Q)), j) {
+              var X = (
+                /** @type {Batch} */
+                h
+              ), R = s ? l : a, A = s ? a : l;
+              R && X.skipped_effects.delete(R), A && X.skipped_effects.add(A), X.add_callback(x);
+            } else
+              x();
+          }
+        };
+        Jt(() => {
+          f = !1, e(o), f || _(null, null);
+        }, i);
+      }
+      function ue(t) {
+        var e, n, r = "";
+        if (typeof t == "string" || typeof t == "number") r += t;
+        else if (typeof t == "object") if (Array.isArray(t)) {
+          var l = t.length;
+          for (e = 0; e < l; e++) t[e] && (n = ue(t[e])) && (r && (r += " "), r += n);
+        } else for (n in t) t[n] && (r && (r += " "), r += n);
+        return r;
+      }
+      function $e() {
+        for (var t, e, n = 0, r = "", l = arguments.length; n < l; n++) (t = arguments[n]) && (e = ue(t)) && (r && (r += " "), r += e);
+        return r;
+      }
+      function tn(t) {
+        return typeof t == "object" ? $e(t) : t ?? "";
+      }
+      function en(t, e, n) {
+        var r = t == null ? "" : "" + t;
+        return r === "" ? null : r;
+      }
+      function nn(t, e, n, r, l, a) {
+        var s = t.__className;
+        if (s !== n || s === void 0) {
+          var i = en(n);
+          i == null ? t.removeAttribute("class") : t.className = i, t.__className = n;
+        }
+        return a;
+      }
+      function rn(t, e, n, r) {
+        var l = (
+          /** @type {V} */
+          r
+        ), a = !0, s = () => (a && (a = !1, l = /** @type {V} */
+        r), l), i;
+        i = /** @type {V} */
+        t[e], i === void 0 && r !== void 0 && (i = s());
+        var f;
+        return f = () => {
+          var o = (
+            /** @type {V} */
+            t[e]
+          );
+          return o === void 0 ? s() : (a = !0, o);
+        }, f;
+      }
+      var ln = /* @__PURE__ */ fe('<div class="app-base-layout__app h-full overflow-auto"><!></div>'), an = /* @__PURE__ */ fe('<div><header class="app-base-layout__top border-b border-surface-muted bg-surface px-6 py-4 shadow-sm"><!></header> <div class="app-base-layout__canvas flex min-h-0 flex-1 overflow-hidden"><nav class="app-base-layout__nav w-72 shrink-0 border-r border-surface-muted bg-surface px-4 py-6"><!></nav> <main class="app-base-layout__workspace flex-1 overflow-hidden bg-surface px-6 py-6"><!></main></div></div>');
+      function sn(t, e) {
+        ge(e, !0);
+        let n = rn(e, "class", 3, "");
+        var r = an(), l = U(r), a = U(l);
+        tt(a, () => e.top ?? et);
+        var s = St(l, 2), i = U(s), f = U(i);
+        tt(f, () => e.nav ?? et);
+        var o = St(i, 2), d = U(o);
+        {
+          var x = (u) => {
+            var p = wt(), j = mt(p);
+            tt(j, () => e.workspace), $(u, p);
+          }, _ = (u) => {
+            var p = ln(), j = U(p);
+            {
+              var Q = (R) => {
+                var A = wt(), ht = mt(A);
+                tt(ht, () => e.app), $(R, A);
+              }, X = (R) => {
+                var A = wt(), ht = mt(A);
+                tt(ht, () => e.children ?? et), $(R, A);
+              };
+              Ot(j, (R) => {
+                e.app ? R(Q) : R(X, !1);
+              });
+            }
+            $(u, p);
+          };
+          Ot(d, (u) => {
+            e.workspace ? u(x) : u(_, !1);
+          });
+        }
+        We((u) => nn(r, 1, u), [
+          () => tn(`app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink ${n()}`.trim())
+        ]), $(t, r), be();
+      }
+      const oe = /* @__PURE__ */ new Map(), fn = () => {
+        const t = "app-base-widget-root", e = document.getElementById(t);
+        if (e)
+          return e.classList.add("app-base-widget"), e;
+        const n = document.createElement("div");
+        return n.id = t, n.classList.add("app-base-widget"), document.body.appendChild(n), n;
+      }, vn = typeof document < "u" ? new sn({
+        target: fn()
+      }) : void 0, un = (t) => {
+        const e = t.detail;
+        if (!e?.id || !e.url) {
+          console.warn("[AppBaseWidget] Manifesto inválido recebido.", e);
+          return;
+        }
+        oe.set(e.id, e);
+      }, on = (t) => {
+        const { id: e } = t.detail ?? {};
+        if (!e) {
+          console.warn("[AppBaseWidget] Solicitação de módulo sem identificador.", t.detail);
+          return;
+        }
+        const n = oe.get(e);
+        if (!n) {
+          console.warn(`[AppBaseWidget] Nenhum manifesto encontrado para o módulo "${e}".`);
+          return;
+        }
+        window.dispatchEvent(
+          new CustomEvent("app-base:module-pending", {
+            detail: { id: e, manifest: n }
+          })
+        );
+      };
+      typeof window < "u" && (window.addEventListener("app-base:register-manifest", un), window.addEventListener("app-base:request-module", on));
+      export {
+        vn as appBaseWidget,
+        oe as manifestRegistry
+      };
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "turbo run build",
     "build:web": "turbo run build --filter=web",
     "build:api": "turbo run build --filter=@marco/api",
+    "build:widget": "npm --workspace web run build:widget && node ./tools/scripts/build-widget-html.mjs",
     "dev:web": "turbo run dev --filter=web",
     "dev:api": "turbo run dev --filter=@marco/api",
     "preview:web": "npm --workspace web run preview",

--- a/tools/scripts/build-widget-html.mjs
+++ b/tools/scripts/build-widget-html.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const widgetDistDir = path.resolve(repoRoot, 'apps/web/dist');
+const outputDir = path.resolve(repoRoot, 'dist');
+const cssPath = path.join(widgetDistDir, 'app-base-widget.css');
+const jsPath = path.join(widgetDistDir, 'app-base-widget.js');
+
+const indent = (value, spaces = 4) => {
+  const pad = ' '.repeat(spaces);
+  return value
+    .split('\n')
+    .map((line) => pad + line)
+    .join('\n');
+};
+
+try {
+  const [cssSource, jsSource] = await Promise.all([
+    readFile(cssPath, 'utf8'),
+    readFile(jsPath, 'utf8')
+  ]);
+
+  await mkdir(outputDir, { recursive: true });
+
+  const sanitizedScript = jsSource.replace(/<\/(script)/gi, '<\\/$1');
+  const html = `<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+${indent(cssSource.trim(), 6)}
+    </style>
+  </head>
+  <body>
+    <div id="app-base-widget-root" class="app-base-widget"></div>
+    <script type="module">
+${indent(sanitizedScript.trim(), 6)}
+    </script>
+  </body>
+</html>
+`;
+
+  const outputPath = path.join(outputDir, 'app-base-widget.html');
+  await writeFile(outputPath, html, 'utf8');
+  console.log(`Widget bundle salvo em ${path.relative(repoRoot, outputPath)}`);
+} catch (error) {
+  console.error('[build-widget-html] Falha ao gerar HTML do widget.');
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a root `build:widget` script and helper to inline the widget bundle into a single HTML file
- scope shared styles with `:where()` selectors and mark the widget root element to avoid host page conflicts
- generate the distributable `dist/app-base-widget.html` snippet for embedding in Elementor/WordPress

## Testing
- npm run build:widget

------
https://chatgpt.com/codex/tasks/task_e_68e1768bf31883209d41ef3f3ecc1bf8