### PR TITLE
docs: orientar incorporação do AppBase no Elementor

### DIFF
--- a/apps/web/docs/marco-zero.md
+++ b/apps/web/docs/marco-zero.md
@@ -1,0 +1,24 @@
+# Marco zero — AppBase sem mini-app
+
+## Contexto atual
+
+- O widget exportado representa apenas o shell institucional (header, navegação lateral e canvas vazio).
+- Nenhum mini-app é carregado por padrão; o host permanece no estado de boas-vindas e exibe a mensagem "Selecione um mini-app para continuar.".
+- Os eventos `app-base:register-manifest` e `app-base:request-module` estão disponíveis para futuras integrações, mas a `manifestRegistry` inicia vazia.
+
+## Dependências obrigatórias
+
+1. **Build do widget** — `npm run build:widget` gera `dist/app-base-widget.html`, `apps/web/dist/app-base-widget.css` e `apps/web/dist/app-base-widget.js`.
+2. **WordPress com Elementor** — necessário para inserir o trecho HTML em uma página ou template.
+3. **Permissão para scripts personalizados** — o Elementor precisa aceitar `<script type="module">` dentro do widget HTML (verificar política de segurança do site). Caso contrário, incorporar via `<iframe src=".../app-base-widget.html">`.
+
+## Checklist de carregamento no WordPress
+
+1. **Gerar o HTML** — executar `npm run build:widget` e garantir que `dist/app-base-widget.html` foi atualizado na branch atual.
+2. **Incorporar no Elementor** — colar o conteúdo entre `<body>...</body>` em um widget HTML ou apontar um `<iframe>` para o arquivo hospedado.
+3. **Carregamento do shell** — publicar a página, recarregar no navegador limpo e confirmar:
+   - Header e navegação institucional renderizados sem mensagens de erro no console.
+   - Placeholder do canvas exibindo o texto padrão do AppHost.
+   - Ausência de solicitações de rede 404 para `manifest/active.json` (nenhum mini-app ativo).
+4. **Evidência visual** — capturar uma screenshot manual ou via Playwright apontando para a URL do WordPress. Validar que o layout ocupa 100% da largura disponível e que o canvas está vazio.
+5. **Logs futuros** — documentar qualquer script extra adicionado para registrar manifests quando mini-apps forem liberados.

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,41 @@ O script `npm run package --workspace web` agora gera:
 - `artifacts/web.tar.gz`: build completo do host.
 - `artifacts/web-<id>.tar.gz`: um pacote por vertical, cada qual com um `manifest/active.json` descrevendo a entrada correspondente. O processo é orquestrado por [`tools/scripts/package-verticals.mjs`](tools/scripts/package-verticals.mjs).
 
+## AppBase no Elementor
+
+### Copiando o HTML gerado
+
+1. Execute `npm run build:widget` na raiz do repositório. O comando compila o bundle do widget (`apps/web/dist/app-base-widget.{css,js}`) e gera o arquivo consolidado [`dist/app-base-widget.html`](dist/app-base-widget.html).
+2. Abra o arquivo HTML em um editor de texto e copie **apenas o conteúdo entre as tags `<body>...</body>`**. Esse trecho contém o container `<div id="app-base-widget-root">`, o estilo injetado e o `<script type="module">` necessário para inicializar o shell.
+3. No Elementor, adicione um widget **HTML personalizado** e cole o trecho copiado. Nenhum ajuste adicional é necessário — o bundle já encapsula CSS e JavaScript.
+
+### Arquivos a serem hospedados
+
+- Hospede o próprio [`dist/app-base-widget.html`](dist/app-base-widget.html) em um local acessível (CDN, biblioteca de mídia do WordPress ou servidor estático). Ele é auto contido e pode ser incorporado via `<iframe>` caso a equipe prefira não colar o código manualmente.
+- Preserve os artefatos gerados em `artifacts/`. Cada `web-<id>.tar.gz` contém o build da vertical e um `manifest/active.json`; eles serão publicados futuramente para liberar mini-apps individuais.
+
+### Ativação de mini-apps
+
+1. Publique o bundle da vertical desejada (conteúdo de `web-<id>.tar.gz`) em um endpoint público e exponha o caminho do módulo (campo `loader` do manifest) por meio de um evento `app-base:register-manifest`.
+2. Ao carregar a página do Elementor, injete um script semelhante ao abaixo para registrar o manifest remoto:
+
+   ```html
+   <script>
+     window.addEventListener('load', () => {
+       window.dispatchEvent(
+         new CustomEvent('app-base:register-manifest', {
+           detail: {
+             id: 'eventos',
+             url: 'https://cdn.example.com/web-eventos/manifest/active.json'
+           }
+         })
+       );
+     });
+   </script>
+   ```
+
+3. Sempre que o shell solicitar um módulo (`app-base:request-module`), responda com o manifest apropriado (o host dispara `app-base:module-pending` automaticamente). Assim que o JSON estiver disponível, o AppBase importará a vertical com base no `loader` informado.
+
 ## Testes visuais
 
 Execute os cenários automatizados de interface com:
@@ -33,3 +68,9 @@ npm run test:visual
 ```
 
 O spec principal [`tests/visual/app-base.spec.ts`](tests/visual/app-base.spec.ts) cobre a navegação entre verticais (incluindo mudança de query string), além do subcenário completo da vertical de eventos — capturando estados **Pronto**, **Edição**, **Salvando** e validando KPIs/responsividade. As imagens ficam anexadas ao relatório do Playwright em `test-results/` (ignorado pelo Git), evitando binários no repositório.
+
+### Verificação visual em páginas incorporadas
+
+- Priorize `npm run test:visual` para garantir o baseline do shell antes de exportar o widget.
+- Depois de colar o HTML no Elementor, abra a página publicada e capture uma screenshot manual ou via Playwright (por exemplo, apontando o navegador para a URL do WordPress). Confirme que o header institucional, a navegação lateral e o container `app-host__canvas` renderizam sem barras de rolagem inesperadas.
+- Armazene a evidência junto ao ticket ou PR correspondente para rastrear regressões de incorporação.


### PR DESCRIPTION
## Summary
- documenta como gerar e incorporar o widget do AppBase no Elementor, incluindo hospedagem e ativação futura de mini-apps
- adiciona guia "marco-zero" descrevendo o estado atual sem mini-apps e checklist de validação no WordPress
- registra passos de verificação visual após a incorporação

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e177f571088320b57c136b2fa8fa29