### PR TITLE
docs: clarify widget embed instructions

### DIFF
--- a/apps/web/docs/marco-zero.md
+++ b/apps/web/docs/marco-zero.md
@@ -1,5 +1,13 @@
 # Marco zero — AppBase sem mini-app
 
+> ⚠️ **Atenção:** [`apps/web/src/app.html`](../src/app.html) é apenas o template do SvelteKit e não deve ser embutido diretamente no WordPress/Elementor. Sempre use o HTML gerado em `dist/app-base-widget.html`. Um 404 para `/bundle/app-host.js` normalmente indica que o snippet colado não corresponde ao widget exportado.
+
+Checklist rápido antes de publicar:
+
+- [ ] Confirme que o HTML embutido contém o `<div id="app-base-widget-root">`.
+- [ ] Verifique se o `<script type="module">` do widget está presente (geralmente aponta para `app-base-widget.js`).
+
+
 ## Contexto atual
 
 - O widget exportado representa apenas o shell institucional (header, navegação lateral e canvas vazio).

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,3 +1,4 @@
+<!-- Template interno do SvelteKit: não incorporar diretamente em WordPress/Elementor. Use dist/app-base-widget.html. -->
 <!doctype html>
 <html lang="pt-br">
   <head>

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ O script `npm run package --workspace web` agora gera:
 
 ## AppBase no Elementor
 
+> ⚠️ **Importante:** o arquivo [`apps/web/src/app.html`](apps/web/src/app.html) é apenas o template interno do SvelteKit. Ele **não** deve ser colado no WordPress/Elementor. Qualquer erro 404 para `/bundle/app-host.js` indica que o snippet utilizado não é o `dist/app-base-widget.html` exportado pelo build.
+
 ### Copiando o HTML gerado
 
 1. Execute `npm run build:widget` na raiz do repositório. O comando compila o bundle do widget (`apps/web/dist/app-base-widget.{css,js}`) e gera o arquivo consolidado [`dist/app-base-widget.html`](dist/app-base-widget.html).


### PR DESCRIPTION
## Summary
- highlight that apps/web/src/app.html is a SvelteKit template that must not be embedded in Elementor
- document the 404 /bundle/app-host.js symptom of using an incorrect snippet
- add a quick checklist to confirm the exported widget HTML contains the expected root div and module script, and annotate the template file itself

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17b8644d883209e734dc80e116fbe