### PR TITLE
docs: add CDN snippet for Elementor embed

### DIFF
--- a/apps/web/docs/marco-zero.md
+++ b/apps/web/docs/marco-zero.md
@@ -1,11 +1,10 @@
 # Marco zero — AppBase sem mini-app
 
-> ⚠️ **Atenção:** [`apps/web/src/app.html`](../src/app.html) é apenas o template do SvelteKit e não deve ser embutido diretamente no WordPress/Elementor. Sempre use o HTML gerado em `dist/app-base-widget.html`. Um 404 para `/bundle/app-host.js` normalmente indica que o snippet colado não corresponde ao widget exportado.
+> ⚠️ **Atenção:** [`apps/web/src/app.html`](../src/app.html) é apenas o template do SvelteKit e não deve ser embutido diretamente no WordPress/Elementor. Use o snippet publicado em [`docs/embed/app-base-snippet.html`](../../../docs/embed/app-base-snippet.html), que aponta para `widgets/app-base/latest/` no CDN institucional. Qualquer 404 para `app-base-widget.{css,js}` indica problema de permissão ou caminho incorreto.
 
 Checklist rápido antes de publicar:
 
-- [ ] Confirme que o HTML embutido contém o `<div id="app-base-widget-root">`.
-- [ ] Verifique se o `<script type="module">` do widget está presente (geralmente aponta para `app-base-widget.js`).
+- [ ] Confirme que o HTML embutido corresponde ao snippet oficial e contém o `<link rel="stylesheet">`, o `<div id="app-base-widget-root">` e o `<script type="module">` apontando para o CDN.
 
 
 ## Contexto atual
@@ -16,17 +15,17 @@ Checklist rápido antes de publicar:
 
 ## Dependências obrigatórias
 
-1. **Build do widget** — `npm run build:widget` gera `dist/app-base-widget.html`, `apps/web/dist/app-base-widget.css` e `apps/web/dist/app-base-widget.js`.
+1. **Snippet CDN ativo** — garantir acesso ao endpoint `https://cdn.5horas.app/widgets/app-base/latest/` (ou domínio equivalente usado pelo time).
 2. **WordPress com Elementor** — necessário para inserir o trecho HTML em uma página ou template.
 3. **Permissão para scripts personalizados** — o Elementor precisa aceitar `<script type="module">` dentro do widget HTML (verificar política de segurança do site). Caso contrário, incorporar via `<iframe src=".../app-base-widget.html">`.
 
 ## Checklist de carregamento no WordPress
 
-1. **Gerar o HTML** — executar `npm run build:widget` e garantir que `dist/app-base-widget.html` foi atualizado na branch atual.
-2. **Incorporar no Elementor** — colar o conteúdo entre `<body>...</body>` em um widget HTML ou apontar um `<iframe>` para o arquivo hospedado.
+1. **Selecionar o snippet** — copie [`docs/embed/app-base-snippet.html`](../../../docs/embed/app-base-snippet.html) ou referencie-o diretamente no Elementor.
+2. **Incorporar no Elementor** — adicione um widget HTML personalizado e cole o snippet. Verifique se o WordPress permite `<script type="module">`.
 3. **Carregamento do shell** — publicar a página, recarregar no navegador limpo e confirmar:
    - Header e navegação institucional renderizados sem mensagens de erro no console.
    - Placeholder do canvas exibindo o texto padrão do AppHost.
-   - Ausência de solicitações de rede 404 para `manifest/active.json` (nenhum mini-app ativo).
+   - Ausência de solicitações de rede 404 para `app-base-widget.{css,js}` e `manifest/active.json` (nenhum mini-app ativo).
 4. **Evidência visual** — capturar uma screenshot manual ou via Playwright apontando para a URL do WordPress. Validar que o layout ocupa 100% da largura disponível e que o canvas está vazio.
 5. **Logs futuros** — documentar qualquer script extra adicionado para registrar manifests quando mini-apps forem liberados.

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,4 +1,4 @@
-<!-- Template interno do SvelteKit: não incorporar diretamente em WordPress/Elementor. Use dist/app-base-widget.html. -->
+<!-- Template interno do SvelteKit: não incorporar diretamente em WordPress/Elementor. Utilize docs/embed/app-base-snippet.html. -->
 <!doctype html>
 <html lang="pt-br">
   <head>

--- a/docs/embed/app-base-snippet.html
+++ b/docs/embed/app-base-snippet.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="https://cdn.5horas.app/widgets/app-base/latest/app-base-widget.css" />
+<div id="app-base-widget-root"></div>
+<script type="module" src="https://cdn.5horas.app/widgets/app-base/latest/app-base-widget.js"></script>

--- a/readme.md
+++ b/readme.md
@@ -26,17 +26,29 @@ O script `npm run package --workspace web` agora gera:
 
 ## AppBase no Elementor
 
-> ⚠️ **Importante:** o arquivo [`apps/web/src/app.html`](apps/web/src/app.html) é apenas o template interno do SvelteKit. Ele **não** deve ser colado no WordPress/Elementor. Qualquer erro 404 para `/bundle/app-host.js` indica que o snippet utilizado não é o `dist/app-base-widget.html` exportado pelo build.
+> ⚠️ **Importante:** o arquivo [`apps/web/src/app.html`](apps/web/src/app.html) é apenas o template interno do SvelteKit. Ele **não** deve ser colado no WordPress/Elementor. Utilize sempre o snippet hospedado no CDN; qualquer 404 para `app-base-widget.{css,js}` indica caminho incorreto ou bloqueio de permissão.
 
-### Copiando o HTML gerado
+### Snippet CDN pronto para uso
 
-1. Execute `npm run build:widget` na raiz do repositório. O comando compila o bundle do widget (`apps/web/dist/app-base-widget.{css,js}`) e gera o arquivo consolidado [`dist/app-base-widget.html`](dist/app-base-widget.html).
-2. Abra o arquivo HTML em um editor de texto e copie **apenas o conteúdo entre as tags `<body>...</body>`**. Esse trecho contém o container `<div id="app-base-widget-root">`, o estilo injetado e o `<script type="module">` necessário para inicializar o shell.
-3. No Elementor, adicione um widget **HTML personalizado** e cole o trecho copiado. Nenhum ajuste adicional é necessário — o bundle já encapsula CSS e JavaScript.
+O snippet oficial distribuído via CDN fica versionado em [`docs/embed/app-base-snippet.html`](docs/embed/app-base-snippet.html). Ele já referencia os artefatos publicados em `widgets/app-base/latest/` e pode ser colado diretamente em um widget **HTML personalizado** do Elementor.
+
+```html
+<link rel="stylesheet" href="https://cdn.5horas.app/widgets/app-base/latest/app-base-widget.css" />
+<div id="app-base-widget-root"></div>
+<script type="module" src="https://cdn.5horas.app/widgets/app-base/latest/app-base-widget.js"></script>
+```
+
+> Caso o projeto precise de uma versão fixada, clone o arquivo, substitua o caminho `latest/` pelo carimbo desejado e publique o snippet em outro local.
+
+### Build local (opcional)
+
+Se for necessário gerar o HTML inline (por exemplo, para depuração offline), execute `npm run build:widget`. O comando compila o bundle do widget (`apps/web/dist/app-base-widget.{css,js}`) e gera o arquivo consolidado [`dist/app-base-widget.html`](dist/app-base-widget.html).
+
+> Para facilitar o consumo por terceiros, considere empacotar o snippet em um pacote NPM (`app-base-widget-snippet`) ou publicar uma tag no GitHub Releases apontando para o mesmo conteúdo de `docs/embed/app-base-snippet.html`.
 
 ### Arquivos a serem hospedados
 
-- Hospede o próprio [`dist/app-base-widget.html`](dist/app-base-widget.html) em um local acessível (CDN, biblioteca de mídia do WordPress ou servidor estático). Ele é auto contido e pode ser incorporado via `<iframe>` caso a equipe prefira não colar o código manualmente.
+- O CDN oficial publica os artefatos individuais (`app-base-widget.css` e `app-base-widget.js`) em `widgets/app-base/latest/`. Para uso interno, basta consumir o snippet pronto (`docs/embed/app-base-snippet.html`).
 - Preserve os artefatos gerados em `artifacts/`. Cada `web-<id>.tar.gz` contém o build da vertical e um `manifest/active.json`; eles serão publicados futuramente para liberar mini-apps individuais.
 
 ### Ativação de mini-apps
@@ -60,6 +72,12 @@ O script `npm run package --workspace web` agora gera:
    ```
 
 3. Sempre que o shell solicitar um módulo (`app-base:request-module`), responda com o manifest apropriado (o host dispara `app-base:module-pending` automaticamente). Assim que o JSON estiver disponível, o AppBase importará a vertical com base no `loader` informado.
+
+### Checklist rápido pós-incorporação
+
+1. Abra a página publicada, inspecione o console do navegador e confirme que **não há erros 404** nas solicitações de `app-base-widget.{css,js}`.
+2. Valide se o header institucional e a navegação lateral renderizam com o tema oficial.
+3. Capture uma evidência visual ou execute `npm run test:visual` apontando para o ambiente incorporado, quando aplicável.
 
 ## Testes visuais
 


### PR DESCRIPTION
## Summary
- add a ready-to-use CDN snippet for the AppBase widget
- refresh Elementor documentation to reference the CDN snippet and console validation steps
- align in-repo guidance to point editors toward the canonical embed file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17f226fdc83209ec1946502a478f7