### PR TITLE
Atualiza documentação do AppBase com fluxo de deploy contínuo

### DIFF
--- a/apps/web/docs/marco-zero.md
+++ b/apps/web/docs/marco-zero.md
@@ -1,6 +1,12 @@
 # Marco zero — AppBase sem mini-app
 
-> ⚠️ **Atenção:** [`apps/web/src/app.html`](../src/app.html) é apenas o template do SvelteKit e não deve ser embutido diretamente no WordPress/Elementor. Use o snippet publicado em [`docs/embed/app-base-snippet.html`](../../../docs/embed/app-base-snippet.html), que aponta para `widgets/app-base/latest/` no CDN institucional. Qualquer 404 para `app-base-widget.{css,js}` indica problema de permissão ou caminho incorreto.
+> ⚠️ **Atenção:** [`apps/web/src/app.html`](../src/app.html) é apenas o template do SvelteKit e não deve ser embutido diretamente no WordPress/Elementor. Somente o snippet hospedado em [`docs/embed/app-base-snippet.html`](../../../docs/embed/app-base-snippet.html) é suportado; ele aponta para `widgets/app-base/latest/` no CDN institucional. Qualquer 404 para `app-base-widget.{css,js}` indica problema de permissão ou caminho incorreto.
+
+### Fluxo contínuo de publicação
+
+1. **Merge na `main`** — integre suas alterações na branch principal para acionar o workflow `Deploy AppBase`.
+2. **Workflow automático** — o GitHub Actions empacota o host e publica `app-base-widget.{css,js}` no caminho `widgets/app-base/latest/` do CDN.
+3. **Snippet hospedado** — como o Elementor carrega [`app-base-snippet.html`](../../../docs/embed/app-base-snippet.html) diretamente do repositório/CDN, a página atualiza sozinha assim que o deploy finaliza, sem colar `app.html`.
 
 Checklist rápido antes de publicar:
 
@@ -27,5 +33,6 @@ Checklist rápido antes de publicar:
    - Header e navegação institucional renderizados sem mensagens de erro no console.
    - Placeholder do canvas exibindo o texto padrão do AppHost.
    - Ausência de solicitações de rede 404 para `app-base-widget.{css,js}` e `manifest/active.json` (nenhum mini-app ativo).
-4. **Evidência visual** — capturar uma screenshot manual ou via Playwright apontando para a URL do WordPress. Validar que o layout ocupa 100% da largura disponível e que o canvas está vazio.
-5. **Logs futuros** — documentar qualquer script extra adicionado para registrar manifests quando mini-apps forem liberados.
+4. **Checklist pós-deploy** — após o merge e o workflow, abra a página Elementor publicada, inspecione o console (sem erros 404) e capture uma screenshot para anexar ao ticket/PR.
+5. **Validação Playwright** — assim que o comando dedicado estiver disponível (planejado como `npm run test:marco-zero`), execute-o para capturar evidências automatizadas do "marco 0".
+6. **Logs futuros** — documentar qualquer script extra adicionado para registrar manifests quando mini-apps forem liberados.

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,4 +1,4 @@
-<!-- Template interno do SvelteKit: não incorporar diretamente em WordPress/Elementor. Utilize docs/embed/app-base-snippet.html. -->
+<!-- Template interno do SvelteKit: não incorporar diretamente em WordPress/Elementor. Somente o snippet hospedado (docs/embed/app-base-snippet.html) é suportado. -->
 <!doctype html>
 <html lang="pt-br">
   <head>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,15 @@ O script `npm run package --workspace web` agora gera:
 
 ## AppBase no Elementor
 
-> ⚠️ **Importante:** o arquivo [`apps/web/src/app.html`](apps/web/src/app.html) é apenas o template interno do SvelteKit. Ele **não** deve ser colado no WordPress/Elementor. Utilize sempre o snippet hospedado no CDN; qualquer 404 para `app-base-widget.{css,js}` indica caminho incorreto ou bloqueio de permissão.
+> ⚠️ **Importante:** o arquivo [`apps/web/src/app.html`](apps/web/src/app.html) é apenas o template interno do SvelteKit e serve exclusivamente para o runtime do SvelteKit. Ele **não** deve ser colado no WordPress/Elementor — somente o snippet hospedado no CDN é suportado. Qualquer 404 para `app-base-widget.{css,js}` indica caminho incorreto ou bloqueio de permissão.
+
+### Fluxo contínuo de publicação
+
+1. **Merge na `main`** — toda alteração de front-end precisa ser integrada na branch principal. O merge dispara o workflow `Deploy AppBase` no GitHub Actions.
+2. **Execução automática do workflow** — o pipeline compila o host, atualiza o `widgets/app-base/latest/` e publica os artefatos (`app-base-widget.{css,js}`) no CDN institucional.
+3. **Snippet hospedado atualizado** — o arquivo [`docs/embed/app-base-snippet.html`](docs/embed/app-base-snippet.html) referencia o caminho `latest/`. Assim que o CDN conclui a publicação, qualquer página Elementor carregando o snippet passa a exibir a nova versão automaticamente, sem necessidade de colar HTML adicional.
+
+Documente no ticket correspondente a hora do merge e o link do workflow para rastreabilidade.
 
 ### Snippet CDN pronto para uso
 
@@ -73,11 +81,12 @@ Se for necessário gerar o HTML inline (por exemplo, para depuração offline), 
 
 3. Sempre que o shell solicitar um módulo (`app-base:request-module`), responda com o manifest apropriado (o host dispara `app-base:module-pending` automaticamente). Assim que o JSON estiver disponível, o AppBase importará a vertical com base no `loader` informado.
 
-### Checklist rápido pós-incorporação
+### Checklist pós-deploy (marco zero)
 
-1. Abra a página publicada, inspecione o console do navegador e confirme que **não há erros 404** nas solicitações de `app-base-widget.{css,js}`.
-2. Valide se o header institucional e a navegação lateral renderizam com o tema oficial.
-3. Capture uma evidência visual ou execute `npm run test:visual` apontando para o ambiente incorporado, quando aplicável.
+1. **Abrir a página Elementor publicada** e validar o carregamento automático do snippet (sem colar `app.html`).
+2. **Inspecionar erros no console** garantindo ausência de 404 para `app-base-widget.{css,js}` e scripts relacionados.
+3. **Capturar uma screenshot atualizada** para anexar ao ticket/PR.
+4. **Executar a suíte Playwright do marco zero** assim que o comando dedicado estiver disponível (planejado como `npm run test:marco-zero`). Anexar relatório quando aplicável.
 
 ## Testes visuais
 


### PR DESCRIPTION
## Summary
- reforça a orientação para usar apenas o snippet hospedado do AppBase
- documenta o fluxo automático de deploy (merge na main, workflow e atualização no CDN)
- adiciona checklist pós-deploy com inspeção, evidência visual e referência ao futuro teste Playwright

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18022c3ac8320979b70704e96d4ef