### PR TITLE
Improve app host accessibility and layout

### DIFF
--- a/apps/web/src/lib/appHost/AppHost.svelte
+++ b/apps/web/src/lib/appHost/AppHost.svelte
@@ -173,12 +173,13 @@ import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
     </div>
   )}
   nav={() => (
-    <ul class="app-host__nav">
+    <ul class="app-host__nav" role="list">
       {#each manifestList as entry (entry.id)}
         <li>
           <button
             type="button"
             class:active={entry.id === activeId}
+            aria-current={entry.id === activeId ? 'page' : undefined}
             on:click={() => handleSelect(entry.id)}
           >
             <span class="icon" aria-hidden="true">{entry.icon}</span>
@@ -193,11 +194,11 @@ import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
       <div class="app-host__workspace">
         <MiniAppBase class="app-host__miniapp-base" />
         {#if loading}
-          <div class="app-host__stage app-host__stage--status">
+          <div class="app-host__stage app-host__stage--status" aria-live="polite" aria-busy="true">
             <p class="app-host__status">Carregando {activeId ? manifestMap[activeId]?.label : 'mini-app'}…</p>
           </div>
         {:else if error}
-          <div class="app-host__stage app-host__stage--status">
+          <div class="app-host__stage app-host__stage--status" aria-live="assertive">
             <div class="app-host__error" role="alert">
               <strong>Erro ao carregar módulo.</strong>
               <pre>{error.message}</pre>

--- a/apps/web/src/lib/appHost/manifest.config.json
+++ b/apps/web/src/lib/appHost/manifest.config.json
@@ -14,6 +14,13 @@
     "requires": ["projectData", "bus", "ac"]
   },
   {
+    "id": "tarefas",
+    "label": "Tarefas",
+    "icon": "✅",
+    "loader": "@marco/features-tarefas",
+    "requires": ["projectData", "bus", "ac"]
+  },
+  {
     "id": "anfitriao",
     "label": "Anfitrião",
     "icon": "🤝",
@@ -26,13 +33,6 @@
     "icon": "📝",
     "loader": "./verticals/placeholder.svelte",
     "requires": ["projectData"]
-  },
-  {
-    "id": "tarefas",
-    "label": "Tarefas",
-    "icon": "✅",
-    "loader": "@marco/features-tarefas",
-    "requires": ["projectData", "bus", "ac"]
   },
   {
     "id": "fornecedores",

--- a/apps/web/src/lib/layout/AppBaseLayout.svelte
+++ b/apps/web/src/lib/layout/AppBaseLayout.svelte
@@ -3,20 +3,26 @@
 </script>
 
 <div class={`app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink ${className}`.trim()}>
-  <header class="app-base-layout__top border-b border-surface-muted bg-surface px-6 py-4 shadow-sm">
+  <header class="app-base-layout__top border-b border-surface-muted bg-surface px-4 py-4 shadow-sm sm:px-6">
     {@render top?.()}
   </header>
 
-  <div class="app-base-layout__canvas flex min-h-0 flex-1 overflow-hidden">
-    <nav class="app-base-layout__nav w-72 shrink-0 border-r border-surface-muted bg-surface px-4 py-6">
+  <div class="app-base-layout__canvas flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
+    <nav
+      class="
+        app-base-layout__nav
+        w-full shrink-0 overflow-x-auto border-b border-surface-muted bg-surface px-4 py-5
+        lg:w-72 lg:border-b-0 lg:border-r lg:overflow-y-auto
+      "
+    >
       {@render nav?.()}
     </nav>
 
-    <main class="app-base-layout__workspace flex-1 overflow-hidden bg-surface px-6 py-6">
+    <main class="app-base-layout__workspace flex-1 min-h-0 overflow-hidden bg-surface px-4 py-6 sm:px-6">
       {#if workspace}
         {@render workspace()}
       {:else}
-        <div class="app-base-layout__app h-full overflow-auto">
+        <div class="app-base-layout__app h-full min-h-0 overflow-auto">
           {#if app}
             {@render app()}
           {:else}


### PR DESCRIPTION
## Summary
- add accessibility affordances to the AppHost navigation and status panels
- reorder the manifest to bring the tarefas vertical forward
- refine AppBaseLayout spacing and responsiveness for small screens

## Testing
- `npm run test:visual` *(fails: build script errors because src/app.html is missing %sveltekit.body%)*

------
https://chatgpt.com/codex/tasks/task_e_68e193a7558c8320930e57f62953c637