### PR TITLE
Adjust AppHost layout for non-runes lint compliance

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -11,10 +11,19 @@
     %sveltekit.head%
     <link rel="stylesheet" href="/bundle/app-base.css" data-app-base="local" />
     <script type="module" src="/bundle/app-host.js" defer data-app-base="local"></script>
+    <script>
+      window.addEventListener('sveltekit:start', () => {
+        document.querySelector('[data-app-base-fallback]')?.remove();
+      });
+    </script>
   </head>
   <body class="app-base-body" data-sveltekit-preload-data="hover">
     <div class="app-base-root">
-      <div class="app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink">
+      %sveltekit.body%
+      <div
+        class="app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink"
+        data-app-base-fallback
+      >
         <header class="app-base-layout__top border-b border-surface-muted bg-surface px-6 py-4 shadow-sm">
           <div class="app-base-topbar flex items-center justify-between gap-4">
             <div class="app-base-topbar__branding">

--- a/apps/web/src/lib/appHost/AppHost.svelte
+++ b/apps/web/src/lib/appHost/AppHost.svelte
@@ -1,9 +1,11 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
   import { createEventDispatcher, onMount, setContext } from 'svelte';
   import type { ComponentType } from 'svelte';
   import { get } from 'svelte/store';
-import MiniAppBase from '$lib/components/miniAppBase/MiniAppBase.svelte';
-import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
+  import MiniAppBase from '$lib/components/miniAppBase/MiniAppBase.svelte';
+  import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
   import { projectData } from '$lib/data/projects';
   import { bus } from '@marco/platform/bus';
   import manifestDefault, {
@@ -162,63 +164,60 @@ import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
   <title>Gerenciar Eventos — Hub de Verticais</title>
 </svelte:head>
 
-<AppBaseLayout
-  class="app-host"
-  top={() => (
-    <div class="app-host__header">
-      <div>
-        <h1>Gestão de eventos</h1>
-        <p>Selecione um mini-app para continuar.</p>
-      </div>
+<AppBaseLayout className="app-host">
+  <div slot="top" class="app-host__header">
+    <div>
+      <h1>Gestão de eventos</h1>
+      <p>Selecione um mini-app para continuar.</p>
     </div>
-  )}
-  nav={() => (
-    <ul class="app-host__nav">
-      {#each manifestList as entry (entry.id)}
-        <li>
-          <button
-            type="button"
-            class:active={entry.id === activeId}
-            on:click={() => handleSelect(entry.id)}
-          >
-            <span class="icon" aria-hidden="true">{entry.icon}</span>
-            <span class="label">{entry.label}</span>
-          </button>
-        </li>
-      {/each}
-    </ul>
-  )}
-  app={() => (
-    <div class="app-host__canvas">
-      <div class="app-host__workspace">
-        <MiniAppBase class="app-host__miniapp-base" />
-        {#if loading}
-          <div class="app-host__stage app-host__stage--status">
-            <p class="app-host__status">Carregando {activeId ? manifestMap[activeId]?.label : 'mini-app'}…</p>
-          </div>
-        {:else if error}
-          <div class="app-host__stage app-host__stage--status">
-            <div class="app-host__error" role="alert">
-              <strong>Erro ao carregar módulo.</strong>
-              <pre>{error.message}</pre>
-            </div>
-          </div>
-        {:else if component}
-          <div class="app-host__stage app-host__stage--component">
-            <svelte:component this={component} {...componentProps} />
-          </div>
-        {:else}
-          <div class="app-host__stage app-host__stage--placeholder">
-            <div class="app-host__stage-placeholder">
-              <h2>Tela inicial dos mini apps</h2>
-              <p>Escolha uma vertical na navegação lateral para começar.</p>
-            </div>
-          </div>
-        {/if}
+  </div>
+
+  <ul slot="nav" class="app-host__nav">
+    {#each manifestList as entry (entry.id)}
+      <li>
+        <button
+          type="button"
+          class:active={entry.id === activeId}
+          onclick={() => handleSelect(entry.id)}
+        >
+          <span class="icon" aria-hidden="true">{entry.icon}</span>
+          <span class="label">{entry.label}</span>
+        </button>
+      </li>
+    {/each}
+  </ul>
+
+  <div slot="app" class="app-host__canvas">
+    <div class="app-host__workspace">
+      <div class="app-host__miniapp-base">
+        <MiniAppBase />
       </div>
+      {#if loading}
+        <div class="app-host__stage app-host__stage--status">
+          <p class="app-host__status">Carregando {activeId ? manifestMap[activeId]?.label : 'mini-app'}…</p>
+        </div>
+      {:else if error}
+        <div class="app-host__stage app-host__stage--status">
+          <div class="app-host__error" role="alert">
+            <strong>Erro ao carregar módulo.</strong>
+            <pre>{error.message}</pre>
+          </div>
+        </div>
+      {:else if component}
+        <div class="app-host__stage app-host__stage--component">
+          <svelte:component this={component} {...componentProps} />
+        </div>
+      {:else}
+        <div class="app-host__stage app-host__stage--placeholder">
+          <div class="app-host__stage-placeholder">
+            <h2>Tela inicial dos mini apps</h2>
+            <p>Escolha uma vertical na navegação lateral para começar.</p>
+          </div>
+        </div>
+      {/if}
     </div>
-  )}
-/>
+  </div>
+</AppBaseLayout>
 
 <style>
   .app-host__header {

--- a/apps/web/src/lib/appHost/logic.d.ts
+++ b/apps/web/src/lib/appHost/logic.d.ts
@@ -4,6 +4,7 @@ import type {
   AppManifestEntry,
   AppManifestOverrides,
 } from './types';
+import type { ComponentType } from 'svelte';
 
 export interface MergeManifestResult {
   list: AppManifestEntry[];
@@ -24,4 +25,4 @@ export declare function resolveActiveId(
 export declare function loadVertical<T>(
   entry: AppManifestEntry,
   importer: (loader: string) => Promise<T>,
-): Promise<Function>;
+): Promise<ComponentType>;

--- a/apps/web/src/lib/components/miniAppBase/MiniAppBase.svelte
+++ b/apps/web/src/lib/components/miniAppBase/MiniAppBase.svelte
@@ -1,8 +1,10 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
   import { userProfile } from '$lib/data/userProfile';
   import type { UserProfileState } from '$lib/data/userProfile';
 
-  let { class: className = '' } = $props();
+  export let className = '';
 
   const formatValue = (value: string) => (value?.trim() ? value.trim() : '—');
 

--- a/apps/web/src/lib/data/projects.ts
+++ b/apps/web/src/lib/data/projects.ts
@@ -48,7 +48,12 @@ async function prepareStore(): Promise<ProjectStore> {
         lastError = error;
         try {
           await candidate.close();
-        } catch {}
+        } catch (closeError) {
+          console.warn(
+            '[projectData] Falha ao encerrar adaptador após erro de inicialização',
+            closeError,
+          );
+        }
       }
     }
     throw lastError || new Error('Falha ao inicializar store de projetos');

--- a/apps/web/src/lib/layout/AppBaseLayout.svelte
+++ b/apps/web/src/lib/layout/AppBaseLayout.svelte
@@ -1,29 +1,27 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
-  let { class: className = '', top, nav, workspace, app, children } = $props();
+  export let className = '';
 </script>
 
 <div class={`app-base-layout grid min-h-screen grid-rows-[auto,1fr] bg-surface-muted text-ink ${className}`.trim()}>
   <header class="app-base-layout__top border-b border-surface-muted bg-surface px-6 py-4 shadow-sm">
-    {@render top?.()}
+    <slot name="top" />
   </header>
 
   <div class="app-base-layout__canvas flex min-h-0 flex-1 overflow-hidden">
     <nav class="app-base-layout__nav w-72 shrink-0 border-r border-surface-muted bg-surface px-4 py-6">
-      {@render nav?.()}
+      <slot name="nav" />
     </nav>
 
     <main class="app-base-layout__workspace flex-1 overflow-hidden bg-surface px-6 py-6">
-      {#if workspace}
-        {@render workspace()}
-      {:else}
+      <slot name="workspace">
         <div class="app-base-layout__app h-full overflow-auto">
-          {#if app}
-            {@render app()}
-          {:else}
-            {@render children?.()}
-          {/if}
+          <slot name="app">
+            <slot />
+          </slot>
         </div>
-      {/if}
+      </slot>
     </main>
   </div>
 </div>

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,15 +1,17 @@
-<script lang="ts">
-        import '../app.css';
-        import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
-        import favicon from '$lib/assets/favicon.svg';
+<svelte:options runes={false} />
 
-        let { children } = $props();
+<script lang="ts">
+  import '../app.css';
+  import AppBaseLayout from '$lib/layout/AppBaseLayout.svelte';
+  import favicon from '$lib/assets/favicon.svg';
 </script>
 
 <svelte:head>
-        <link rel="icon" href={favicon} />
+  <link rel="icon" href={favicon} />
 </svelte:head>
 
 <AppBaseLayout>
-        {@render children?.()}
+  <svelte:fragment slot="app">
+    <slot />
+  </svelte:fragment>
 </AppBaseLayout>


### PR DESCRIPTION
## Summary
- disable runes mode across the host layout components and refactor AppBaseLayout/AppHost to use slot-based markup compatible with eslint
- expose the legacy MiniAppBase props, tighten project store cleanup logging, and return ComponentType from loadVertical typings
- embed the SvelteKit body placeholder plus fallback cleanup in app.html so builds succeed alongside the Elementor-style static fallback

## Testing
- npm run lint:web
- npm --workspace web run test:unit
- npm run test:visual *(fails: ReferenceError: exports is not defined in tests/fixtures/wedding.ts)*
- npm run format *(fails: marco-format not found in package workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_68e193c697f08320ac11e3f87f5270f2