### PR TITLE
feat: load mini-apps from manifest-driven boot config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ HTML estático e JavaScript vanilla.
 │   ├── index.html             # Página principal do AppBase + mini-apps
 │   ├── locales/               # Arquivos de tradução (JSON)
 │   ├── scripts/               # AppBase, mocks, UI e módulos de exportação
+│   ├── miniapps/              # Manifestos declarativos dos mini-apps
 │   └── styles/                # Tokens de design e estilos de componentes
 ├── MARCO_BLUEPRINT.md         # Blueprint consolidado do AppBase
 ├── README.md                  # Este documento
@@ -36,7 +37,10 @@ HTML estático e JavaScript vanilla.
 - **AppBase modular** (`src/scripts/app-base.js`): registra mini-apps, controla
   toggles e expõe a configuração resolvida.
 - **Mocks e snapshots** (`src/scripts/state.js`): simula KPIs, sessão, catálogo
-  de marketplace, observabilidade e auditoria com suporte a traduções.
+  de marketplace, observabilidade e auditoria com suporte a traduções e expõe o
+  contrato `bootConfig` com a lista `miniApps`.
+- **Manifestos de mini-app** (`src/miniapps/*.json`): definem metadados, painéis
+  e dados de marketplace consumidos dinamicamente no boot.
 - **Camada de UI** (`src/scripts/ui.js`): renderiza cards, conecta eventos,
   atualiza métricas e aplica traduções dinâmicas (incluindo time relative e
   textos do marketplace).

--- a/src/miniapps/account.json
+++ b/src/miniapps/account.json
@@ -1,0 +1,38 @@
+{
+  "key": "account",
+  "module": {
+    "type": "template"
+  },
+  "meta": {
+    "id": "mini-app-conta",
+    "card": {
+      "label": "Conta & Backup",
+      "labelKey": "miniapps.account.label",
+      "meta": "Identidade, dispositivos e direitos LGPD",
+      "metaKey": "miniapps.account.meta",
+      "cta": "Gerenciar conta",
+      "ctaKey": "miniapps.account.cta"
+    },
+    "badges": ["LGPD", "Backup"],
+    "badgeKeys": ["miniapps.account.badge1", "miniapps.account.badge2"],
+    "panel": {
+      "template": "panel-template-account",
+      "meta": "Masters para direitos do titular, dispositivos e backups.",
+      "metaKey": "miniapps.account.panel"
+    },
+    "marketplace": {
+      "title": "Conta & Backup",
+      "titleKey": "market.catalog.account.title",
+      "description": "Identidade, dispositivos, direitos do titular e backups.",
+      "descriptionKey": "market.catalog.account.description",
+      "capabilities": ["LGPD", "Backup", "Passkeys"],
+      "capabilityKeys": [
+        "market.catalog.account.capability1",
+        "market.catalog.account.capability2",
+        "market.catalog.account.capability3"
+      ],
+      "license": "Base",
+      "licenseKey": "market.catalog.account.license"
+    }
+  }
+}

--- a/src/miniapps/analytics.json
+++ b/src/miniapps/analytics.json
@@ -1,0 +1,24 @@
+{
+  "key": "analytics",
+  "module": {
+    "type": "placeholder"
+  },
+  "meta": {
+    "marketplace": {
+      "title": "Insights Avançados",
+      "titleKey": "market.catalog.analytics.title",
+      "description": "Visualizações analíticas e previsões operacionais.",
+      "descriptionKey": "market.catalog.analytics.description",
+      "capabilities": ["Forecast", "Análises", "Dashboards"],
+      "capabilityKeys": [
+        "market.catalog.analytics.capability1",
+        "market.catalog.analytics.capability2",
+        "market.catalog.analytics.capability3"
+      ],
+      "license": "Add-on",
+      "licenseKey": "market.catalog.analytics.license",
+      "comingSoon": true,
+      "comingSoonKey": "market.catalog.analytics.soon"
+    }
+  }
+}

--- a/src/miniapps/market.json
+++ b/src/miniapps/market.json
@@ -1,0 +1,38 @@
+{
+  "key": "market",
+  "module": {
+    "type": "template"
+  },
+  "meta": {
+    "id": "mini-app-market",
+    "card": {
+      "label": "Marketplace",
+      "labelKey": "miniapps.market.label",
+      "meta": "Catálogo confiável de mini-apps do tenant",
+      "metaKey": "miniapps.market.meta",
+      "cta": "Gerenciar licenças",
+      "ctaKey": "miniapps.market.cta"
+    },
+    "badges": ["Catálogo", "Provisionamento"],
+    "badgeKeys": ["miniapps.market.badge1", "miniapps.market.badge2"],
+    "panel": {
+      "template": "panel-template-market",
+      "meta": "Preview compacto para habilitar ou revogar licenças.",
+      "metaKey": "miniapps.market.panel"
+    },
+    "marketplace": {
+      "title": "Marketplace",
+      "titleKey": "market.catalog.market.title",
+      "description": "Gestão de catálogos, licenças e habilitação de MiniApps.",
+      "descriptionKey": "market.catalog.market.description",
+      "capabilities": ["Catálogo", "Licenças", "Provisionamento"],
+      "capabilityKeys": [
+        "market.catalog.market.capability1",
+        "market.catalog.market.capability2",
+        "market.catalog.market.capability3"
+      ],
+      "license": "Base",
+      "licenseKey": "market.catalog.market.license"
+    }
+  }
+}

--- a/src/miniapps/operations.json
+++ b/src/miniapps/operations.json
@@ -1,0 +1,38 @@
+{
+  "key": "operations",
+  "module": {
+    "type": "template"
+  },
+  "meta": {
+    "id": "mini-app-painel",
+    "card": {
+      "label": "Painel de Operações",
+      "labelKey": "miniapps.operations.label",
+      "meta": "KPIs, dados mestres e status de recursos",
+      "metaKey": "miniapps.operations.meta",
+      "cta": "Abrir painel detalhado",
+      "ctaKey": "miniapps.operations.cta"
+    },
+    "badges": ["KPIs", "Alertas"],
+    "badgeKeys": ["miniapps.operations.badge1", "miniapps.operations.badge2"],
+    "panel": {
+      "template": "panel-template-operations",
+      "meta": "Masters do painel operacional prontos para receber subcards.",
+      "metaKey": "miniapps.operations.panel"
+    },
+    "marketplace": {
+      "title": "Painel de Operações",
+      "titleKey": "market.catalog.operations.title",
+      "description": "KPIs, dados mestres e status unificado do tenant.",
+      "descriptionKey": "market.catalog.operations.description",
+      "capabilities": ["KPIs", "Alertas", "Workflow"],
+      "capabilityKeys": [
+        "market.catalog.operations.capability1",
+        "market.catalog.operations.capability2",
+        "market.catalog.operations.capability3"
+      ],
+      "license": "Base",
+      "licenseKey": "market.catalog.operations.license"
+    }
+  }
+}

--- a/src/miniapps/settings.json
+++ b/src/miniapps/settings.json
@@ -1,0 +1,38 @@
+{
+  "key": "settings",
+  "module": {
+    "type": "template"
+  },
+  "meta": {
+    "id": "mini-app-config",
+    "card": {
+      "label": "Configuração & Operação",
+      "labelKey": "miniapps.settings.label",
+      "meta": "Parametros, observabilidade e auditoria",
+      "metaKey": "miniapps.settings.meta",
+      "cta": "Abrir configurações",
+      "ctaKey": "miniapps.settings.cta"
+    },
+    "badges": ["Schemas", "Logs"],
+    "badgeKeys": ["miniapps.settings.badge1", "miniapps.settings.badge2"],
+    "panel": {
+      "template": "panel-template-settings",
+      "meta": "Masters de configuração rápida e observabilidade do tenant.",
+      "metaKey": "miniapps.settings.panel"
+    },
+    "marketplace": {
+      "title": "Configuração & Operação",
+      "titleKey": "market.catalog.settings.title",
+      "description": "Parâmetros do AppBase, observabilidade e auditoria.",
+      "descriptionKey": "market.catalog.settings.description",
+      "capabilities": ["Schemas", "Observabilidade", "LGPD"],
+      "capabilityKeys": [
+        "market.catalog.settings.capability1",
+        "market.catalog.settings.capability2",
+        "market.catalog.settings.capability3"
+      ],
+      "license": "Base",
+      "licenseKey": "market.catalog.settings.license"
+    }
+  }
+}

--- a/src/miniapps/tasks.json
+++ b/src/miniapps/tasks.json
@@ -1,0 +1,38 @@
+{
+  "key": "tasks",
+  "module": {
+    "type": "template"
+  },
+  "meta": {
+    "id": "mini-app-tarefas",
+    "card": {
+      "label": "Gestor de Tarefas",
+      "labelKey": "miniapps.tasks.label",
+      "meta": "Cronogramas, responsáveis e dados consumidos",
+      "metaKey": "miniapps.tasks.meta",
+      "cta": "Abrir lista de tarefas",
+      "ctaKey": "miniapps.tasks.cta"
+    },
+    "badges": ["Workflow", "Autosave"],
+    "badgeKeys": ["miniapps.tasks.badge1", "miniapps.tasks.badge2"],
+    "panel": {
+      "template": "panel-template-tasks",
+      "meta": "Masters do gestor focados em filtros e status prioritários.",
+      "metaKey": "miniapps.tasks.panel"
+    },
+    "marketplace": {
+      "title": "Gestor de Tarefas",
+      "titleKey": "market.catalog.tasks.title",
+      "description": "Cronogramas, responsáveis e dependências críticas.",
+      "descriptionKey": "market.catalog.tasks.description",
+      "capabilities": ["Quadro", "Alertas", "Exportação"],
+      "capabilityKeys": [
+        "market.catalog.tasks.capability1",
+        "market.catalog.tasks.capability2",
+        "market.catalog.tasks.capability3"
+      ],
+      "license": "Base",
+      "licenseKey": "market.catalog.tasks.license"
+    }
+  }
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -3,7 +3,6 @@ import {
   dashboardSnapshot,
   sessionState,
   backupSnapshot,
-  marketCatalog,
   observabilitySnapshot,
   bootConfig,
   moduleDefinitions,
@@ -22,10 +21,148 @@ import {
   bindBackToHome,
 } from './ui.js';
 
-async function bootstrap() {
-  moduleDefinitions.forEach((definition) => {
-    AppBase.register(definition.key, definition);
+let catalogEntries = [];
+
+async function loadMiniAppManifest(entry) {
+  if (entry?.manifest) {
+    return entry.manifest;
+  }
+  if (!entry?.manifestUrl) {
+    throw new Error(`Mini-app "${entry?.key ?? 'desconhecido'}" sem manifestUrl definido.`);
+  }
+  const manifestUrl = new URL(entry.manifestUrl, import.meta.url);
+  const response = await fetch(manifestUrl.href);
+  if (!response.ok) {
+    throw new Error(`Falha ao carregar manifesto de ${entry.key ?? 'mini-app'}. Código ${response.status}`);
+  }
+  return response.json();
+}
+
+async function createModuleFromManifest(entry, manifest, moduleType = 'template') {
+  const key = manifest.key ?? entry.key;
+  if (!key) {
+    throw new Error('Mini-app sem chave definida no manifesto.');
+  }
+
+  if (moduleType === 'template') {
+    const specifier = entry.moduleUrl ?? './template-module.js';
+    const moduleUrl = new URL(specifier, import.meta.url).href;
+    const moduleFactory = await import(moduleUrl);
+    const factory =
+      typeof moduleFactory.createTemplateModule === 'function'
+        ? moduleFactory.createTemplateModule
+        : typeof moduleFactory.default === 'function'
+          ? moduleFactory.default
+          : null;
+    if (!factory) {
+      throw new Error(`O módulo "${specifier}" não exporta createTemplateModule.`);
+    }
+    const config = { key, ...(manifest.meta ?? {}) };
+    return factory(config);
+  }
+
+  return null;
+}
+
+function createFallbackMap(definitions) {
+  return new Map(definitions.map((definition) => [definition.key, definition]));
+}
+
+async function resolveMiniApp(entry, fallbackMap) {
+  const result = {
+    key: entry.key ?? null,
+    registered: false,
+    marketplace: null,
+  };
+
+  try {
+    const manifest = await loadMiniAppManifest(entry);
+    const key = manifest.key ?? entry.key;
+    if (!key) {
+      throw new Error('Manifesto de mini-app sem chave.');
+    }
+    result.key = key;
+
+    const moduleType = manifest.module?.type ?? entry.moduleType ?? 'template';
+    const marketplaceMeta = manifest.meta?.marketplace ?? manifest.marketplace ?? null;
+    if (marketplaceMeta) {
+      result.marketplace = { key, ...marketplaceMeta };
+    }
+
+    if (moduleType === 'placeholder') {
+      return result;
+    }
+
+    const definition = await createModuleFromManifest(entry, manifest, moduleType);
+    if (!definition) {
+      throw new Error(`Mini-app ${key} não possui definição de módulo válida.`);
+    }
+
+    AppBase.register(key, definition);
+    fallbackMap.delete(key);
+    result.registered = true;
+    return result;
+  } catch (error) {
+    const fallbackKey = result.key ?? entry.key;
+    if (fallbackKey && fallbackMap.has(fallbackKey)) {
+      const fallbackDefinition = fallbackMap.get(fallbackKey);
+      AppBase.register(fallbackKey, fallbackDefinition);
+      fallbackMap.delete(fallbackKey);
+      result.key = fallbackKey;
+      result.registered = true;
+      if (!result.marketplace && fallbackDefinition.meta?.marketplace) {
+        result.marketplace = { key: fallbackKey, ...fallbackDefinition.meta.marketplace };
+      }
+      console.warn(`Mini-app "${fallbackKey}" carregado via fallback local.`, error);
+    } else {
+      console.error(`Falha ao carregar mini-app "${fallbackKey ?? 'desconhecido'}"`, error);
+    }
+    return result;
+  }
+}
+
+function collectMarketplaceEntries(resolved, fallbackMap) {
+  const entries = [];
+
+  resolved.forEach((item) => {
+    if (item.marketplace) {
+      entries.push(item.marketplace);
+    }
   });
+
+  fallbackMap.forEach((definition, key) => {
+    if (AppBase.resolve(key)) {
+      return;
+    }
+    AppBase.register(key, definition);
+    fallbackMap.delete(key);
+    if (definition.meta?.marketplace) {
+      entries.push({ key, ...definition.meta.marketplace });
+    }
+  });
+
+  if (!entries.length) {
+    AppBase.getModuleMetaEntries().forEach(([key, meta]) => {
+      if (meta.marketplace) {
+        entries.push({ key, ...meta.marketplace });
+      }
+    });
+  }
+
+  return entries;
+}
+
+async function bootstrap() {
+  const fallbackMap = createFallbackMap(moduleDefinitions);
+  const miniAppConfig = Array.isArray(bootConfig.miniApps) ? bootConfig.miniApps : [];
+  const resolvedMiniApps = [];
+
+  for (const entry of miniAppConfig) {
+    const resolved = await resolveMiniApp(entry, fallbackMap);
+    resolvedMiniApps.push(resolved);
+  }
+
+  catalogEntries = collectMarketplaceEntries(resolvedMiniApps, fallbackMap);
 
   await initLocalization('pt-BR');
   initThemeControls();
@@ -33,7 +170,7 @@ async function bootstrap() {
   AppBase.boot(bootConfig);
 
   renderMiniAppGrid();
-  buildMarketplace(marketCatalog);
+  buildMarketplace(catalogEntries);
   updateHeaderSession(bootConfig, sessionState);
   updateHomeSnapshot(dashboardSnapshot);
   updateAccountDetails(bootConfig, sessionState, backupSnapshot);
@@ -44,7 +181,7 @@ async function bootstrap() {
 
   AppBase.onChange(() => {
     renderMiniAppGrid();
-    buildMarketplace(marketCatalog);
+    buildMarketplace(catalogEntries);
   });
 }
 

--- a/src/scripts/state.js
+++ b/src/scripts/state.js
@@ -1,3 +1,5 @@
+import { createTemplateModule } from './template-module.js';
+
 export const dashboardSnapshot = {
   taskFlow: 82,
   capacity: 92,
@@ -82,172 +84,6 @@ export const backupSnapshot = {
   },
 };
 
-export const marketCatalog = [
-  {
-    key: 'operations',
-    title: 'Painel de Operações',
-    titleKey: 'market.catalog.operations.title',
-    description: 'KPIs, dados mestres e status unificado do tenant.',
-    descriptionKey: 'market.catalog.operations.description',
-    capabilities: ['KPIs', 'Alertas', 'Workflow'],
-    capabilityKeys: [
-      'market.catalog.operations.capability1',
-      'market.catalog.operations.capability2',
-      'market.catalog.operations.capability3',
-    ],
-    license: 'Base',
-    licenseKey: 'market.catalog.operations.license',
-  },
-  {
-    key: 'tasks',
-    title: 'Gestor de Tarefas',
-    titleKey: 'market.catalog.tasks.title',
-    description: 'Cronogramas, responsáveis e dependências críticas.',
-    descriptionKey: 'market.catalog.tasks.description',
-    capabilities: ['Quadro', 'Alertas', 'Exportação'],
-    capabilityKeys: [
-      'market.catalog.tasks.capability1',
-      'market.catalog.tasks.capability2',
-      'market.catalog.tasks.capability3',
-    ],
-    license: 'Base',
-    licenseKey: 'market.catalog.tasks.license',
-  },
-  {
-    key: 'account',
-    title: 'Conta & Backup',
-    titleKey: 'market.catalog.account.title',
-    description: 'Identidade, dispositivos, direitos do titular e backups.',
-    descriptionKey: 'market.catalog.account.description',
-    capabilities: ['LGPD', 'Backup', 'Passkeys'],
-    capabilityKeys: [
-      'market.catalog.account.capability1',
-      'market.catalog.account.capability2',
-      'market.catalog.account.capability3',
-    ],
-    license: 'Premium',
-    licenseKey: 'market.catalog.account.license',
-  },
-  {
-    key: 'market',
-    title: 'Marketplace',
-    titleKey: 'market.catalog.market.title',
-    description: 'Gestão de catálogos, licenças e habilitação de MiniApps.',
-    descriptionKey: 'market.catalog.market.description',
-    capabilities: ['Catálogo', 'Licenças', 'Provisionamento'],
-    capabilityKeys: [
-      'market.catalog.market.capability1',
-      'market.catalog.market.capability2',
-      'market.catalog.market.capability3',
-    ],
-    license: 'Base',
-    licenseKey: 'market.catalog.market.license',
-  },
-  {
-    key: 'settings',
-    title: 'Configuração & Operação',
-    titleKey: 'market.catalog.settings.title',
-    description: 'Parâmetros do AppBase, observabilidade e auditoria.',
-    descriptionKey: 'market.catalog.settings.description',
-    capabilities: ['Schemas', 'Observabilidade', 'LGPD'],
-    capabilityKeys: [
-      'market.catalog.settings.capability1',
-      'market.catalog.settings.capability2',
-      'market.catalog.settings.capability3',
-    ],
-    license: 'Base',
-    licenseKey: 'market.catalog.settings.license',
-  },
-  {
-    key: 'analytics',
-    title: 'Insights Avançados',
-    titleKey: 'market.catalog.analytics.title',
-    description: 'Visualizações analíticas e previsões operacionais.',
-    descriptionKey: 'market.catalog.analytics.description',
-    capabilities: ['Forecast', 'Análises', 'Dashboards'],
-    capabilityKeys: [
-      'market.catalog.analytics.capability1',
-      'market.catalog.analytics.capability2',
-      'market.catalog.analytics.capability3',
-    ],
-    license: 'Add-on',
-    licenseKey: 'market.catalog.analytics.license',
-    comingSoon: true,
-    comingSoonKey: 'market.catalog.analytics.soon',
-  },
-];
-
-
-function createTemplateModule(config) {
-  const meta = {
-    key: config.key,
-    id: config.id,
-    card: config.card,
-    badges: config.badges ?? [],
-    badgeKeys: config.badgeKeys ?? [],
-    panel: config.panel ?? {},
-  };
-
-  return {
-    key: meta.key,
-    meta,
-    init(container, context = {}) {
-      if (!container) {
-        return;
-      }
-      const templateId = meta.panel?.template;
-      const uiContext = context.ui ?? {};
-      const applyTranslations = typeof uiContext.applyTranslations === 'function' ? uiContext.applyTranslations : null;
-      const translateWithFallback =
-        typeof uiContext.translateWithFallback === 'function' ? uiContext.translateWithFallback : null;
-      const translate = typeof uiContext.translate === 'function' ? uiContext.translate : null;
-
-      if (templateId) {
-        const template = document.getElementById(templateId);
-        if (template) {
-          container.appendChild(template.content.cloneNode(true));
-          if (applyTranslations) {
-            applyTranslations(container);
-          }
-        }
-      }
-
-      if (!container.hasChildNodes()) {
-        const resolvedLabel =
-          (translateWithFallback && translateWithFallback(meta.card?.labelKey, meta.card?.label ?? '')) ||
-          (translate && meta.card?.labelKey
-            ? (() => {
-                const value = translate(meta.card.labelKey, {});
-                return value !== meta.card.labelKey ? value : null;
-              })()
-            : null) ||
-          meta.card?.label ||
-          meta.key;
-
-        const fallbackText =
-          (translateWithFallback &&
-            translateWithFallback(
-              'panel.placeholder.default',
-              `Selecione um mini-app para ${resolvedLabel}`,
-              { label: resolvedLabel },
-            )) ||
-          (translate
-            ? (() => {
-                const value = translate('panel.placeholder.default', { label: resolvedLabel });
-                return value !== 'panel.placeholder.default' ? value : null;
-              })()
-            : null) ||
-          `Selecione um mini-app para ${resolvedLabel}`;
-
-        const fallback = document.createElement('p');
-        fallback.className = 'panel-note';
-        fallback.textContent = fallbackText;
-        container.appendChild(fallback);
-      }
-    },
-  };
-}
-
 export const moduleDefinitions = [
   createTemplateModule({
     key: 'operations',
@@ -266,6 +102,20 @@ export const moduleDefinitions = [
       template: 'panel-template-operations',
       meta: 'Masters do painel operacional prontos para receber subcards.',
       metaKey: 'miniapps.operations.panel',
+    },
+    marketplace: {
+      title: 'Painel de Operações',
+      titleKey: 'market.catalog.operations.title',
+      description: 'KPIs, dados mestres e status unificado do tenant.',
+      descriptionKey: 'market.catalog.operations.description',
+      capabilities: ['KPIs', 'Alertas', 'Workflow'],
+      capabilityKeys: [
+        'market.catalog.operations.capability1',
+        'market.catalog.operations.capability2',
+        'market.catalog.operations.capability3',
+      ],
+      license: 'Base',
+      licenseKey: 'market.catalog.operations.license',
     },
   }),
   createTemplateModule({
@@ -286,6 +136,20 @@ export const moduleDefinitions = [
       meta: 'Masters do gestor focados em filtros e status prioritários.',
       metaKey: 'miniapps.tasks.panel',
     },
+    marketplace: {
+      title: 'Gestor de Tarefas',
+      titleKey: 'market.catalog.tasks.title',
+      description: 'Cronogramas, responsáveis e dependências críticas.',
+      descriptionKey: 'market.catalog.tasks.description',
+      capabilities: ['Quadro', 'Alertas', 'Exportação'],
+      capabilityKeys: [
+        'market.catalog.tasks.capability1',
+        'market.catalog.tasks.capability2',
+        'market.catalog.tasks.capability3',
+      ],
+      license: 'Base',
+      licenseKey: 'market.catalog.tasks.license',
+    },
   }),
   createTemplateModule({
     key: 'account',
@@ -304,6 +168,20 @@ export const moduleDefinitions = [
       template: 'panel-template-account',
       meta: 'Masters para direitos do titular, dispositivos e backups.',
       metaKey: 'miniapps.account.panel',
+    },
+    marketplace: {
+      title: 'Conta & Backup',
+      titleKey: 'market.catalog.account.title',
+      description: 'Identidade, dispositivos, direitos do titular e backups.',
+      descriptionKey: 'market.catalog.account.description',
+      capabilities: ['LGPD', 'Backup', 'Passkeys'],
+      capabilityKeys: [
+        'market.catalog.account.capability1',
+        'market.catalog.account.capability2',
+        'market.catalog.account.capability3',
+      ],
+      license: 'Base',
+      licenseKey: 'market.catalog.account.license',
     },
   }),
   createTemplateModule({
@@ -324,6 +202,20 @@ export const moduleDefinitions = [
       meta: 'Preview compacto para habilitar ou revogar licenças.',
       metaKey: 'miniapps.market.panel',
     },
+    marketplace: {
+      title: 'Marketplace',
+      titleKey: 'market.catalog.market.title',
+      description: 'Gestão de catálogos, licenças e habilitação de MiniApps.',
+      descriptionKey: 'market.catalog.market.description',
+      capabilities: ['Catálogo', 'Licenças', 'Provisionamento'],
+      capabilityKeys: [
+        'market.catalog.market.capability1',
+        'market.catalog.market.capability2',
+        'market.catalog.market.capability3',
+      ],
+      license: 'Base',
+      licenseKey: 'market.catalog.market.license',
+    },
   }),
   createTemplateModule({
     key: 'settings',
@@ -342,6 +234,20 @@ export const moduleDefinitions = [
       template: 'panel-template-settings',
       meta: 'Masters de configuração rápida e observabilidade do tenant.',
       metaKey: 'miniapps.settings.panel',
+    },
+    marketplace: {
+      title: 'Configuração & Operação',
+      titleKey: 'market.catalog.settings.title',
+      description: 'Parâmetros do AppBase, observabilidade e auditoria.',
+      descriptionKey: 'market.catalog.settings.description',
+      capabilities: ['Schemas', 'Observabilidade', 'LGPD'],
+      capabilityKeys: [
+        'market.catalog.settings.capability1',
+        'market.catalog.settings.capability2',
+        'market.catalog.settings.capability3',
+      ],
+      license: 'Base',
+      licenseKey: 'market.catalog.settings.license',
     },
   }),
 ];
@@ -394,6 +300,38 @@ export const bootConfig = {
     entitlements: { backup: true, marketplace: true },
     providers: { login: ['google', 'apple'], storage: ['drive', 'onedrive'] },
   },
+  miniApps: [
+    {
+      key: 'operations',
+      manifestUrl: '../miniapps/operations.json',
+      moduleUrl: './template-module.js',
+    },
+    {
+      key: 'tasks',
+      manifestUrl: '../miniapps/tasks.json',
+      moduleUrl: './template-module.js',
+    },
+    {
+      key: 'account',
+      manifestUrl: '../miniapps/account.json',
+      moduleUrl: './template-module.js',
+    },
+    {
+      key: 'market',
+      manifestUrl: '../miniapps/market.json',
+      moduleUrl: './template-module.js',
+    },
+    {
+      key: 'settings',
+      manifestUrl: '../miniapps/settings.json',
+      moduleUrl: './template-module.js',
+    },
+    {
+      key: 'analytics',
+      manifestUrl: '../miniapps/analytics.json',
+      moduleType: 'placeholder',
+    },
+  ],
   ui: { theme: 'dark', layout: 'tabs' },
   meta: { version: '1.0', signature: 'demo-signature', checksum: 'demo-checksum' },
 };

--- a/src/scripts/template-module.js
+++ b/src/scripts/template-module.js
@@ -1,0 +1,80 @@
+export function createTemplateModule(config) {
+  if (!config || typeof config !== 'object') {
+    throw new Error('createTemplateModule requer um objeto de configuração válido.');
+  }
+
+  const key = config.key;
+  if (!key) {
+    throw new Error('createTemplateModule requer a propriedade "key".');
+  }
+
+  const meta = {
+    key,
+    id: config.id ?? key,
+    card: { ...(config.card ?? {}) },
+    badges: Array.isArray(config.badges) ? [...config.badges] : [],
+    badgeKeys: Array.isArray(config.badgeKeys) ? [...config.badgeKeys] : [],
+    panel: { ...(config.panel ?? {}) },
+    marketplace: config.marketplace ? { ...config.marketplace } : null,
+  };
+
+  return {
+    key,
+    meta,
+    init(container, context = {}) {
+      if (!container) {
+        return;
+      }
+
+      const templateId = meta.panel?.template;
+      const uiContext = context.ui ?? {};
+      const applyTranslations = typeof uiContext.applyTranslations === 'function' ? uiContext.applyTranslations : null;
+      const translateWithFallback =
+        typeof uiContext.translateWithFallback === 'function' ? uiContext.translateWithFallback : null;
+      const translate = typeof uiContext.translate === 'function' ? uiContext.translate : null;
+
+      if (templateId) {
+        const template = document.getElementById(templateId);
+        if (template) {
+          container.appendChild(template.content.cloneNode(true));
+          if (applyTranslations) {
+            applyTranslations(container);
+          }
+        }
+      }
+
+      if (!container.hasChildNodes()) {
+        const resolvedLabel =
+          (translateWithFallback && translateWithFallback(meta.card?.labelKey, meta.card?.label ?? '')) ||
+          (translate && meta.card?.labelKey
+            ? (() => {
+                const value = translate(meta.card.labelKey, {});
+                return value !== meta.card.labelKey ? value : null;
+              })()
+            : null) ||
+          meta.card?.label ||
+          meta.key;
+
+        const fallbackText =
+          (translateWithFallback &&
+            translateWithFallback(
+              'panel.placeholder.default',
+              `Selecione um mini-app para ${resolvedLabel}`,
+              { label: resolvedLabel },
+            )) ||
+          (translate
+            ? (() => {
+                const value = translate('panel.placeholder.default', { label: resolvedLabel });
+                return value !== 'panel.placeholder.default' ? value : null;
+              })()
+            : null) ||
+          `Selecione um mini-app para ${resolvedLabel}`;
+
+        const fallback = document.createElement('p');
+        fallback.className = 'panel-note';
+        fallback.textContent = fallbackText;
+        container.appendChild(fallback);
+      }
+    },
+  };
+}

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -337,7 +337,7 @@ export function updateAccountDetails(config, session, backup) {
       card.className = 'storage-card';
       const statusText = translateWithFallback(data?.statusKey, data?.status ?? '—');
       const relativeSync = data?.lastSync ? formatRelativeTime(data.lastSync) : '';
-      const syncText = relativeSync || data?.lastSync ?? '—';
+      const syncText = relativeSync || (data?.lastSync ?? '—');
       card.innerHTML = `
               <strong>${data?.name ?? providerKey.toUpperCase()}</strong>
               <span>${translateWithFallback('account.backup.statusLabel', `Status: ${statusText}`, {
@@ -358,7 +358,8 @@ export function updateAccountDetails(config, session, backup) {
       const card = document.createElement('article');
       card.className = 'device-card';
       const statusText = translateWithFallback(device.statusKey, device.status);
-      const typeText = translateWithFallback(device.typeKey, device.type ?? '—') || device.type ?? '—';
+      const typeText =
+        translateWithFallback(device.typeKey, device.type ?? '—') || (device.type ?? '—');
       const lastActivityText = device.lastActivity ? formatRelativeTime(device.lastActivity) : device.lastActivity ?? '—';
       card.innerHTML = `
               <header>
@@ -512,7 +513,7 @@ function createMiniAppCard(meta, key) {
   return article;
 }
 
-export function buildMarketplace(catalog, appBase = AppBase) {
+export function buildMarketplace(catalog = [], appBase = AppBase) {
   storedCatalog = catalog;
   const container = document.getElementById('market-grid');
   if (!container) {
@@ -527,8 +528,8 @@ export function buildMarketplace(catalog, appBase = AppBase) {
     const header = document.createElement('header');
     header.innerHTML = `
             <div>
-              <h4>${translateWithFallback(item.titleKey, item.title)}</h4>
-              <p>${translateWithFallback(item.descriptionKey, item.description)}</p>
+              <h4>${translateWithFallback(item.titleKey, item.title ?? item.key)}</h4>
+              <p>${translateWithFallback(item.descriptionKey, item.description ?? '')}</p>
             </div>
           `;
     card.appendChild(header);
@@ -549,9 +550,14 @@ export function buildMarketplace(catalog, appBase = AppBase) {
     const statusRow = document.createElement('div');
     statusRow.className = 'chip-row';
     const statusChip = document.createElement('span');
-    if (item.comingSoon) {
+    const isComingSoon = Boolean(item.comingSoon);
+    const comingSoonLabel = item.comingSoonKey
+      ? translateWithFallback(item.comingSoonKey, translateWithFallback('market.catalog.comingSoon', 'Em breve'))
+      : translateWithFallback('market.catalog.comingSoon', 'Em breve');
+
+    if (isComingSoon) {
       statusChip.className = 'chip neutral';
-      statusChip.textContent = translateWithFallback('market.catalog.comingSoon', 'Em breve');
+      statusChip.textContent = comingSoonLabel;
     } else if (appBase.isEnabled(item.key)) {
       statusChip.className = 'chip success';
       statusChip.textContent = translateWithFallback('market.catalog.enabled', 'Ativo');
@@ -572,10 +578,10 @@ export function buildMarketplace(catalog, appBase = AppBase) {
     card.appendChild(statusRow);
 
     const footer = document.createElement('footer');
-    if (item.comingSoon) {
+    if (isComingSoon) {
       const info = document.createElement('span');
       info.className = 'chip neutral';
-      info.textContent = translateWithFallback('market.catalog.soonMessage', 'Catálogo agendado para Q3');
+      info.textContent = translateWithFallback('market.catalog.soonMessage', comingSoonLabel);
       footer.appendChild(info);
     } else {
       const toggle = document.createElement('button');


### PR DESCRIPTION
## Summary
- extend the mocked bootConfig with a miniApps manifest list and add JSON manifests for each module
- load mini-app definitions dynamically during bootstrap, importing the template module helper and falling back to local definitions when necessary
- render the marketplace from loaded metadata, document the manifest workflow in the README, and fix UI fallbacks that relied on invalid nullish coalescing chains

## Testing
- Manual verification in browser (python -m http.server 8000)

------
https://chatgpt.com/codex/tasks/task_e_68e2bbd79d4083208ec28544ef3a4dfe