### PR TITLE
Create control panel base application

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -1,0 +1,464 @@
+:root {
+  --ac-color-bg: #0f172a;
+  --ac-color-surface: #111c34;
+  --ac-color-surface-alt: #1e2a47;
+  --ac-color-border: #2e3b5e;
+  --ac-color-accent: #38bdf8;
+  --ac-color-accent-strong: #0ea5e9;
+  --ac-color-text: #f8fafc;
+  --ac-color-text-subtle: #cbd5f5;
+  --ac-color-danger: #f87171;
+  --ac-color-success: #4ade80;
+  --ac-color-warning: #fbbf24;
+  --ac-radius-sm: 6px;
+  --ac-radius-md: 12px;
+  --ac-radius-lg: 18px;
+  --ac-shadow-elevated: 0 18px 40px rgba(15, 23, 42, 0.35);
+  --ac-font-base: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --ac-transition: 0.2s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: var(--ac-font-base);
+  color: var(--ac-color-text);
+  background: var(--ac-color-bg);
+}
+
+a {
+  color: var(--ac-color-accent);
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--ac-color-accent);
+  outline-offset: 2px;
+}
+
+.ac-app {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.ac-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ac-appbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.75rem;
+  background: var(--ac-color-surface);
+  border-bottom: 1px solid var(--ac-color-border);
+}
+
+.ac-appbar__branding {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.ac-logo {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ac-color-accent-strong);
+  color: var(--ac-color-bg);
+  font-size: 1.35rem;
+  box-shadow: var(--ac-shadow-elevated);
+}
+
+.ac-appbar__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.ac-main {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.ac-rail {
+  background: var(--ac-color-surface);
+  border-radius: var(--ac-radius-lg);
+  padding: 1.25rem;
+  border: 1px solid var(--ac-color-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.ac-rail__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ac-rail__card {
+  width: 100%;
+  text-align: left;
+  padding: 1rem;
+  border-radius: var(--ac-radius-md);
+  border: 1px solid transparent;
+  background: var(--ac-color-surface-alt);
+  color: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--ac-transition), transform var(--ac-transition),
+    border-color var(--ac-transition);
+}
+
+.ac-rail__card:hover,
+.ac-rail__card:focus-visible {
+  background: color-mix(in srgb, var(--ac-color-accent) 12%, var(--ac-color-surface-alt));
+  transform: translateY(-1px);
+}
+
+.ac-rail__card[aria-current="page"] {
+  border-color: var(--ac-color-accent);
+  background: color-mix(in srgb, var(--ac-color-accent) 18%, var(--ac-color-surface-alt));
+}
+
+.ac-stage {
+  background: var(--ac-color-surface);
+  border-radius: var(--ac-radius-lg);
+  padding: 1.5rem;
+  border: 1px solid var(--ac-color-border);
+  box-shadow: var(--ac-shadow-elevated);
+  display: grid;
+}
+
+.ac-panel {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ac-panel--active {
+  display: flex;
+}
+
+.ac-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ac-breadcrumb ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--ac-color-text-subtle);
+}
+
+.ac-breadcrumb li::after {
+  content: "/";
+  margin-left: 0.75rem;
+  color: var(--ac-color-border);
+}
+
+.ac-breadcrumb li:last-child::after {
+  content: "";
+}
+
+.ac-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ac-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.ac-toolbar__label {
+  color: var(--ac-color-text-subtle);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.ac-btn {
+  border: 1px solid var(--ac-color-accent);
+  background: var(--ac-color-accent-strong);
+  color: var(--ac-color-bg);
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--ac-radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--ac-transition), transform var(--ac-transition);
+}
+
+.ac-btn:hover {
+  background: var(--ac-color-accent);
+}
+
+.ac-btn:active {
+  transform: translateY(1px);
+}
+
+.ac-btn--ghost {
+  background: transparent;
+  color: var(--ac-color-text);
+  border-color: var(--ac-color-border);
+}
+
+.ac-btn--ghost:hover {
+  border-color: var(--ac-color-accent);
+  color: var(--ac-color-accent);
+}
+
+.ac-toggle {
+  border: 1px solid var(--ac-color-border);
+  background: var(--ac-color-surface-alt);
+  color: var(--ac-color-text);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--ac-transition), color var(--ac-transition),
+    border-color var(--ac-transition);
+}
+
+.ac-toggle[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--ac-color-success) 32%, var(--ac-color-surface-alt));
+  border-color: var(--ac-color-success);
+  color: var(--ac-color-text);
+}
+
+.ac-tiles {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.ac-tile {
+  background: var(--ac-color-surface-alt);
+  border-radius: var(--ac-radius-md);
+  padding: 1.25rem;
+  border: 1px solid var(--ac-color-border);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ac-tile header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ac-kpi-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: var(--ac-color-danger);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.25);
+}
+
+.ac-tile[data-state="active"] .ac-kpi-dot {
+  background: var(--ac-color-success);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.25);
+}
+
+.ac-tile[data-state="warning"] .ac-kpi-dot {
+  background: var(--ac-color-warning);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.25);
+}
+
+.ac-table-wrapper {
+  background: var(--ac-color-surface-alt);
+  border-radius: var(--ac-radius-md);
+  border: 1px solid var(--ac-color-border);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.ac-table-header h2 {
+  margin: 0;
+}
+
+.ac-table-header p {
+  margin: 0;
+  color: var(--ac-color-text-subtle);
+}
+
+.ac-table-scroller {
+  overflow-x: auto;
+}
+
+.ac-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.ac-table thead {
+  background: color-mix(in srgb, var(--ac-color-accent) 8%, var(--ac-color-surface-alt));
+}
+
+.ac-table th,
+.ac-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ac-color-border);
+}
+
+.ac-table tbody tr:hover {
+  background: color-mix(in srgb, var(--ac-color-accent) 16%, transparent);
+}
+
+.ac-th {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.ac-th::after {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid var(--ac-color-text-subtle);
+  border-bottom: 2px solid var(--ac-color-text-subtle);
+  transform: rotate(45deg);
+  transition: transform var(--ac-transition);
+}
+
+.ac-th[data-order="asc"]::after {
+  transform: rotate(-135deg);
+}
+
+.ac-th[data-order="desc"]::after {
+  transform: rotate(45deg);
+}
+
+.ac-footer {
+  padding: 1rem 1.75rem;
+  border-top: 1px solid var(--ac-color-border);
+  background: var(--ac-color-surface);
+  text-align: center;
+  color: var(--ac-color-text-subtle);
+  font-size: 0.875rem;
+}
+
+.ac-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+}
+
+.ac-overlay[hidden] {
+  display: none;
+}
+
+.ac-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+}
+
+.ac-dialog {
+  position: relative;
+  background: var(--ac-color-surface);
+  border-radius: var(--ac-radius-lg);
+  border: 1px solid var(--ac-color-border);
+  box-shadow: var(--ac-shadow-elevated);
+  padding: 1.75rem;
+  width: min(420px, 90vw);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.ac-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ac-dialog__body {
+  display: grid;
+  gap: 1rem;
+}
+
+.ac-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.ac-field {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+}
+
+.ac-field input {
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--ac-radius-sm);
+  border: 1px solid var(--ac-color-border);
+  background: var(--ac-color-bg);
+  color: var(--ac-color-text);
+}
+
+.ac-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 960px) {
+  .ac-main {
+    grid-template-columns: 1fr;
+  }
+
+  .ac-rail {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+
+  .ac-rail__list {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(180px, 1fr);
+  }
+}

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -1,0 +1,255 @@
+const MarcoBus = {
+  emit(eventName, payload) {
+    console.log(`[MarcoBus] ${eventName}`, payload ?? "");
+  }
+};
+
+const Store = {
+  state: new Map(),
+  set(key, value) {
+    this.state.set(key, value);
+    console.log(`[Store] set ${key}`, value);
+  },
+  get(key) {
+    return this.state.get(key);
+  }
+};
+
+const railButtons = Array.from(document.querySelectorAll('.js-etiq'));
+const panels = new Map(
+  Array.from(document.querySelectorAll('.ac-panel')).map((panel) => [panel.id, panel])
+);
+
+function updateBreadcrumb(panel, label) {
+  const breadcrumbItems = panel.querySelectorAll('.ac-breadcrumb li');
+  if (breadcrumbItems.length > 1) {
+    const currentItem = breadcrumbItems[breadcrumbItems.length - 1];
+    currentItem.textContent = label;
+    currentItem.setAttribute('aria-current', 'page');
+  }
+}
+
+function setActivePanel(panelId, label) {
+  panels.forEach((panel) => {
+    panel.classList.toggle('ac-panel--active', panel.id === panelId);
+  });
+
+  railButtons.forEach((button) => {
+    const isActive = button.dataset.target === panelId;
+    button.setAttribute('aria-current', isActive ? 'page' : 'false');
+    button.classList.toggle('is-active', isActive);
+  });
+
+  const activePanel = panels.get(panelId);
+  if (activePanel) {
+    updateBreadcrumb(activePanel, label);
+    activePanel.focus?.();
+  }
+
+  Store.set('ui.activePanel', panelId);
+  MarcoBus.emit('panel:change', { panelId, label });
+}
+
+railButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const target = button.dataset.target;
+    const label = button.textContent.trim();
+    setActivePanel(target, label);
+  });
+});
+
+function formatDate(date) {
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+function updateKpi(service, isActive) {
+  const tile = document.querySelector(`.ac-tile[data-kpi="${service}"]`);
+  if (!tile) return;
+
+  const stateEl = tile.querySelector(`.ac-kpi-state[data-state="${service}"]`);
+  const dateEl = tile.querySelector(`.ac-kpi-date[data-date="${service}"]`);
+  if (!stateEl || !dateEl) return;
+
+  if (isActive) {
+    tile.dataset.state = 'active';
+    stateEl.textContent = 'Ativo';
+    const now = new Date();
+    const formatted = formatDate(now);
+    dateEl.textContent = formatted;
+    dateEl.dateTime = now.toISOString();
+  } else {
+    delete tile.dataset.state;
+    stateEl.textContent = 'Desativado';
+    dateEl.textContent = '—';
+    dateEl.removeAttribute('dateTime');
+  }
+}
+
+function handleToggle(button, serviceKey) {
+  if (!button) return;
+  button.addEventListener('click', () => {
+    const current = button.getAttribute('aria-pressed') === 'true';
+    const next = !current;
+    button.setAttribute('aria-pressed', String(next));
+    updateKpi(serviceKey, next);
+    Store.set(`services.${serviceKey}`, { enabled: next, updatedAt: next ? new Date().toISOString() : null });
+    MarcoBus.emit(`service:${serviceKey}:${next ? 'enabled' : 'disabled'}`);
+  });
+}
+
+handleToggle(document.querySelector('.js-toggle-sync'), 'sync');
+handleToggle(document.querySelector('.js-toggle-backup'), 'backup');
+
+const table = document.querySelector('.ac-table');
+const tableBody = table?.querySelector('tbody');
+const headerButtons = table ? Array.from(table.querySelectorAll('.ac-th')) : [];
+
+function getCellValue(cell, sortKey) {
+  const rawValue = cell.textContent.trim();
+  if (sortKey === 'data') {
+    const timeEl = cell.querySelector('time');
+    const source = timeEl?.dateTime ?? rawValue;
+    return new Date(source);
+  }
+  return rawValue.toLocaleLowerCase();
+}
+
+function sortRows(sortKey, direction) {
+  if (!tableBody) return;
+
+  const rows = Array.from(tableBody.querySelectorAll('tr'));
+  const sorted = rows.sort((rowA, rowB) => {
+    const cellA = rowA.querySelector(`[data-type="${sortKey}"]`);
+    const cellB = rowB.querySelector(`[data-type="${sortKey}"]`);
+    if (!cellA || !cellB) return 0;
+
+    let valueA = getCellValue(cellA, sortKey);
+    let valueB = getCellValue(cellB, sortKey);
+
+    if (valueA instanceof Date && valueB instanceof Date) {
+      valueA = valueA.getTime();
+      valueB = valueB.getTime();
+    }
+
+    if (valueA < valueB) return direction === 'asc' ? -1 : 1;
+    if (valueA > valueB) return direction === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  sorted.forEach((row) => tableBody.appendChild(row));
+
+  MarcoBus.emit('table:sorted', { sortKey, direction });
+}
+
+headerButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const currentOrder = button.dataset.order === 'asc' ? 'asc' : button.dataset.order === 'desc' ? 'desc' : null;
+    const nextOrder = currentOrder === 'asc' ? 'desc' : 'asc';
+
+    headerButtons.forEach((other) => {
+      if (other !== button) {
+        delete other.dataset.order;
+      }
+    });
+
+    button.dataset.order = nextOrder;
+    const sortKey = button.dataset.sort;
+    sortRows(sortKey, nextOrder);
+  });
+});
+
+function tableToCsv(tableElement) {
+  const rows = Array.from(tableElement.querySelectorAll('tr'));
+  return rows
+    .map((row) =>
+      Array.from(row.children)
+        .map((cell) => `"${cell.textContent.trim().replace(/"/g, '""')}"`)
+        .join(',')
+    )
+    .join('\n');
+}
+
+const exportButton = document.querySelector('.js-export');
+if (exportButton && table) {
+  exportButton.addEventListener('click', () => {
+    const csvContent = tableToCsv(table);
+    const blob = new Blob(['\ufeff', csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'eventos.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    MarcoBus.emit('table:export', { rows: table.querySelectorAll('tbody tr').length });
+  });
+}
+
+const overlay = document.getElementById('login-overlay');
+const dialog = overlay?.querySelector('.ac-dialog');
+const closeControls = overlay ? Array.from(overlay.querySelectorAll('.js-close')) : [];
+const openLoginButton = document.querySelector('.js-open-login');
+let lastFocus = null;
+
+function openOverlay() {
+  if (!overlay || !dialog) return;
+  lastFocus = document.activeElement;
+  overlay.hidden = false;
+  requestAnimationFrame(() => {
+    dialog.focus();
+  });
+  MarcoBus.emit('overlay:open');
+  Store.set('ui.loginOverlay', { open: true });
+}
+
+function closeOverlay() {
+  if (!overlay || !dialog) return;
+  overlay.hidden = true;
+  if (lastFocus && typeof lastFocus.focus === 'function') {
+    lastFocus.focus();
+  }
+  MarcoBus.emit('overlay:close');
+  Store.set('ui.loginOverlay', { open: false });
+}
+
+openLoginButton?.addEventListener('click', openOverlay);
+
+closeControls.forEach((control) => {
+  control.addEventListener('click', closeOverlay);
+});
+
+overlay?.addEventListener('click', (event) => {
+  const target = event.target;
+  if (target instanceof HTMLElement && target.dataset.overlayDismiss === 'true') {
+    closeOverlay();
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !overlay?.hidden) {
+    event.preventDefault();
+    closeOverlay();
+  }
+});
+
+if (dialog) {
+  dialog.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+    }
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const activeButton = railButtons.find((button) => button.getAttribute('aria-current') === 'page');
+  if (activeButton) {
+    setActivePanel(activeButton.dataset.target, activeButton.textContent.trim());
+  }
+
+  updateKpi('sync', false);
+  updateKpi('backup', false);
+});

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Marco · Painel de controle</title>
+    <link rel="stylesheet" href="app.css" />
+  </head>
+  <body>
+    <div class="ac-app">
+      <header class="ac-appbar" role="banner">
+        <div class="ac-appbar__branding">
+          <span class="ac-logo" aria-hidden="true">◈</span>
+          <span class="ac-appbar__title">Marco Console</span>
+        </div>
+        <div class="ac-appbar__actions">
+          <button type="button" class="ac-btn ac-btn--ghost js-open-login">
+            Entrar
+          </button>
+        </div>
+      </header>
+      <div class="ac-main">
+        <aside class="ac-rail" aria-label="Seções do painel">
+          <ul class="ac-rail__list">
+            <li>
+              <button
+                type="button"
+                class="ac-rail__card js-etiq"
+                data-target="painel-controle"
+                aria-current="page"
+              >
+                Painel de controle
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="ac-rail__card js-etiq"
+                data-target="visao-geral"
+              >
+                Visão geral
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="ac-rail__card js-etiq"
+                data-target="alertas"
+              >
+                Alertas
+              </button>
+            </li>
+          </ul>
+        </aside>
+        <main class="ac-stage" id="main-stage">
+          <section
+            id="painel-controle"
+            class="ac-panel ac-panel--active"
+            aria-labelledby="heading-painel"
+            tabindex="-1"
+          >
+            <header class="ac-panel__header">
+              <h1 id="heading-painel" class="ac-sr-only">Painel de controle</h1>
+              <nav class="ac-breadcrumb" aria-label="Navegação hierárquica">
+                <ol>
+                  <li><a href="#main-stage">Início</a></li>
+                  <li aria-current="page">Painel de controle</li>
+                </ol>
+              </nav>
+              <div class="ac-toolbar" role="toolbar" aria-label="Ações do painel">
+                <div class="ac-toolbar__group" aria-label="Sincronização">
+                  <span class="ac-toolbar__label">Serviços</span>
+                  <button
+                    type="button"
+                    class="ac-toggle js-toggle-sync"
+                    aria-pressed="false"
+                    aria-label="Alternar sincronização"
+                  >
+                    Sync
+                  </button>
+                  <button
+                    type="button"
+                    class="ac-toggle js-toggle-backup"
+                    aria-pressed="false"
+                    aria-label="Alternar backup"
+                  >
+                    Backup
+                  </button>
+                </div>
+                <div class="ac-toolbar__group">
+                  <button type="button" class="ac-btn js-export">Exportar CSV</button>
+                </div>
+              </div>
+            </header>
+            <div class="ac-panel__body">
+              <section class="ac-tiles" aria-label="Indicadores">
+                <article class="ac-tile" data-kpi="sync">
+                  <header>
+                    <span class="ac-kpi-dot" aria-hidden="true"></span>
+                    <h2 id="heading-sync">Sincronização</h2>
+                  </header>
+                  <p>
+                    Estado: <span class="ac-kpi-state" data-state="sync">Desativado</span>
+                  </p>
+                  <p>
+                    Última execução: <time class="ac-kpi-date" data-date="sync">—</time>
+                  </p>
+                </article>
+                <article class="ac-tile" data-kpi="backup">
+                  <header>
+                    <span class="ac-kpi-dot" aria-hidden="true"></span>
+                    <h2 id="heading-backup">Backup</h2>
+                  </header>
+                  <p>
+                    Estado: <span class="ac-kpi-state" data-state="backup">Desativado</span>
+                  </p>
+                  <p>
+                    Última execução: <time class="ac-kpi-date" data-date="backup">—</time>
+                  </p>
+                </article>
+              </section>
+              <section class="ac-table-wrapper" aria-label="Eventos recentes">
+                <header class="ac-table-header">
+                  <h2 id="heading-eventos">Eventos recentes</h2>
+                  <p>Monitore as últimas atualizações registradas pelos serviços.</p>
+                </header>
+                <div class="ac-table-scroller">
+                  <table class="ac-table" aria-describedby="heading-eventos">
+                    <thead>
+                      <tr>
+                        <th scope="col">
+                          <button type="button" class="ac-th" data-sort="data">
+                            Data
+                          </button>
+                        </th>
+                        <th scope="col">
+                          <button type="button" class="ac-th" data-sort="evento">
+                            Evento
+                          </button>
+                        </th>
+                        <th scope="col">
+                          <button type="button" class="ac-th" data-sort="responsavel">
+                            Responsável
+                          </button>
+                        </th>
+                        <th scope="col">
+                          <button type="button" class="ac-th" data-sort="status">
+                            Status
+                          </button>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td data-type="data">
+                          <time datetime="2024-04-22T09:30:00Z">22/04/2024 09:30</time>
+                        </td>
+                        <td data-type="evento">Sincronização concluída</td>
+                        <td data-type="responsavel">Serviço Sync</td>
+                        <td data-type="status">Sucesso</td>
+                      </tr>
+                      <tr>
+                        <td data-type="data">
+                          <time datetime="2024-04-22T07:10:00Z">22/04/2024 07:10</time>
+                        </td>
+                        <td data-type="evento">Backup agendado</td>
+                        <td data-type="responsavel">Serviço Backup</td>
+                        <td data-type="status">Agendado</td>
+                      </tr>
+                      <tr>
+                        <td data-type="data">
+                          <time datetime="2024-04-21T18:45:00Z">21/04/2024 18:45</time>
+                        </td>
+                        <td data-type="evento">Sincronização falhou</td>
+                        <td data-type="responsavel">Serviço Sync</td>
+                        <td data-type="status">Falha</td>
+                      </tr>
+                      <tr>
+                        <td data-type="data">
+                          <time datetime="2024-04-21T08:15:00Z">21/04/2024 08:15</time>
+                        </td>
+                        <td data-type="evento">Backup concluído</td>
+                        <td data-type="responsavel">Serviço Backup</td>
+                        <td data-type="status">Sucesso</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section
+            id="visao-geral"
+            class="ac-panel"
+            aria-labelledby="heading-visao"
+            tabindex="-1"
+          >
+            <header class="ac-panel__header">
+              <h2 id="heading-visao" class="ac-sr-only">Visão geral</h2>
+              <nav class="ac-breadcrumb" aria-label="Navegação hierárquica">
+                <ol>
+                  <li><a href="#main-stage">Início</a></li>
+                  <li aria-current="page">Visão geral</li>
+                </ol>
+              </nav>
+              <div class="ac-toolbar" role="toolbar" aria-label="Ações da visão geral">
+                <div class="ac-toolbar__group">
+                  <button type="button" class="ac-btn ac-btn--ghost">Atualizar</button>
+                </div>
+              </div>
+            </header>
+            <div class="ac-panel__body">
+              <p>
+                A visão geral apresenta um resumo dos KPIs principais da plataforma. Use as ações no rail para voltar ao painel de controle e explorar os detalhes dos eventos.
+              </p>
+            </div>
+          </section>
+          <section
+            id="alertas"
+            class="ac-panel"
+            aria-labelledby="heading-alertas"
+            tabindex="-1"
+          >
+            <header class="ac-panel__header">
+              <h2 id="heading-alertas" class="ac-sr-only">Alertas</h2>
+              <nav class="ac-breadcrumb" aria-label="Navegação hierárquica">
+                <ol>
+                  <li><a href="#main-stage">Início</a></li>
+                  <li aria-current="page">Alertas</li>
+                </ol>
+              </nav>
+              <div class="ac-toolbar" role="toolbar" aria-label="Ações de alertas">
+                <div class="ac-toolbar__group">
+                  <button type="button" class="ac-btn">Silenciar</button>
+                </div>
+              </div>
+            </header>
+            <div class="ac-panel__body">
+              <p>
+                Nenhum alerta crítico no momento. Alertas recentes serão listados aqui assim que ocorrerem.
+              </p>
+            </div>
+          </section>
+        </main>
+      </div>
+      <footer class="ac-footer" role="contentinfo">
+        <p>© 2024 Marco Cloud. Todos os direitos reservados.</p>
+      </footer>
+    </div>
+    <div class="ac-overlay" id="login-overlay" hidden>
+      <div class="ac-overlay__backdrop" data-overlay-dismiss="true"></div>
+      <div
+        class="ac-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="login-title"
+        aria-describedby="login-desc"
+        tabindex="-1"
+      >
+        <header class="ac-dialog__header">
+          <h2 id="login-title">Acesso restrito</h2>
+          <button type="button" class="ac-btn ac-btn--ghost js-close" aria-label="Fechar janela de login">
+            ×
+          </button>
+        </header>
+        <div class="ac-dialog__body">
+          <p id="login-desc">Informe as credenciais corporativas para continuar.</p>
+          <form class="ac-form">
+            <label class="ac-field">
+              <span>E-mail</span>
+              <input type="email" name="email" autocomplete="username" required />
+            </label>
+            <label class="ac-field">
+              <span>Senha</span>
+              <input type="password" name="password" autocomplete="current-password" required />
+            </label>
+            <div class="ac-form__actions">
+              <button type="submit" class="ac-btn">Entrar</button>
+              <button type="button" class="ac-btn ac-btn--ghost js-close">Cancelar</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the appbase single-page layout with navigation rail, stage panels, and login overlay
- style the dashboard using design tokens and reusable `ac-*` utility classes for the rail, tiles, table, and overlay
- implement vanilla JS interactions for panel switching, toggles, table sorting/export, and overlay management with accessibility hooks

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e2c0aefec083208b861226e37c912d