### PR TITLE
Expand app shell to viewport width

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -63,13 +63,19 @@ input {
 }
 
 .ac-app {
-  max-width: 1360px;
-  margin: 0 auto;
-  padding: 12px;
+  width: min(100vw, 100%);
+  margin: 0;
+  padding: 12px clamp(18px, 4vw, 56px);
   display: grid;
   gap: 14px;
   grid-template-rows: auto 1fr auto;
   min-height: 100vh;
+}
+
+@media (min-width: 1600px) {
+  .ac-app {
+    padding-inline: clamp(48px, 8vw, 120px);
+  }
 }
 
 .ac-appbar,


### PR DESCRIPTION
## Summary
- replace the fixed max-width on `.ac-app` with a viewport-based width and responsive horizontal padding
- add a large-screen media query so the app shell keeps comfortable gutters on very wide monitors

## Testing
- Manual validation in browser (tablet horizontal preset)

------
https://chatgpt.com/codex/tasks/task_e_68e2dd38b1a083209f83c80cf8a82b7d