### PR TITLE
Exibe logo oficial e destaca status beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ arquivos dedicados dentro de `appbase/`.
 ├── appbase/
 │   ├── index.html            # Shell do AppBase + painel de controle
 │   ├── app.css               # Tokens `--ac-*` e componentes visuais
-│   └── app.js                # Interações (painéis, toggles, overlay, exportação)
+│   └── app.js                # Interações (toggles, overlay, foco do painel, exportação)
 ├── assets/                   # Logos e imagens utilizadas pelo protótipo
 ├── index.html                # Redirecionamento (GitHub Pages)
 ├── src/                      # Versão anterior do protótipo modular
@@ -31,17 +31,25 @@ referência descrito na especificação Visual & Interação — R1.0.
 2. Abra `appbase/index.html` em um navegador (Chrome, Edge, Firefox ou Safari).
    - O `index.html` na raiz redireciona automaticamente para essa versão.
    - Se precisar da versão legada modular, abra `src/index.html` diretamente.
-3. Interaja com as etiquetas no rail para alternar os painéis do palco.
-4. Utilize os toggles de Sync/Backup, exporte a tabela de eventos em CSV e abra o
-   overlay de login para testar o fluxo completo.
+3. Utilize o botão de engrenagem na AppBar para focar o Painel de Controles ou
+   role manualmente até o palco principal.
+4. Explore a pilha de miniapps no rail esquerdo (slots livres + Painel de
+   Controles), acione os toggles de Sync/Backup, exporte a tabela de eventos em
+   CSV e abra o overlay de login para testar o fluxo completo.
 
 ## Destaques da versão AppBase R1.0
 
 - **Layout 100vh** com AppBar fixa, rail de 280px e palco central rolável.
 - **Toggles coloridos** (verde/vermelho) sincronizados com os indicadores do
   rail, registrando stubs `sync/toggle` e `backup/toggle`.
+- **Identidade visual atualizada** com o logotipo oficial 5Horas na AppBar e o
+  selo "Versão beta" destacado no topo do painel de controles.
 - **Tabela de eventos** com header sticky, ordenação por coluna e exportação CSV
   (`eventos.csv`).
+- **Marketplace e Configurações integrados** ao painel principal em tiles
+  dedicados para consulta rápida.
+- **Rail reorganizado** com contêiner branco para miniapps e Painel de Controles
+  limitado em altura, preparado para hospedar novos módulos.
 - **Overlay de login** com campos Nome/E-mail/Telefone, lista de dispositivos e
   ações que disparam os stubs (`auth/login/open`, `auth/login/save`,
   `auth/session/logout`, `devices/disconnect`).

--- a/appbase/app.css
+++ b/appbase/app.css
@@ -111,9 +111,15 @@ input {
   border: var(--ac-border-width-strong) solid var(--ac-border);
   display: grid;
   place-items: center;
-  font-weight: 700;
-  font-size: 1.25rem;
-  color: var(--ac-primary);
+  background: #fff;
+  overflow: hidden;
+}
+
+.ac-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
 
 .ac-headings {
@@ -130,10 +136,6 @@ input {
 .ac-h2 {
   font-size: 1rem;
   color: var(--ac-muted);
-}
-
-.ac-appmenu {
-  margin-left: auto;
 }
 
 .ac-btn {
@@ -166,6 +168,7 @@ input {
   display: flex;
   gap: 6px;
   align-items: center;
+  margin-left: auto;
 }
 
 .ac-bullet {
@@ -188,7 +191,77 @@ input {
   display: grid;
   gap: 12px;
   padding-right: 4px;
-  overflow-y: auto;
+  overflow-y: visible;
+  align-self: start;
+}
+
+.ac-rail__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: #fff;
+  border: var(--ac-border-width-strong) solid var(--ac-border);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 12px 32px var(--ac-shadow);
+}
+
+.ac-miniapp {
+  border: var(--ac-border-width) solid rgba(15, 23, 42, 0.12);
+  border-radius: 16px;
+  padding: 12px;
+  background: rgba(230, 237, 255, 0.35);
+  display: grid;
+  gap: 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.ac-miniapp.is-active {
+  border-color: var(--ac-accent);
+  background: rgba(230, 237, 255, 0.65);
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.18);
+}
+
+.ac-miniapp__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.ac-miniapp__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ac-primary);
+}
+
+.ac-miniapp__tag {
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  padding: 4px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ac-muted);
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.ac-miniapp__placeholder {
+  min-height: 72px;
+  border-radius: 12px;
+  border: 2px dashed rgba(15, 23, 42, 0.25);
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: var(--ac-muted);
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.ac-card--panel {
+  max-height: 280px;
+  overflow: auto;
+  display: grid;
+  gap: 12px;
 }
 
 .ac-card {
@@ -225,6 +298,28 @@ input {
   margin: 0;
   color: var(--ac-muted);
   font-size: 0.9rem;
+}
+
+.ac-iconbtn {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  background: var(--ac-bg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  margin-left: 6px;
+}
+
+.ac-iconbtn:hover,
+.ac-iconbtn:focus-visible {
+  background: var(--ac-primary);
+  border-color: var(--ac-primary);
+  color: #fff;
+  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(31, 58, 138, 0.28);
 }
 
 .ac-kebab {
@@ -323,10 +418,26 @@ input {
   color: var(--ac-muted);
 }
 
-.ac-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.ac-stage__beta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  background: var(--ac-card-bg);
+  color: var(--ac-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.ac-stage__beta::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--ac-accent);
 }
 
 .ac-switch {
@@ -404,6 +515,31 @@ input {
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--ac-primary);
+}
+
+.ac-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ac-muted);
+  background: rgba(15, 23, 42, 0.08);
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.ac-status--ok {
+  color: var(--ac-ok);
+  background: var(--ac-ok-bg);
+}
+
+.ac-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  color: var(--ac-text);
 }
 
 .ac-actions {

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -5,8 +5,6 @@
   const sheet = overlay.querySelector('.ac-sheet');
   const title = byId('login-sheet-title');
   const loginForm = document.getElementById('login-form');
-  const breadcrumbsPrimary = byId('breadcrumbs-primary');
-  const breadcrumbsSecondary = byId('breadcrumbs-secondary');
   let lastFocusedElement = null;
 
   function logStub(topic, payload = {}) {
@@ -15,37 +13,6 @@
 
   function formatNow() {
     return new Date().toLocaleString('pt-BR');
-  }
-
-  function updateBreadcrumbs(card) {
-    const titleEl = card.querySelector('.ac-card__title');
-    const subtitleEl = card.querySelector('.ac-card__subtitle');
-    breadcrumbsPrimary.textContent = titleEl ? titleEl.textContent.trim() : '';
-    breadcrumbsSecondary.textContent = subtitleEl
-      ? subtitleEl.textContent.trim()
-      : '';
-  }
-
-  function selectPanel(id, card) {
-    const panels = document.querySelectorAll('.js-panel');
-    panels.forEach((panel) => {
-      if (panel.id === `panel-${id}`) {
-        panel.hidden = false;
-      } else {
-        panel.hidden = true;
-      }
-    });
-    document.querySelectorAll('.js-etiq').forEach((etiq) => {
-      const isTarget = etiq.dataset.panel === id;
-      etiq.classList.toggle('is-active', isTarget);
-      if (isTarget) {
-        etiq.setAttribute('aria-current', 'page');
-      } else {
-        etiq.removeAttribute('aria-current');
-      }
-    });
-    updateBreadcrumbs(card);
-    logStub('ui/panel/select', { id });
   }
 
   function setDotState(el, isOn) {
@@ -260,15 +227,6 @@
     }
   }
 
-  function bindPanelSwitcher() {
-    document.querySelectorAll('.js-etiq').forEach((card) => {
-      card.addEventListener('click', () => {
-        const id = card.dataset.panel;
-        selectPanel(id, card);
-      });
-    });
-  }
-
   function bindToggles() {
     const syncButton = document.querySelector('.js-toggle-sync');
     const backupButton = document.querySelector('.js-toggle-backup');
@@ -294,11 +252,26 @@
     }
   }
 
+  function bindPanelFocus() {
+    const focusButton = document.querySelector('.js-panel-focus');
+    const panel = document.getElementById('panel-controles');
+    const heading = document.getElementById('panel-title-controles');
+    if (!focusButton || !panel) return;
+
+    focusButton.addEventListener('click', () => {
+      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      if (heading && typeof heading.focus === 'function') {
+        heading.focus();
+      }
+      logStub('ui/panel/focus', { id: 'painel-controles' });
+    });
+  }
+
   function init() {
-    bindPanelSwitcher();
     bindToggles();
     bindTableControls();
     bindOverlayActions();
+    bindPanelFocus();
   }
 
   document.addEventListener('DOMContentLoaded', init);

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -11,117 +11,107 @@
     <div class="ac-app">
       <header class="ac-appbar">
         <div class="ac-brand">
-          <div class="ac-logo" aria-hidden="true">5h</div>
+          <div class="ac-logo" aria-hidden="true">
+            <img
+              src="../assets/app/brand/icon-light-500.png"
+              alt=""
+              width="48"
+              height="48"
+            />
+          </div>
           <div class="ac-headings">
             <div class="ac-h1">Projeto Marco</div>
-            <div class="ac-h2">AppBase</div>
+            <div class="ac-h2">Painel de Controles</div>
           </div>
         </div>
-        <nav class="ac-appmenu" aria-label="Menu do sistema">
-          <button class="ac-btn ac-sys" type="button">Sistema ⋯</button>
-        </nav>
-        <div class="ac-breadcrumbs">
-          <span id="breadcrumbs-primary">Painel de controle</span>
+        <nav class="ac-breadcrumbs" aria-label="Localização">
+          <span id="breadcrumbs-primary">Painel de Controles</span>
           <span class="ac-bullet" aria-hidden="true">•</span>
-          <span class="ac-muted" id="breadcrumbs-secondary">Visão detalhada</span>
-        </div>
+          <span class="ac-muted" id="breadcrumbs-secondary">Visão integrada</span>
+        </nav>
+        <button
+          class="ac-iconbtn js-panel-focus"
+          type="button"
+          aria-label="Abrir Painel de Controles"
+        >
+          <span aria-hidden="true">⚙️</span>
+        </button>
       </header>
 
       <div class="ac-layout">
-        <nav class="ac-rail" aria-label="Etiquetas">
-          <section
-            class="ac-card is-active js-etiq"
-            data-panel="painel-controle"
-            aria-current="page"
-          >
-            <div class="ac-card__head">
-              <div>
-                <h3 class="ac-card__title">Painel de controle</h3>
-                <p class="ac-card__subtitle" id="user-name">Fabio</p>
-              </div>
-              <button class="ac-kebab" type="button" aria-label="Opções">⋯</button>
-            </div>
-            <div class="ac-meta">
-              <div class="ac-meta-row">
-                <span class="t">Último login:</span>
-                <span id="meta-login">05/10/2025 09:12:00</span>
-              </div>
-              <div class="ac-meta-row">
-                <span class="t">Último sync:</span>
-                <span id="meta-sync"></span>
-              </div>
-              <div class="ac-meta-row">
-                <span class="t">Último backup:</span>
-                <span id="meta-backup"></span>
-              </div>
-            </div>
-            <div class="ac-badges">
-              <span class="ac-badge">
-                <span id="kpi-conn" class="ac-dot ac-dot--ok" aria-hidden="true"></span>
-                <span class="ac-label">Conexão</span>
-              </span>
-              <span class="ac-badge">
-                <span id="kpi-sync" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
-                <span class="ac-label">Sync</span>
-              </span>
-              <span class="ac-badge">
-                <span id="kpi-backup" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
-                <span class="ac-label">Backup</span>
-              </span>
-            </div>
-          </section>
+        <nav class="ac-rail" aria-label="Miniapps">
+          <div class="ac-rail__stack" role="list" aria-label="Miniapps fixos">
+            <article class="ac-miniapp is-active" role="listitem" aria-current="page">
+              <header class="ac-miniapp__head">
+                <h3 class="ac-miniapp__title">Painel de Controles</h3>
+                <span class="ac-miniapp__tag">Principal</span>
+              </header>
+              <section class="ac-card ac-card--panel" aria-labelledby="miniapp-panel-title">
+                <div class="ac-card__head">
+                  <div>
+                    <h3 id="miniapp-panel-title" class="ac-card__title">Status geral</h3>
+                    <p class="ac-card__subtitle" id="user-name">Fabio</p>
+                  </div>
+                  <button class="ac-kebab" type="button" aria-label="Opções">⋯</button>
+                </div>
+                <div class="ac-meta">
+                  <div class="ac-meta-row">
+                    <span class="t">Último login:</span>
+                    <span id="meta-login">05/10/2025 09:12:00</span>
+                  </div>
+                  <div class="ac-meta-row">
+                    <span class="t">Último sync:</span>
+                    <span id="meta-sync"></span>
+                  </div>
+                  <div class="ac-meta-row">
+                    <span class="t">Último backup:</span>
+                    <span id="meta-backup"></span>
+                  </div>
+                </div>
+                <div class="ac-badges">
+                  <span class="ac-badge">
+                    <span id="kpi-conn" class="ac-dot ac-dot--ok" aria-hidden="true"></span>
+                    <span class="ac-label">Conexão</span>
+                  </span>
+                  <span class="ac-badge">
+                    <span id="kpi-sync" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
+                    <span class="ac-label">Sync</span>
+                  </span>
+                  <span class="ac-badge">
+                    <span id="kpi-backup" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
+                    <span class="ac-label">Backup</span>
+                  </span>
+                </div>
+              </section>
+            </article>
 
-          <section class="ac-card js-etiq" data-panel="market">
-            <div class="ac-card__head">
-              <div>
-                <h3 class="ac-card__title">Marketplace</h3>
-                <p class="ac-card__subtitle">Catálogo</p>
-              </div>
-              <button class="ac-kebab" type="button" aria-label="Opções">⋯</button>
-            </div>
-            <div class="ac-badges">
-              <span class="ac-badge">
-                <span class="ac-dot ac-dot--ok" aria-hidden="true"></span>
-                <span class="ac-label">Online</span>
-              </span>
-            </div>
-          </section>
+            <article class="ac-miniapp" role="listitem">
+              <div class="ac-miniapp__placeholder">Slot livre para miniapp</div>
+            </article>
 
-          <section class="ac-card js-etiq" data-panel="settings">
-            <div class="ac-card__head">
-              <div>
-                <h3 class="ac-card__title">Configurações</h3>
-                <p class="ac-card__subtitle">Sistema</p>
-              </div>
-              <button class="ac-kebab" type="button" aria-label="Opções">⋯</button>
-            </div>
-            <div class="ac-badges">
-              <span class="ac-badge">
-                <span class="ac-dot" aria-hidden="true"></span>
-                <span class="ac-label">Padrões</span>
-              </span>
-            </div>
-          </section>
+            <article class="ac-miniapp" role="listitem">
+              <div class="ac-miniapp__placeholder">Slot livre para miniapp</div>
+            </article>
+          </div>
         </nav>
 
         <main class="ac-stage" role="main">
-          <section id="panel-painel-controle" class="js-panel" aria-labelledby="panel-title-pc">
+          <section
+            id="panel-controles"
+            aria-labelledby="panel-title-controles"
+          >
             <div class="ac-stage__head">
               <div class="ac-stage__titles">
-                <h2 id="panel-title-pc" class="ac-title-lg">Painel de controle</h2>
-                <div class="ac-sub">Visão detalhada</div>
+                <h2
+                  id="panel-title-controles"
+                  class="ac-title-lg"
+                  tabindex="-1"
+                >
+                  Painel de Controles
+                </h2>
+                <div class="ac-sub">Visão integrada</div>
               </div>
-              <div class="ac-toolbar" role="group" aria-label="Ações rápidas">
-                <button class="ac-switch js-toggle-sync is-off" type="button" aria-pressed="false">
-                  <span class="ac-dot" aria-hidden="true"></span>
-                  <span class="ac-switch__label">Sync desativada</span>
-                </button>
-                <button class="ac-switch js-toggle-backup is-off" type="button" aria-pressed="false">
-                  <span class="ac-dot" aria-hidden="true"></span>
-                  <span class="ac-switch__label">Backup desativado</span>
-                </button>
-                <button class="ac-btn js-export" type="button">Exportar CSV</button>
-              </div>
+              <div class="ac-stage__beta" role="status">Versão beta</div>
             </div>
 
             <div class="ac-grid">
@@ -143,6 +133,12 @@
                 <p class="ac-v">Última: <span id="v-sync"></span></p>
                 <p class="ac-v">Provedor: <span id="v-sync-provider">Google Drive</span></p>
                 <p class="ac-v">Pendências offline: <span id="v-pending">0</span></p>
+                <div class="ac-actions">
+                  <button class="ac-switch js-toggle-sync is-off" type="button" aria-pressed="false">
+                    <span class="ac-dot" aria-hidden="true"></span>
+                    <span class="ac-switch__label">Sync desativada</span>
+                  </button>
+                </div>
               </div>
               <div class="ac-tile span-4">
                 <div class="ac-tile__head">
@@ -151,6 +147,12 @@
                 <p class="ac-v">Último: <span id="v-backup"></span></p>
                 <p class="ac-v">Destino: <span id="v-backdest">Servidor 5Horas</span></p>
                 <p class="ac-v">Tamanho total: <span id="v-backsize">128 GB</span></p>
+                <div class="ac-actions">
+                  <button class="ac-switch js-toggle-backup is-off" type="button" aria-pressed="false">
+                    <span class="ac-dot" aria-hidden="true"></span>
+                    <span class="ac-switch__label">Backup desativado</span>
+                  </button>
+                </div>
               </div>
 
               <div class="ac-tile span-6">
@@ -218,34 +220,38 @@
                     </tbody>
                   </table>
                 </div>
+                <div class="ac-actions">
+                  <button class="ac-btn js-export" type="button">Exportar CSV</button>
+                </div>
               </div>
-            </div>
-          </section>
 
-          <section id="panel-market" class="js-panel" hidden aria-labelledby="panel-title-market">
-            <div class="ac-stage__head">
-              <div class="ac-stage__titles">
-                <h2 id="panel-title-market" class="ac-title-lg">Marketplace</h2>
-                <div class="ac-sub">Catálogo</div>
+              <div class="ac-tile span-6">
+                <div class="ac-tile__head">
+                  <p class="ac-tile__title">Marketplace</p>
+                  <span class="ac-status ac-status--ok">Catálogo online</span>
+                </div>
+                <p class="ac-v">Miniapps disponíveis e instalados recentemente.</p>
+                <ul class="ac-list">
+                  <li><strong>Novos:</strong> Auditoria Fiscal · Dashboard Financeiro</li>
+                  <li><strong>Atualizados:</strong> CRM Field · Inventário Mobile</li>
+                  <li><strong>Disponibilidade:</strong> 24 miniapps ativos</li>
+                </ul>
               </div>
-            </div>
-            <div class="ac-grid">
-              <div class="ac-tile span-12">
-                <p class="ac-v">Miniapps disponíveis/instalados.</p>
-              </div>
-            </div>
-          </section>
 
-          <section id="panel-settings" class="js-panel" hidden aria-labelledby="panel-title-settings">
-            <div class="ac-stage__head">
-              <div class="ac-stage__titles">
-                <h2 id="panel-title-settings" class="ac-title-lg">Configurações</h2>
-                <div class="ac-sub">Sistema</div>
-              </div>
-            </div>
-            <div class="ac-grid">
-              <div class="ac-tile span-12">
-                <p class="ac-v">Preferências gerais.</p>
+              <div class="ac-tile span-6">
+                <div class="ac-tile__head">
+                  <p class="ac-tile__title">Configurações do Sistema</p>
+                  <span class="ac-status">Padrões monitorados</span>
+                </div>
+                <p class="ac-v">Preferências centrais consolidadas no painel.</p>
+                <ul class="ac-list">
+                  <li>Idioma: Português (Brasil)</li>
+                  <li>Fuso horário: GMT-3</li>
+                  <li>Atualizações automáticas: Ativas</li>
+                </ul>
+                <div class="ac-actions">
+                  <button class="ac-btn ac-btn--ghost" type="button">Abrir preferências</button>
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- substitui o placeholder textual pelo logotipo oficial 5Horas na AppBar
- reconfigura o topo do painel para exibir apenas o selo "Versão beta" e realoca toggles/exportação nos tiles correspondentes
- documenta no README a atualização da identidade visual do painel

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2df69b954832090888ba59c3d28e7