### PR TITLE
Implementa MiniApp Painel de controle com store mock e overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Protótipo navegável do **AppBase Marco** pronto para ser aberto diretamente em um
 navegador moderno sem build. A versão R1.0 consolida o shell completo com AppBar,
-rail de etiquetas, palco de painéis e overlay de login, agora organizado em
-arquivos dedicados dentro de `appbase/`.
+rail de etiquetas, palco central e miniapps carregados por vanilla JS dentro da
+pasta `appbase/`, seguindo as diretrizes do blueprint visual.
 
 ## Estrutura do repositório
 
 ```
 .
 ├── appbase/
-│   ├── index.html            # Shell do AppBase + painel de controle
-│   ├── app.css               # Tokens `--ac-*` e componentes visuais
-│   └── app.js                # Interações (toggles, overlay, foco do painel, exportação)
+│   ├── index.html            # Shell do AppBase + MiniApp “Painel de controle”
+│   ├── app.css               # Tokens `--ac-*`, grid responsivo e overlays
+│   └── app.js                # Store reativa, serviços mock, toggles e exportação
 ├── assets/                   # Logos e imagens utilizadas pelo protótipo
 ├── index.html                # Redirecionamento (GitHub Pages)
 ├── src/                      # Versão anterior do protótipo modular
@@ -21,44 +21,52 @@ arquivos dedicados dentro de `appbase/`.
 └── agent.md                  # Diretrizes operacionais para contribuições
 ```
 
-A pasta `src/` preserva o protótipo completo com mini-apps dinâmicos utilizado
-nas versões anteriores. A nova pasta `appbase/` foca no shell estático de
-referência descrito na especificação Visual & Interação — R1.0.
+A pasta `src/` preserva o protótipo modular utilizado nas primeiras iterações.
+A pasta `appbase/` concentra a implementação atual do shell R1.0 com o novo
+MiniApp “Painel de controle”.
 
 ## Como executar
 
 1. Clone ou baixe este repositório.
 2. Abra `appbase/index.html` em um navegador (Chrome, Edge, Firefox ou Safari).
    - O `index.html` na raiz redireciona automaticamente para essa versão.
-   - Se precisar da versão legada modular, abra `src/index.html` diretamente.
-3. Utilize o botão de engrenagem na AppBar para focar o Painel de Controles ou
-   role manualmente até o palco principal.
-4. Explore a pilha de miniapps no rail esquerdo (slots livres + Painel de
-   Controles), acione os toggles de Sync/Backup, exporte a tabela de eventos em
-   CSV e abra o overlay de login para testar o fluxo completo.
+   - Para consultar a versão legada modular, abra `src/index.html` diretamente.
+3. Se nenhuma etiqueta estiver ativa o palco permanece vazio. Clique na etiqueta
+   “Painel de controle” (ou use o kebab para expandir/recolher) para carregar o
+   painel completo.
+4. Utilize a toolbar do painel para alternar Sync/Backup e exportar a tabela de
+   eventos filtrada. Abra os overlays de Login, Sync ou Backup pelos botões ⋯
+   dos tiles para testar os fluxos de gerenciamento.
 
-## Destaques da versão AppBase R1.0
+## MiniApp “Painel de controle” — destaques
 
-- **Layout 100vh** com AppBar fixa, rail de 280px e palco central rolável.
-- **Toggles coloridos** (verde/vermelho) sincronizados com os indicadores do
-  rail, registrando stubs `sync/toggle` e `backup/toggle`.
-- **Identidade visual atualizada** com o logotipo oficial 5Horas na AppBar e o
-  selo "Versão beta" destacado no topo do painel de controles.
-- **Tabela de eventos** com header sticky, ordenação por coluna e exportação CSV
-  (`eventos.csv`).
-- **Marketplace e Configurações integrados** ao painel principal em tiles
-  dedicados para consulta rápida.
-- **Rail reorganizado** com contêiner branco para miniapps e Painel de Controles
-  limitado em altura, preparado para hospedar novos módulos.
-- **Overlay de login** com campos Nome/E-mail/Telefone, lista de dispositivos e
-  ações que disparam os stubs (`auth/login/open`, `auth/login/save`,
-  `auth/session/logout`, `devices/disconnect`).
-- **Acessibilidade**: botões reais, `aria-pressed` nos toggles, overlay com
-  `role="dialog"`, foco gerenciado e fechamento via `Esc` ou backdrop.
+- **Etiqueta dinâmica** com metadados opcionais (último login/sync/backup) e dots
+  conectados ao estado global (`syncOn`, `backupOn`, `conexao`).
+- **Palco em tela cheia** sem painel direito, com cabeçalho azul, subtítulo e
+  toolbar de pills coloridas (verde ON, vermelho OFF) sincronizadas entre o rail
+  e os overlays.
+- **Grid responsivo** (12 colunas quebrando para 1 coluna < 900px) com os tiles:
+  Login, Sincronização, Backup, Conectividade, Segurança e Eventos, todos em
+  pt-BR e sem placeholders quando o valor é vazio.
+- **Tabela de eventos** com filtro live, filtro por tipo, ordenação por coluna,
+  cabeçalho sticky, hover, rolagem vertical e exportação CSV baseada no DOM
+  filtrado.
+- **Overlays acessíveis** (`role="dialog"`, `aria-modal`, foco gerenciado,
+  fechamento por Esc/backdrop) para Login, Sync e Backup, cada um refletindo o
+  estado atual do store (toggles, dispositivos, histórico) e disparando eventos
+  na telemetria local.
+- **Camada de serviço mock** que expõe os contratos REST (GET/PUT/DELETE)
+  esperados. As ações retornam Promises, atualizam a store e registram eventos
+  (`Sync`, `Backup`, `Login`) com timestamps em `pt-BR`.
+- **Arquitetura montável**: o miniapp exporta `window.PainelMiniApp.mount` e
+  `unmount`, permitindo que o shell principal carregue/descadastre o módulo sem
+  vazamentos de listener.
+- **Acessibilidade**: `aria-current` na etiqueta ativa, `aria-pressed` nas pills,
+  foco visível e navegação por teclado em rail, painel, tabelas e overlays.
 
 ## Próximos passos sugeridos
 
-- Integrar dados reais ao painel de controle utilizando os stubs definidos.
-- Expandir os placeholders de Marketplace e Configurações com mini-apps reais.
-- Harmonizar o visual do protótipo completo (`src/`) com os novos tokens `ac-*`
-  para facilitar a evolução unificada.
+- Conectar os serviços mock aos endpoints reais descritos na especificação.
+- Persistir os eventos exportados no backend para rastreabilidade completa.
+- Expandir o shell para carregar múltiplos miniapps montando/desmontando via
+  `window.PainelMiniApp` conforme o rail evoluir.

--- a/appbase/app.css
+++ b/appbase/app.css
@@ -2,24 +2,25 @@
   --ac-border-width: 1px;
   --ac-border-width-strong: 2px;
   --ac-bg: #ffffff;
+  --ac-surface: #f8fafc;
   --ac-text: #1f2937;
+  --ac-muted: #64748b;
   --ac-primary: #1f3a8a;
   --ac-border: #0b2a6b;
   --ac-accent: #f97316;
-  --ac-card-bg: #e6edff;
+  --ac-card-bg: #eef2ff;
   --ac-card-ink: #0f172a;
-  --ac-tile-bg: #e2e8f0;
-  --ac-tile-border: #0b2a6b;
-  --ac-muted: #64748b;
   --ac-ok: #16a34a;
   --ac-ok-bg: #ecfdf5;
   --ac-crit: #ef4444;
-  --ac-crit-bg: #fff1f2;
-  --ac-hover: #eef2ff;
-  --ac-shadow: rgba(17, 24, 39, 0.08);
+  --ac-crit-bg: #fee2e2;
+  --ac-hover: #e0e7ff;
+  --ac-shadow: rgba(15, 23, 42, 0.1);
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -32,8 +33,9 @@ body {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
-  background: var(--ac-bg);
+  background: var(--ac-surface);
   color: var(--ac-text);
+  line-height: 1.5;
 }
 
 a {
@@ -43,8 +45,8 @@ a {
 button {
   font: inherit;
   color: inherit;
-  background: none;
   border: none;
+  background: none;
   cursor: pointer;
 }
 
@@ -55,47 +57,51 @@ select:focus-visible {
   outline-offset: 2px;
 }
 
-input {
+input,
+select {
   font: inherit;
-  padding: 8px 12px;
-  border-radius: 10px;
+  padding: 10px 14px;
+  border-radius: 12px;
   border: var(--ac-border-width) solid var(--ac-border);
   background: #fff;
-  color: var(--ac-text);
+  color: inherit;
+}
+
+select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--ac-border) 50%),
+    linear-gradient(135deg, var(--ac-border) 50%, transparent 50%);
+  background-position: calc(100% - 16px) calc(50% - 4px),
+    calc(100% - 12px) calc(50% - 4px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 36px;
 }
 
 .ac-app {
-  width: min(100vw, 100%);
-  margin: 0;
-  padding: 12px clamp(18px, 4vw, 56px);
-  display: grid;
-  gap: 14px;
-  grid-template-rows: auto 1fr auto;
   min-height: 100vh;
-}
-
-@media (min-width: 1600px) {
-  .ac-app {
-    padding-inline: clamp(48px, 8vw, 120px);
-  }
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 16px;
+  padding: 16px clamp(20px, 5vw, 56px) 24px;
 }
 
 .ac-appbar,
 .ac-footer {
   background: #fff;
   border: var(--ac-border-width-strong) solid var(--ac-border);
-  border-radius: 14px;
-  padding: 16px 20px;
+  border-radius: 16px;
+  padding: 16px 24px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
-  box-shadow: 0 12px 32px var(--ac-shadow);
+  box-shadow: 0 14px 32px var(--ac-shadow);
 }
 
 .ac-footer {
   justify-content: center;
   font-size: 0.95rem;
+  color: var(--ac-muted);
 }
 
 .ac-brand {
@@ -105,9 +111,9 @@ input {
 }
 
 .ac-logo {
-  width: 48px;
-  height: 48px;
-  border-radius: 16px;
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
   border: var(--ac-border-width-strong) solid var(--ac-border);
   display: grid;
   place-items: center;
@@ -116,10 +122,9 @@ input {
 }
 
 .ac-logo img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
   display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .ac-headings {
@@ -128,7 +133,7 @@ input {
 }
 
 .ac-h1 {
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   font-weight: 700;
   color: var(--ac-primary);
 }
@@ -138,36 +143,12 @@ input {
   color: var(--ac-muted);
 }
 
-.ac-btn {
-  border-radius: 14px;
-  border: var(--ac-border-width) solid var(--ac-border);
-  background: var(--ac-bg);
-  padding: 8px 18px;
-  font-weight: 600;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.ac-btn:hover,
-.ac-btn:focus-visible {
-  background: var(--ac-primary);
-  border-color: var(--ac-primary);
-  color: #fff;
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(31, 58, 138, 0.28);
-}
-
-.ac-btn--ghost {
-  border-color: var(--ac-border);
-  background: transparent;
-  padding: 6px 12px;
-}
-
 .ac-breadcrumbs {
-  font-size: 0.95rem;
-  color: var(--ac-text);
+  margin-left: auto;
   display: flex;
-  gap: 6px;
   align-items: center;
+  gap: 6px;
+  color: var(--ac-text);
 }
 
 .ac-bullet {
@@ -179,308 +160,225 @@ input {
 }
 
 .ac-appbar__actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.ac-layout {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 14px;
-  overflow: hidden;
-  min-height: 0;
-}
-
-.ac-rail {
-  display: grid;
-  gap: 12px;
-  padding-right: 4px;
-  overflow-y: visible;
-  align-self: start;
-}
-
-.ac-rail__stack {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  background: #fff;
-  border: var(--ac-border-width-strong) solid var(--ac-border);
-  border-radius: 18px;
-  padding: 16px;
-  box-shadow: 0 12px 32px var(--ac-shadow);
-}
-
-.ac-miniapp {
-  display: block;
-}
-
-.ac-miniapp__card {
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.ac-miniapp.is-active .ac-miniapp__card {
-  border-color: var(--ac-accent);
-  background: rgba(230, 237, 255, 0.82);
-  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.16);
-}
-
-.ac-miniapp--empty {
-  border: var(--ac-border-width) solid rgba(15, 23, 42, 0.12);
-  border-radius: 16px;
-  padding: 12px;
-  background: rgba(230, 237, 255, 0.35);
-  display: grid;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.ac-miniapp--empty:hover,
-.ac-miniapp--empty:focus-within {
-  border-color: var(--ac-primary);
-  background: rgba(230, 237, 255, 0.65);
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
-}
-
-.ac-miniapp__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.ac-miniapp__legend {
-  display: grid;
-  gap: 6px;
-}
-
-.ac-miniapp__title {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--ac-primary);
-}
-
-.ac-miniapp__meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.8rem;
-  color: var(--ac-muted);
-}
-
-.ac-miniapp__tag {
-  border-radius: 999px;
-  border: var(--ac-border-width) solid var(--ac-border);
-  padding: 4px 12px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--ac-muted);
-  background: rgba(15, 23, 42, 0.05);
-}
-
-.ac-miniapp__subtitle {
-  font-weight: 500;
-  font-size: 0.8rem;
-  color: var(--ac-muted);
-}
-
-.ac-miniapp__shortcuts {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.ac-miniapp__shortcut {
-  border-radius: 999px;
-  border: var(--ac-border-width) solid rgba(15, 23, 42, 0.18);
-  padding: 4px 12px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.8);
-  color: var(--ac-primary);
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.ac-miniapp__shortcut:hover,
-.ac-miniapp__shortcut:focus-visible {
-  background: var(--ac-primary);
-  border-color: var(--ac-primary);
-  color: #fff;
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(31, 58, 138, 0.16);
-}
-
-.ac-miniapp__summary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 8px;
-  font-size: 0.85rem;
-}
-
-.ac-miniapp__summary-item {
-  display: grid;
-  gap: 4px;
-  padding: 8px 10px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.7);
-  border: var(--ac-border-width) solid rgba(15, 23, 42, 0.08);
-}
-
-.ac-miniapp__label {
-  font-weight: 500;
-  color: var(--ac-muted);
-}
-
-.ac-miniapp__value {
-  font-weight: 500;
-  color: var(--ac-card-ink);
-}
-
-.ac-miniapp__health {
-  gap: 12px;
-}
-
-.ac-miniapp__placeholder {
-  min-height: 72px;
-  border-radius: 12px;
-  border: 2px dashed rgba(15, 23, 42, 0.25);
-  display: grid;
-  place-items: center;
-  font-size: 0.9rem;
-  color: var(--ac-muted);
-  background: rgba(15, 23, 42, 0.03);
-}
-
-.ac-card {
-  background: var(--ac-card-bg);
-  color: var(--ac-card-ink);
-  border: var(--ac-border-width) solid var(--ac-border);
-  border-radius: 16px;
-  padding: 12px 14px;
-  display: grid;
-  gap: 12px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.ac-card--panel {
-  gap: 10px;
-  padding: 12px;
-  background: rgba(230, 237, 255, 0.6);
-}
-
-.ac-card.is-active {
-  border-color: var(--ac-accent);
-  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.25);
-}
-
-.ac-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 8px;
-}
-
-.ac-card__title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--ac-primary);
-}
-
-.ac-card__subtitle {
-  margin: 0;
-  color: var(--ac-muted);
-  font-size: 0.9rem;
+  position: relative;
 }
 
 .ac-iconbtn {
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
   border: var(--ac-border-width) solid var(--ac-border);
-  background: var(--ac-bg);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.4rem;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  background: #fff;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.ac-iconbtn--small {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
 }
 
 .ac-iconbtn:hover,
 .ac-iconbtn:focus-visible {
   background: var(--ac-primary);
-  border-color: var(--ac-primary);
   color: #fff;
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(31, 58, 138, 0.28);
+  border-color: var(--ac-primary);
 }
 
-.ac-kebab {
-  border: var(--ac-border-width) solid transparent;
+.ac-appbar__menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  background: #fff;
+  border: var(--ac-border-width) solid var(--ac-border);
   border-radius: 12px;
-  padding: 4px 8px;
-  font-size: 1.2rem;
+  box-shadow: 0 18px 36px var(--ac-shadow);
+  z-index: 10;
+}
+
+.ac-appbar__menu[hidden] {
+  display: none;
+}
+
+.ac-appbar__menu button {
+  padding: 8px 12px;
+  border-radius: 10px;
+  text-align: left;
+  background: transparent;
+}
+
+.ac-appbar__menu button:hover,
+.ac-appbar__menu button:focus-visible {
+  background: var(--ac-hover);
+}
+
+.ac-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 16px;
+  min-height: 0;
+}
+
+@media (max-width: 1200px) {
+  .ac-layout {
+    grid-template-columns: 280px 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .ac-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .ac-appbar,
+  .ac-footer {
+    flex-wrap: wrap;
+  }
+}
+
+.ac-rail {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.ac-miniapp-card {
+  background: var(--ac-card-bg);
+  color: var(--ac-card-ink);
+  border: var(--ac-border-width-strong) solid var(--ac-border);
+  border-radius: 18px;
+  padding: 20px;
+  display: grid;
+  gap: 18px;
+  cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.ac-kebab:hover,
-.ac-kebab:focus-visible {
+.ac-miniapp-card:hover {
+  box-shadow: 0 16px 32px var(--ac-shadow);
+}
+
+.ac-miniapp-card.is-active {
   border-color: var(--ac-accent);
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(249, 115, 22, 0.25);
 }
 
-.ac-badges {
+.ac-miniapp-card__head {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
 }
 
-.ac-badge {
+.ac-miniapp-card__titles {
+  display: grid;
+  gap: 4px;
+}
+
+.ac-miniapp-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ac-primary);
+}
+
+.ac-miniapp-card__subtitle {
+  margin: 0;
+  color: var(--ac-muted);
+  font-weight: 600;
+}
+
+.ac-miniapp-card__meta {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.ac-miniapp-card__meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.95rem;
+}
+
+.ac-miniapp-card__meta dt {
+  font-weight: 600;
+}
+
+.ac-miniapp-card__meta dd {
+  margin: 0;
+  font-weight: 500;
+}
+
+.ac-miniapp-card__kpis {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.ac-kpi {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-weight: 500;
-  color: var(--ac-muted);
+  font-weight: 600;
 }
 
 .ac-dot {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: var(--ac-border-width) solid var(--ac-border);
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
   background: var(--ac-muted);
-  display: inline-block;
+  border: var(--ac-border-width) solid transparent;
 }
 
 .ac-dot--ok {
   background: var(--ac-ok);
-  border-color: var(--ac-ok);
 }
 
 .ac-dot--crit {
   background: var(--ac-crit);
-  border-color: var(--ac-crit);
 }
 
 .ac-stage {
+  background: #fff;
   border: var(--ac-border-width-strong) solid var(--ac-border);
   border-radius: 18px;
-  background: #fff;
-  padding: 20px;
-  display: flex;
+  padding: 0;
+  position: relative;
+  min-height: 620px;
+  display: grid;
+}
+
+.ac-stage__empty {
+  display: grid;
+  place-items: center;
+  padding: 48px;
+  text-align: center;
+  color: var(--ac-muted);
+}
+
+.ac-stage__panel {
+  display: none;
   flex-direction: column;
-  gap: 24px;
-  min-height: 0;
+  height: 100%;
+}
+
+.ac-stage__panel:not([hidden]) {
+  display: flex;
 }
 
 .ac-stage__head {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
   gap: 16px;
+  padding: 24px;
+  border-bottom: var(--ac-border-width) solid var(--ac-border);
+  align-items: flex-start;
 }
 
 .ac-stage__titles {
@@ -490,104 +388,45 @@ input {
 
 .ac-title-lg {
   margin: 0;
-  color: var(--ac-primary);
   font-size: 1.6rem;
-}
-
-.ac-sub {
-  color: var(--ac-muted);
-}
-
-.ac-beta-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 16px;
-  border-radius: 999px;
-  border: var(--ac-border-width) solid var(--ac-border);
-  background: var(--ac-card-bg);
   color: var(--ac-primary);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 
-.ac-beta-pill::before {
-  content: '';
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--ac-accent);
+.ac-subtitle {
+  margin: 0;
+  color: var(--ac-muted);
+  font-weight: 500;
 }
 
-.ac-switch {
-  display: inline-flex;
+.ac-stage__toolbar {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: var(--ac-border-width) solid var(--ac-border);
-  background: var(--ac-crit-bg);
-  color: var(--ac-crit);
-  font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.ac-switch:focus-visible {
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 4) rgba(15, 23, 42, 0.3);
-}
-
-.ac-switch .ac-dot {
-  width: 12px;
-  height: 12px;
-}
-
-.ac-switch.is-on {
-  background: var(--ac-ok-bg);
-  border-color: var(--ac-ok);
-  color: var(--ac-ok);
-}
-
-.ac-switch.is-on .ac-dot {
-  background: var(--ac-ok);
-  border-color: var(--ac-ok);
-}
-
-.ac-switch.is-off {
-  background: var(--ac-crit-bg);
-  border-color: var(--ac-crit);
-  color: var(--ac-crit);
-}
-
-.ac-switch.is-off .ac-dot {
-  background: var(--ac-crit);
-  border-color: var(--ac-crit);
 }
 
 .ac-grid {
+  padding: 24px;
   display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 14px;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 4px;
+  gap: 16px;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
 }
 
 .ac-tile {
-  background: var(--ac-tile-bg);
-  border: var(--ac-border-width) solid var(--ac-tile-border);
-  border-radius: 20px;
-  padding: 18px;
+  background: #fff;
+  border: var(--ac-border-width) solid var(--ac-border);
+  border-radius: 16px;
+  padding: 20px;
   display: grid;
-  gap: 10px;
+  gap: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
 }
 
 .ac-tile__head {
   display: flex;
+  align-items: start;
   justify-content: space-between;
-  align-items: center;
+  gap: 12px;
 }
 
 .ac-tile__title {
@@ -597,98 +436,126 @@ input {
   color: var(--ac-primary);
 }
 
-.ac-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--ac-muted);
-  background: rgba(15, 23, 42, 0.08);
-  padding: 4px 10px;
-  border-radius: 999px;
-}
-
-.ac-status--ok {
-  color: var(--ac-ok);
-  background: var(--ac-ok-bg);
-}
-
-.ac-list {
+.ac-tile__meta {
   margin: 0;
-  padding-left: 18px;
   display: grid;
-  gap: 6px;
-  color: var(--ac-text);
+  gap: 12px;
 }
 
-.ac-actions {
-  margin-top: 6px;
+.ac-tile__meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.97rem;
 }
 
-.ac-v {
+.ac-tile__meta dt {
+  font-weight: 600;
+}
+
+.ac-tile__meta dd {
   margin: 0;
-  font-size: 0.95rem;
-  color: var(--ac-text);
+  text-align: right;
+  font-weight: 500;
 }
 
 .ac-mono {
-  font-family: 'JetBrains Mono', 'Fira Mono', 'Source Code Pro', monospace;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas,
+    'Liberation Mono', monospace;
 }
 
-.span-4 {
+.ac-tile--span-4 {
   grid-column: span 4;
 }
 
-.span-6 {
+.ac-tile--span-6 {
   grid-column: span 6;
 }
 
-.span-12 {
+.ac-tile--span-12 {
   grid-column: span 12;
 }
 
+@media (max-width: 1200px) {
+  .ac-tile--span-4,
+  .ac-tile--span-6 {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 900px) {
+  .ac-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ac-tile,
+  .ac-tile--span-4,
+  .ac-tile--span-6,
+  .ac-tile--span-12 {
+    grid-column: 1 / -1;
+  }
+}
+
+.ac-events-filter {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+  .ac-events-filter {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ac-field {
+  display: grid;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.ac-field__label {
+  font-weight: 600;
+  color: var(--ac-primary);
+}
+
 .ac-table-wrap {
-  max-height: 220px;
-  overflow: auto;
-  border-radius: 12px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  border-radius: 14px;
+  overflow: hidden;
   background: #fff;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.ac-table-wrap--inner {
+  max-height: 240px;
 }
 
 .ac-table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
+  border-collapse: collapse;
   font-size: 0.95rem;
-  color: var(--ac-text);
 }
 
 .ac-table thead th {
   position: sticky;
   top: 0;
-  background: var(--ac-bg);
+  background: var(--ac-card-bg);
+  color: var(--ac-primary);
   text-align: left;
-  padding: 12px;
+  padding: 12px 16px;
   border-bottom: var(--ac-border-width) solid var(--ac-border);
+  z-index: 1;
 }
 
 .ac-table tbody td {
-  padding: 12px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  padding: 12px 16px;
+  border-bottom: var(--ac-border-width) solid rgba(15, 23, 42, 0.08);
 }
 
 .ac-table tbody tr:hover {
   background: var(--ac-hover);
-}
-
-.ac-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.ac-table.ac-table--compact thead th,
-.ac-table.ac-table--compact tbody td {
-  padding: 10px 12px;
-  font-size: 0.9rem;
 }
 
 .ac-table__actions {
@@ -696,69 +563,123 @@ input {
 }
 
 .ac-th {
+  font: inherit;
+  color: inherit;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-weight: 700;
+  background: transparent;
+}
+
+.ac-th:hover,
+.ac-th:focus-visible {
   color: var(--ac-primary);
 }
 
-.ac-th .arrow {
-  font-size: 0.85em;
+.ac-table--compact thead th {
+  padding: 10px 14px;
 }
 
-.ac-stage {
-  overflow: hidden;
+.ac-table--compact tbody td {
+  padding: 10px 14px;
 }
 
-.ac-overlay[aria-hidden='true'] {
-  display: none;
+.ac-btn {
+  border-radius: 14px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  background: #fff;
+  padding: 10px 18px;
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ac-btn:hover,
+.ac-btn:focus-visible {
+  background: var(--ac-primary);
+  color: #fff;
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 4px rgba(31, 58, 138, 0.24);
+}
+
+.ac-pill-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid transparent;
+  padding: 8px 18px;
+  font-weight: 600;
+  background: var(--ac-crit-bg);
+  color: var(--ac-crit);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.ac-pill-toggle__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.ac-pill-toggle--inline {
+  padding: 6px 14px;
+  font-size: 0.85rem;
+}
+
+.ac-pill-toggle--inline .ac-pill-toggle__dot {
+  width: 10px;
+  height: 10px;
+}
+
+.ac-pill-toggle[aria-pressed='true'] {
+  background: var(--ac-ok-bg);
+  color: var(--ac-ok);
+  border-color: var(--ac-ok);
+}
+
+.ac-pill-toggle:focus-visible {
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.25);
 }
 
 .ac-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(8px);
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  z-index: 1000;
+  background: rgba(15, 23, 42, 0.48);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.ac-overlay[aria-hidden='false'] {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .ac-sheet {
-  width: min(720px, 100%);
+  width: min(720px, 96vw);
+  max-height: 78vh;
   background: #fff;
+  border-radius: 18px;
   border: var(--ac-border-width-strong) solid var(--ac-border);
-  border-radius: 20px;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  max-height: 90vh;
-}
-
-.ac-sheet__head,
-.ac-sheet__foot {
-  padding: 20px 24px;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
 }
 
 .ac-sheet__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
   border-bottom: var(--ac-border-width) solid var(--ac-border);
-}
-
-.ac-sheet__foot {
-  border-top: var(--ac-border-width) solid var(--ac-border);
-  flex-wrap: wrap;
-}
-
-.ac-sheet__body {
-  padding: 24px;
-  overflow-y: auto;
-  display: grid;
-  gap: 24px;
 }
 
 .ac-sheet__title {
@@ -767,70 +688,67 @@ input {
   color: var(--ac-primary);
 }
 
-.ac-sheet__subtitle {
-  margin: 0 0 12px;
-  color: var(--ac-primary);
-  font-size: 1rem;
-}
-
-.ac-sheet__section {
+.ac-sheet__body {
+  padding: 20px 24px;
+  overflow-y: auto;
   display: grid;
-  gap: 12px;
-}
-
-.ac-sheet__close {
-  border: var(--ac-border-width) solid transparent;
-  border-radius: 12px;
-  padding: 6px 10px;
-  font-size: 1.1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.ac-sheet__close:hover,
-.ac-sheet__close:focus-visible {
-  border-color: var(--ac-accent);
-  box-shadow: 0 0 0 calc(var(--ac-border-width) * 3) rgba(249, 115, 22, 0.25);
+  gap: 24px;
 }
 
 .ac-form-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 640px) {
+  .ac-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ac-sheet__section {
+  display: grid;
   gap: 16px;
 }
 
-.ac-field {
-  display: grid;
-  gap: 8px;
+.ac-sheet__section--stack {
+  align-items: start;
 }
 
-.ac-field__label {
-  font-weight: 600;
+.ac-sheet__subtitle {
+  margin: 0;
+  font-size: 1rem;
   color: var(--ac-primary);
 }
 
-@media (max-width: 1024px) {
-  .ac-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .ac-rail {
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(240px, 1fr);
-    overflow-x: auto;
-    padding-bottom: 12px;
-  }
-
-  .ac-stage {
-    min-height: 60vh;
-  }
+.ac-sheet__foot {
+  padding: 18px 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  border-top: var(--ac-border-width) solid var(--ac-border);
+  justify-content: flex-end;
 }
 
-@media (prefers-contrast: more) {
-  .ac-card,
-  .ac-tile,
-  .ac-sheet,
-  .ac-appbar,
-  .ac-footer {
-    box-shadow: none;
-  }
+.ac-sheet__status {
+  margin: 0;
+  color: var(--ac-muted);
+  font-weight: 600;
+}
+
+[data-stage-empty] {
+  font-size: 1.05rem;
+}
+
+.ac-stage__panel[hidden] {
+  display: none;
+}
+
+.ac-stage__panel:focus-visible {
+  outline: none;
+}
+
+[hidden] {
+  display: none !important;
 }

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -1,133 +1,1044 @@
 (function () {
-  const byId = (id) => document.getElementById(id);
+  const formatDateTime = (date = new Date()) => {
+    const day = date.toLocaleDateString('pt-BR');
+    const time = date.toLocaleTimeString('pt-BR', {
+      hour12: false,
+    });
+    return `${day} ${time}`;
+  };
 
-  const overlay = byId('login-overlay');
-  const sheet = overlay.querySelector('.ac-sheet');
-  const title = byId('login-sheet-title');
-  const loginForm = document.getElementById('login-form');
-  let lastFocusedElement = null;
+  const formatTime = (date = new Date()) =>
+    date.toLocaleTimeString('pt-BR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
 
-  function logStub(topic, payload = {}) {
-    console.log(`[stub] ${topic}`, payload);
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+
+  function createStore(initialState) {
+    let state = clone(initialState);
+    const listeners = new Set();
+
+    return {
+      getState() {
+        return state;
+      },
+      setState(updater) {
+        const nextState =
+          typeof updater === 'function' ? updater(state) : clone(updater);
+        state = nextState;
+        listeners.forEach((listener) => listener(state));
+      },
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
   }
 
-  function formatNow() {
-    return new Date().toLocaleString('pt-BR');
+  const initialState = {
+    user: {
+      id: 'u1',
+      nome: 'Fabio',
+      nomeCompleto: 'Fabio Henrique',
+      email: 'fabio@5horas.app',
+      telefone: '+55 11 99999-0000',
+      conta: '5Horas',
+    },
+    status: {
+      conexao: 'ok',
+      syncOn: false,
+      backupOn: false,
+      lastLogin: '05/10/2025 09:12:00',
+      lastSync: '',
+      lastBackup: '',
+    },
+    sync: {
+      provider: 'Google Drive',
+      pendenciasOffline: 0,
+      devices: [
+        {
+          id: 'd1',
+          nome: 'Notebook',
+          ultimaSync: '05/10/2025 09:10:00',
+          habilitado: true,
+        },
+        {
+          id: 'd2',
+          nome: 'Cliente web',
+          ultimaSync: '05/10/2025 09:40:00',
+          habilitado: true,
+        },
+        {
+          id: 'd3',
+          nome: 'Mobile iOS',
+          ultimaSync: '04/10/2025 22:05:11',
+          habilitado: false,
+        },
+      ],
+      historico: [
+        {
+          id: 'h1',
+          data: '05/10/2025 09:40:00',
+          duracao: '08s',
+          itens: '3 itens',
+        },
+        {
+          id: 'h2',
+          data: '05/10/2025 08:55:12',
+          duracao: '14s',
+          itens: '12 itens',
+        },
+        {
+          id: 'h3',
+          data: '04/10/2025 22:05:11',
+          duracao: '25s',
+          itens: '28 itens',
+        },
+      ],
+    },
+    backup: {
+      destino: 'Servidor 5Horas',
+      total: '—',
+      historico: [
+        {
+          id: 'b1',
+          data: '04/10/2025 23:20:00',
+          tipo: 'Incremental',
+          tamanho: '1,4 GB',
+          status: 'Concluído',
+        },
+        {
+          id: 'b2',
+          data: '03/10/2025 23:18:11',
+          tipo: 'Completo',
+          tamanho: '12,8 GB',
+          status: 'Concluído',
+        },
+        {
+          id: 'b3',
+          data: '02/10/2025 23:30:45',
+          tipo: 'Incremental',
+          tamanho: '1,1 GB',
+          status: 'Concluído',
+        },
+      ],
+    },
+    net: {
+      endpoint: 'api.marco.local',
+      regiao: 'br-south',
+      lat: '42ms',
+      perdas: '0%',
+    },
+    sec: {
+      ultimoAcesso: '05/10/2025 09:12:00',
+      sessoes: 3,
+      tokenExpira: '31/12/2025 23:59',
+      escopos: 'read:store, write:sync',
+    },
+    sessions: {
+      devices: [
+        {
+          id: 's1',
+          nome: 'Notebook Fabio',
+          local: 'São Paulo, BR',
+          ultimoAcesso: '05/10/2025 09:12:00',
+        },
+        {
+          id: 's2',
+          nome: 'Cliente web',
+          local: 'São Paulo, BR',
+          ultimoAcesso: '05/10/2025 09:40:00',
+        },
+        {
+          id: 's3',
+          nome: 'Mobile iOS',
+          local: 'Campinas, BR',
+          ultimoAcesso: '04/10/2025 22:05:11',
+        },
+      ],
+    },
+    eventos: [
+      { time: '09:41', type: 'Backup', msg: 'Backup concluído em 12s', src: 'agente#1' },
+      { time: '09:40', type: 'Sync', msg: 'Sync aplicado: 3 registros', src: 'cliente-web' },
+      { time: '09:12', type: 'Login', msg: 'Login bem-sucedido', src: 'Fabio · 187.22.10.4' },
+      { time: '08:55', type: 'Ping', msg: 'Ping servidor: 41ms', src: 'probe' },
+      { time: '08:40', type: 'Backup', msg: 'Backup agendado iniciado', src: 'agente#1' },
+      { time: '08:35', type: 'Sync', msg: 'Sync diferido aguardando rede', src: 'cliente-mobile' },
+      { time: '08:20', type: 'Login', msg: 'Sessão autenticada', src: 'Fabio · 187.22.10.4' },
+      { time: '07:58', type: 'Ping', msg: 'Ping servidor: 45ms', src: 'probe' },
+      { time: '07:15', type: 'Backup', msg: 'Backup incremental iniciado', src: 'agente#1' },
+      { time: '07:00', type: 'Sync', msg: 'Sync automático concluído', src: 'cliente-web' },
+      { time: '06:45', type: 'Ping', msg: 'Ping servidor: 44ms', src: 'probe' },
+      { time: '06:20', type: 'Login', msg: 'Sessão encerrada por inatividade', src: 'Mobile iOS' },
+    ],
+  };
+
+  function createServices(store) {
+    return {
+      getEstado() {
+        const state = store.getState();
+        return Promise.resolve({
+          status: clone(state.status),
+          sync: clone(state.sync),
+          backup: clone(state.backup),
+          net: clone(state.net),
+          sec: clone(state.sec),
+        });
+      },
+      getEventos() {
+        return Promise.resolve(clone(store.getState().eventos));
+      },
+      putSync({ on, provider }) {
+        const state = store.getState();
+        const now = formatDateTime();
+        const historyEntry = on
+          ? {
+              id: `h-${Date.now()}`,
+              data: now,
+              duracao: '09s',
+              itens: '5 itens',
+            }
+          : null;
+        return Promise.resolve({
+          status: {
+            ...state.status,
+            syncOn: on,
+            lastSync: on ? now : state.status.lastSync,
+          },
+          sync: {
+            ...state.sync,
+            provider: provider ?? state.sync.provider,
+            historico:
+              historyEntry !== null
+                ? [historyEntry, ...state.sync.historico].slice(0, 8)
+                : state.sync.historico,
+          },
+        });
+      },
+      putBackup({ on }) {
+        const state = store.getState();
+        const now = formatDateTime();
+        const historyEntry = on
+          ? {
+              id: `b-${Date.now()}`,
+              data: now,
+              tipo: 'Incremental',
+              tamanho: '1,2 GB',
+              status: 'Concluído',
+            }
+          : null;
+        return Promise.resolve({
+          status: {
+            ...state.status,
+            backupOn: on,
+            lastBackup: on ? now : state.status.lastBackup,
+          },
+          backup: {
+            ...state.backup,
+            historico:
+              historyEntry !== null
+                ? [historyEntry, ...state.backup.historico].slice(0, 8)
+                : state.backup.historico,
+          },
+        });
+      },
+      putUser(payload) {
+        const state = store.getState();
+        return Promise.resolve({
+          user: {
+            ...state.user,
+            ...payload,
+          },
+        });
+      },
+      deleteSession(id) {
+        const state = store.getState();
+        const devices = state.sessions.devices.filter((device) => device.id !== id);
+        return Promise.resolve({
+          sessions: { devices },
+          sec: { ...state.sec, sessoes: devices.length },
+        });
+      },
+      deleteAllSessions() {
+        const state = store.getState();
+        return Promise.resolve({
+          sessions: { devices: [] },
+          sec: { ...state.sec, sessoes: 0 },
+        });
+      },
+      putSyncDevice(id, habilitado) {
+        const state = store.getState();
+        const devices = state.sync.devices.map((device) =>
+          device.id === id ? { ...device, habilitado } : device
+        );
+        return Promise.resolve({
+          sync: { ...state.sync, devices },
+        });
+      },
+    };
   }
 
-  function setDotState(el, isOn) {
-    if (!el) return;
-    el.classList.toggle('ac-dot--ok', isOn);
-    el.classList.toggle('ac-dot--crit', !isOn);
+  function createActions(store, services) {
+    const appendEvent = (events, type, msg, src = 'Painel de controle') => [
+      { time: formatTime(), type, msg, src },
+      ...events,
+    ];
+
+    return {
+      toggleSync(on) {
+        return services.putSync({ on }).then((payload) => {
+          store.setState((state) => ({
+            ...state,
+            status: payload.status,
+            sync: payload.sync,
+            eventos: appendEvent(
+              state.eventos,
+              'Sync',
+              on ? 'Sync ativada pelo painel' : 'Sync desativada pelo painel'
+            ),
+          }));
+        });
+      },
+      setSyncProvider(provider) {
+        return services
+          .putSync({ on: store.getState().status.syncOn, provider })
+          .then((payload) => {
+            store.setState((state) => ({
+              ...state,
+              status: payload.status,
+              sync: payload.sync,
+              eventos: appendEvent(
+                state.eventos,
+                'Sync',
+                `Provedor de sync alterado para ${provider}`
+              ),
+            }));
+          });
+      },
+      toggleBackup(on) {
+        return services.putBackup({ on }).then((payload) => {
+          store.setState((state) => ({
+            ...state,
+            status: payload.status,
+            backup: payload.backup,
+            eventos: appendEvent(
+              state.eventos,
+              'Backup',
+              on ? 'Backup ativado pelo painel' : 'Backup desativado pelo painel'
+            ),
+          }));
+        });
+      },
+      saveLogin(payload) {
+        return services.putUser(payload).then((response) => {
+          store.setState((state) => ({
+            ...state,
+            user: response.user,
+            eventos: appendEvent(state.eventos, 'Login', 'Dados de login atualizados'),
+          }));
+        });
+      },
+      logoff() {
+        store.setState((state) => ({
+          ...state,
+          eventos: appendEvent(state.eventos, 'Login', 'Logoff solicitado'),
+        }));
+      },
+      killSessions() {
+        return services.deleteAllSessions().then((payload) => {
+          store.setState((state) => ({
+            ...state,
+            sessions: payload.sessions,
+            sec: payload.sec,
+            eventos: appendEvent(
+              state.eventos,
+              'Login',
+              'Todas as sessões foram encerradas'
+            ),
+          }));
+        });
+      },
+      disconnectSession(id) {
+        const current = store.getState();
+        const device = current.sessions.devices.find((entry) => entry.id === id);
+        const label = device ? device.nome : id;
+        return services.deleteSession(id).then((payload) => {
+          store.setState((state) => ({
+            ...state,
+            sessions: payload.sessions,
+            sec: payload.sec,
+            eventos: appendEvent(
+              state.eventos,
+              'Login',
+              `Sessão desconectada (${label})`
+            ),
+          }));
+        });
+      },
+      toggleSyncDevice(id, habilitado) {
+        const current = store.getState();
+        const device = current.sync.devices.find((entry) => entry.id === id);
+        const label = device ? device.nome : id;
+        return services.putSyncDevice(id, habilitado).then((payload) => {
+          store.setState((state) => ({
+            ...state,
+            sync: payload.sync,
+            eventos: appendEvent(
+              state.eventos,
+              'Sync',
+              `${habilitado ? 'Habilitado' : 'Desabilitado'} sync em ${label}`
+            ),
+          }));
+        });
+      },
+      exportEvents(count) {
+        store.setState((state) => ({
+          ...state,
+          eventos: appendEvent(
+            state.eventos,
+            'Sync',
+            `Eventos exportados (${count} linhas)`
+          ),
+        }));
+      },
+      changePassword() {
+        store.setState((state) => ({
+          ...state,
+          eventos: appendEvent(state.eventos, 'Login', 'Pedido de troca de senha'),
+        }));
+      },
+    };
   }
 
-  function setSwitchState(button, isOn, labels) {
-    button.classList.toggle('is-on', isOn);
-    button.classList.toggle('is-off', !isOn);
-    button.setAttribute('aria-pressed', String(isOn));
-    const label = button.querySelector('.ac-switch__label');
-    if (label) {
-      label.textContent = isOn ? labels.on : labels.off;
+  const defaultStore = createStore(initialState);
+  const defaultServices = createServices(defaultStore);
+
+  const uiState = {
+    eventsSearch: '',
+    eventsType: 'all',
+    sort: { key: 'time', direction: 'desc' },
+  };
+
+  const elements = {};
+  let listeners = [];
+  let unsubscribe = null;
+  let activeStore = null;
+  let activeServices = null;
+  let actions = null;
+  let panelOpen = false;
+  let currentEventsView = [];
+  let openOverlayId = null;
+  let lastOverlayTrigger = null;
+  let menuOpen = false;
+
+  function cacheElements() {
+    const card = document.querySelector('[data-miniapp="painel"]');
+    const stage = document.getElementById('painel-stage');
+    const stageEmpty = document.querySelector('[data-stage-empty]');
+    const loginForm = document.querySelector('[data-login-form]');
+
+    Object.assign(elements, {
+      app: document.querySelector('.ac-app'),
+      card,
+      togglePanel: card?.querySelector('[data-toggle-panel]') || null,
+      userName: card?.querySelector('[data-user-name]') || null,
+      cardMeta: {
+        login: {
+          container: card?.querySelector('[data-meta="login"]') || null,
+          value: card?.querySelector('[data-meta-value="login"]') || null,
+        },
+        sync: {
+          container: card?.querySelector('[data-meta="sync"]') || null,
+          value: card?.querySelector('[data-meta-value="sync"]') || null,
+        },
+        backup: {
+          container: card?.querySelector('[data-meta="backup"]') || null,
+          value: card?.querySelector('[data-meta-value="backup"]') || null,
+        },
+      },
+      kpis: {
+        conexao: card?.querySelector('[data-kpi="conexao"] .ac-dot') || null,
+        sync: card?.querySelector('[data-kpi="sync"] .ac-dot') || null,
+        backup: card?.querySelector('[data-kpi="backup"] .ac-dot') || null,
+      },
+      stage,
+      stageEmpty,
+      stageTitle: stage?.querySelector('#painel-stage-title') || null,
+      loginUser: stage?.querySelector('[data-login-user]') || null,
+      loginAccount: stage?.querySelector('[data-login-account]') || null,
+      loginLast: stage?.querySelector('[data-login-last]') || null,
+      syncLast: stage?.querySelector('[data-sync-last]') || null,
+      syncProvider: stage?.querySelector('[data-sync-provider]') || null,
+      syncPending: stage?.querySelector('[data-sync-pending]') || null,
+      backupLast: stage?.querySelector('[data-backup-last]') || null,
+      backupDestination: stage?.querySelector('[data-backup-destination]') || null,
+      backupTotal: stage?.querySelector('[data-backup-total]') || null,
+      net: {
+        endpoint: stage?.querySelector('[data-net-endpoint]') || null,
+        regiao: stage?.querySelector('[data-net-region]') || null,
+        latencia: stage?.querySelector('[data-net-latency]') || null,
+        perdas: stage?.querySelector('[data-net-loss]') || null,
+      },
+      sec: {
+        ultimo: stage?.querySelector('[data-sec-last]') || null,
+        sessoes: stage?.querySelector('[data-sec-sessions]') || null,
+        expira: stage?.querySelector('[data-sec-expire]') || null,
+        escopos: stage?.querySelector('[data-sec-scopes]') || null,
+      },
+      events: {
+        search: stage?.querySelector('[data-events-search]') || null,
+        type: stage?.querySelector('[data-events-type]') || null,
+        body: stage?.querySelector('[data-events-body]') || null,
+        sortButtons: stage
+          ? Array.from(stage.querySelectorAll('[data-sort]'))
+          : [],
+      },
+      overlays: {
+        login: document.querySelector('[data-overlay="login"]'),
+        sync: document.querySelector('[data-overlay="sync"]'),
+        backup: document.querySelector('[data-overlay="backup"]'),
+      },
+      login: {
+        form: loginForm,
+        fields: {
+          nome: loginForm?.querySelector('[name="nome"]') || null,
+          email: loginForm?.querySelector('[name="email"]') || null,
+          telefone: loginForm?.querySelector('[name="telefone"]') || null,
+        },
+        devicesBody: document.querySelector('[data-login-devices-body]'),
+        title: document.getElementById('login-dialog-title'),
+      },
+      syncOverlay: {
+        provider: document.querySelector('[data-sync-provider]'),
+        devicesBody: document.querySelector('[data-sync-devices-body]'),
+        historyBody: document.querySelector('[data-sync-history-body]'),
+        title: document.getElementById('sync-dialog-title'),
+      },
+      backupOverlay: {
+        historyBody: document.querySelector('[data-backup-history-body]'),
+        title: document.getElementById('backup-dialog-title'),
+      },
+      systemMenu: document.querySelector('[data-system-menu]'),
+      systemMenuPanel: document.querySelector('[data-system-menu-panel]'),
+    });
+  }
+
+  function setDotState(dot, ok) {
+    if (!dot) return;
+    dot.classList.toggle('ac-dot--ok', ok);
+    dot.classList.toggle('ac-dot--crit', !ok);
+  }
+
+  function renderCard(state) {
+    if (!elements.card) return;
+    if (elements.userName) {
+      elements.userName.textContent = state.user.nome;
     }
-  }
-
-  function toggleSync(button, forceState) {
-    const isOn =
-      typeof forceState === 'boolean'
-        ? forceState
-        : !button.classList.contains('is-on');
-    setSwitchState(button, isOn, {
-      on: 'Sync ativada',
-      off: 'Sync desativada',
-    });
-    const dot = byId('kpi-sync');
-    setDotState(dot, isOn);
-    const value = isOn ? formatNow() : '';
-    byId('meta-sync').textContent = value;
-    byId('v-sync').textContent = value;
-    logStub('sync/toggle', { on: isOn });
-  }
-
-  function toggleBackup(button, forceState) {
-    const isOn =
-      typeof forceState === 'boolean'
-        ? forceState
-        : !button.classList.contains('is-on');
-    setSwitchState(button, isOn, {
-      on: 'Backup ativado',
-      off: 'Backup desativado',
-    });
-    const dot = byId('kpi-backup');
-    setDotState(dot, isOn);
-    const value = isOn ? formatNow() : '';
-    byId('meta-backup').textContent = value;
-    byId('v-backup').textContent = value;
-    logStub('backup/toggle', { on: isOn });
-  }
-
-  function sortTable(key, button) {
-    const table = document.getElementById('events-table');
-    const tbody = table.querySelector('tbody');
-    const rows = Array.from(tbody.querySelectorAll('tr'));
-    const currentOrder = button.dataset.order === 'asc' ? 'asc' : 'desc';
-    const newOrder = currentOrder === 'asc' ? 'desc' : 'asc';
-    const columnIndex = button.closest('th').cellIndex;
-
-    table.querySelectorAll('.ac-th').forEach((th) => {
-      th.dataset.order = '';
-      const arrow = th.querySelector('.arrow');
-      if (arrow) arrow.textContent = '↕';
-    });
-
-    button.dataset.order = newOrder;
-    const arrow = button.querySelector('.arrow');
-    if (arrow) {
-      arrow.textContent = newOrder === 'asc' ? '↑' : '↓';
+    if (elements.cardMeta.login.value) {
+      elements.cardMeta.login.value.textContent = state.status.lastLogin;
     }
-    const compare = (a, b) => {
-      const aText = a.cells[columnIndex].textContent.trim();
-      const bText = b.cells[columnIndex].textContent.trim();
+    if (elements.cardMeta.sync.value) {
+      elements.cardMeta.sync.value.textContent = state.status.lastSync || '';
+    }
+    if (elements.cardMeta.sync.container) {
+      elements.cardMeta.sync.container.hidden = !state.status.lastSync;
+    }
+    if (elements.cardMeta.backup.value) {
+      elements.cardMeta.backup.value.textContent = state.status.lastBackup || '';
+    }
+    if (elements.cardMeta.backup.container) {
+      elements.cardMeta.backup.container.hidden = !state.status.lastBackup;
+    }
+    setDotState(elements.kpis.conexao, state.status.conexao === 'ok');
+    setDotState(elements.kpis.sync, state.status.syncOn);
+    setDotState(elements.kpis.backup, state.status.backupOn);
+  }
+
+  function renderStage(state) {
+    if (!elements.stage) return;
+    if (elements.loginUser) {
+      elements.loginUser.textContent = state.user.nome;
+    }
+    if (elements.loginAccount) {
+      elements.loginAccount.textContent = state.user.conta;
+    }
+    if (elements.loginLast) {
+      elements.loginLast.textContent = state.status.lastLogin;
+    }
+
+    if (elements.syncProvider) {
+      elements.syncProvider.textContent = state.sync.provider;
+    }
+    if (elements.syncPending) {
+      elements.syncPending.textContent = String(state.sync.pendenciasOffline);
+    }
+    if (elements.syncLast) {
+      elements.syncLast.textContent = state.status.lastSync;
+      const wrap = elements.syncLast.closest('div');
+      if (wrap) wrap.hidden = !state.status.lastSync;
+    }
+
+    if (elements.backupLast) {
+      elements.backupLast.textContent = state.status.lastBackup;
+      const wrap = elements.backupLast.closest('div');
+      if (wrap) wrap.hidden = !state.status.lastBackup;
+    }
+    if (elements.backupDestination) {
+      elements.backupDestination.textContent = state.backup.destino;
+    }
+    if (elements.backupTotal) {
+      elements.backupTotal.textContent = state.backup.total;
+    }
+
+    if (elements.net.endpoint) {
+      elements.net.endpoint.textContent = state.net.endpoint;
+    }
+    if (elements.net.regiao) {
+      elements.net.regiao.textContent = state.net.regiao;
+    }
+    if (elements.net.latencia) {
+      elements.net.latencia.textContent = state.net.lat;
+    }
+    if (elements.net.perdas) {
+      elements.net.perdas.textContent = state.net.perdas;
+    }
+
+    if (elements.sec.ultimo) {
+      elements.sec.ultimo.textContent = state.sec.ultimoAcesso;
+    }
+    if (elements.sec.sessoes) {
+      elements.sec.sessoes.textContent = String(state.sec.sessoes);
+    }
+    if (elements.sec.expira) {
+      elements.sec.expira.textContent = state.sec.tokenExpira;
+    }
+    if (elements.sec.escopos) {
+      elements.sec.escopos.textContent = state.sec.escopos;
+    }
+
+    updateToggleGroup('sync', state.status.syncOn);
+    updateToggleGroup('backup', state.status.backupOn);
+
+    renderEventsTable(state);
+  }
+
+  function updateToggleGroup(type, isOn) {
+    document
+      .querySelectorAll(`[data-toggle="${type}"]`)
+      .forEach((button) => {
+        button.setAttribute('aria-pressed', String(isOn));
+        const label = button.querySelector('.ac-pill-toggle__text');
+        if (label) {
+          label.textContent = isOn
+            ? button.dataset.labelOn
+            : button.dataset.labelOff;
+        }
+      });
+  }
+
+  function updateSortIndicators() {
+    elements.events.sortButtons.forEach((button) => {
+      const key = button.dataset.sort;
+      const indicator = button.querySelector('span');
+      if (!indicator) return;
+      if (uiState.sort.key === key) {
+        indicator.textContent = uiState.sort.direction === 'asc' ? '↑' : '↓';
+      } else {
+        indicator.textContent = '↕';
+      }
+    });
+  }
+
+  function renderEventsTable(state) {
+    if (!elements.events.body) return;
+    const searchTerm = uiState.eventsSearch.trim().toLowerCase();
+    const typeFilter = uiState.eventsType;
+    const filtered = state.eventos.filter((event) => {
+      const matchesType = typeFilter === 'all' || event.type === typeFilter;
+      if (!matchesType) return false;
+      if (!searchTerm) return true;
+      const haystack = `${event.time} ${event.type} ${event.msg} ${event.src}`.toLowerCase();
+      return haystack.includes(searchTerm);
+    });
+
+    const sorted = filtered.slice().sort((a, b) => {
+      const { key, direction } = uiState.sort;
+      const dir = direction === 'asc' ? 1 : -1;
       if (key === 'time') {
         const toMinutes = (value) => {
           const [hours, minutes] = value.split(':').map(Number);
           return hours * 60 + minutes;
         };
-        const diff = toMinutes(aText) - toMinutes(bText);
-        return newOrder === 'asc' ? diff : -diff;
+        return (toMinutes(a.time) - toMinutes(b.time)) * dir;
       }
-      const result = aText.localeCompare(bText, 'pt-BR', {
-        numeric: true,
-        sensitivity: 'base',
-      });
-      return newOrder === 'asc' ? result : -result;
-    };
+      return (
+        a[key].localeCompare(b[key], 'pt-BR', {
+          sensitivity: 'base',
+          numeric: true,
+        }) * dir
+      );
+    });
 
-    rows.sort(compare);
-    rows.forEach((row) => tbody.appendChild(row));
+    currentEventsView = sorted;
+
+    const tbody = elements.events.body;
+    tbody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    sorted.forEach((event) => {
+      const tr = document.createElement('tr');
+      tr.dataset.type = event.type.toLowerCase();
+      ['time', 'type', 'msg', 'src'].forEach((key) => {
+        const td = document.createElement('td');
+        td.textContent = event[key];
+        tr.appendChild(td);
+      });
+      fragment.appendChild(tr);
+    });
+    tbody.appendChild(fragment);
+    updateSortIndicators();
   }
 
-  function exportEvents() {
-    const table = document.getElementById('events-table');
-    const rows = Array.from(table.querySelectorAll('tbody tr'));
-    const csvRows = [];
-    const headers = Array.from(table.querySelectorAll('thead th')).map((th) =>
-      th.textContent.trim()
-    );
-    csvRows.push(headers.join(';'));
-    rows.forEach((row) => {
-      if (row.hidden) return;
-      const cols = Array.from(row.cells).map((cell) => {
-        const text = cell.textContent.trim();
-        if (text.includes(';') || text.includes('"')) {
-          return '"' + text.replace(/"/g, '""') + '"';
-        }
-        return text;
+  function renderLoginOverlay(state) {
+    if (!elements.login.form) return;
+    const fields = elements.login.fields;
+    if (fields.nome) fields.nome.value = state.user.nomeCompleto;
+    if (fields.email) fields.email.value = state.user.email;
+    if (fields.telefone) fields.telefone.value = state.user.telefone;
+    if (elements.login.title) {
+      elements.login.title.textContent = `Login — ${state.user.nome}`;
+    }
+
+    const tbody = elements.login.devicesBody;
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    state.sessions.devices.forEach((device) => {
+      const tr = document.createElement('tr');
+      const name = document.createElement('td');
+      name.textContent = device.nome;
+      const local = document.createElement('td');
+      local.textContent = device.local;
+      const last = document.createElement('td');
+      last.textContent = device.ultimoAcesso;
+      const actionsCell = document.createElement('td');
+      actionsCell.className = 'ac-table__actions';
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ac-btn';
+      btn.dataset.sessionDisconnect = device.id;
+      btn.textContent = 'Desconectar';
+      actionsCell.appendChild(btn);
+      tr.append(name, local, last, actionsCell);
+      fragment.appendChild(tr);
+    });
+    tbody.appendChild(fragment);
+  }
+
+  function renderSyncOverlay(state) {
+    if (elements.syncOverlay.title) {
+      elements.syncOverlay.title.textContent = `Sincronização — ${state.user.nome}`;
+    }
+    if (elements.syncOverlay.provider) {
+      elements.syncOverlay.provider.value = state.sync.provider;
+    }
+
+    const devicesBody = elements.syncOverlay.devicesBody;
+    if (devicesBody) {
+      devicesBody.innerHTML = '';
+      const fragment = document.createDocumentFragment();
+      state.sync.devices.forEach((device) => {
+        const tr = document.createElement('tr');
+        const name = document.createElement('td');
+        name.textContent = device.nome;
+        const last = document.createElement('td');
+        last.textContent = device.ultimaSync;
+        const toggleCell = document.createElement('td');
+        toggleCell.className = 'ac-table__actions';
+        const toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'ac-pill-toggle ac-pill-toggle--inline';
+        toggle.dataset.syncDevice = device.id;
+        toggle.dataset.labelOn = 'Habilitado';
+        toggle.dataset.labelOff = 'Desativado';
+        toggle.setAttribute('aria-pressed', String(device.habilitado));
+        const dot = document.createElement('span');
+        dot.className = 'ac-pill-toggle__dot';
+        dot.setAttribute('aria-hidden', 'true');
+        const label = document.createElement('span');
+        label.className = 'ac-pill-toggle__text';
+        label.textContent = device.habilitado ? 'Habilitado' : 'Desativado';
+        toggle.append(dot, label);
+        toggleCell.appendChild(toggle);
+        tr.append(name, last, toggleCell);
+        fragment.appendChild(tr);
       });
-      csvRows.push(cols.join(';'));
+      devicesBody.appendChild(fragment);
+    }
+
+    const historyBody = elements.syncOverlay.historyBody;
+    if (historyBody) {
+      historyBody.innerHTML = '';
+      const fragment = document.createDocumentFragment();
+      state.sync.historico.forEach((entry) => {
+        const tr = document.createElement('tr');
+        ['data', 'duracao', 'itens'].forEach((key) => {
+          const td = document.createElement('td');
+          td.textContent = entry[key];
+          tr.appendChild(td);
+        });
+        fragment.appendChild(tr);
+      });
+      historyBody.appendChild(fragment);
+    }
+  }
+
+  function renderBackupOverlay(state) {
+    if (elements.backupOverlay.title) {
+      elements.backupOverlay.title.textContent = `Backup — ${state.user.nome}`;
+    }
+    const historyBody = elements.backupOverlay.historyBody;
+    if (!historyBody) return;
+    historyBody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    state.backup.historico.forEach((entry) => {
+      const tr = document.createElement('tr');
+      ['data', 'tipo', 'tamanho', 'status'].forEach((key) => {
+        const td = document.createElement('td');
+        td.textContent = entry[key];
+        tr.appendChild(td);
+      });
+      fragment.appendChild(tr);
     });
-    const blob = new Blob([csvRows.join('\n')], {
-      type: 'text/csv;charset=utf-8;',
+    historyBody.appendChild(fragment);
+  }
+
+  function render(state) {
+    renderCard(state);
+    renderStage(state);
+    renderLoginOverlay(state);
+    renderSyncOverlay(state);
+    renderBackupOverlay(state);
+  }
+
+  function openPanel() {
+    if (!elements.card || !elements.stage || !elements.togglePanel) return;
+    panelOpen = true;
+    elements.card.classList.add('is-active');
+    elements.card.setAttribute('aria-current', 'page');
+    elements.togglePanel.setAttribute('aria-expanded', 'true');
+    elements.togglePanel.setAttribute('aria-label', 'Recolher painel de controle');
+    elements.stage.hidden = false;
+    if (elements.stageEmpty) {
+      elements.stageEmpty.hidden = true;
+    }
+    requestAnimationFrame(() => {
+      elements.stageTitle?.focus();
     });
+  }
+
+  function closePanel() {
+    if (!elements.card || !elements.stage || !elements.togglePanel) return;
+    panelOpen = false;
+    elements.card.classList.remove('is-active');
+    elements.card.removeAttribute('aria-current');
+    elements.togglePanel.setAttribute('aria-expanded', 'false');
+    elements.togglePanel.setAttribute('aria-label', 'Expandir painel de controle');
+    elements.stage.hidden = true;
+    if (elements.stageEmpty) {
+      elements.stageEmpty.hidden = false;
+    }
+  }
+
+  function togglePanelState() {
+    if (panelOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  }
+
+  function closeOverlay() {
+    if (!openOverlayId) return;
+    const overlay = elements.overlays[openOverlayId];
+    if (!overlay) return;
+    overlay.setAttribute('aria-hidden', 'true');
+    overlay.removeEventListener('click', handleOverlayBackdrop, true);
+    document.removeEventListener('keydown', handleOverlayEsc, true);
+    if (lastOverlayTrigger && typeof lastOverlayTrigger.focus === 'function') {
+      lastOverlayTrigger.focus();
+    }
+    openOverlayId = null;
+    lastOverlayTrigger = null;
+  }
+
+  function openOverlay(id, trigger) {
+    const overlay = elements.overlays[id];
+    if (!overlay || openOverlayId === id) return;
+    closeOverlay();
+    overlay.setAttribute('aria-hidden', 'false');
+    overlay.addEventListener('click', handleOverlayBackdrop, true);
+    document.addEventListener('keydown', handleOverlayEsc, true);
+    const title = overlay.querySelector('.ac-sheet__title');
+    requestAnimationFrame(() => {
+      title?.focus();
+    });
+    openOverlayId = id;
+    lastOverlayTrigger = trigger;
+  }
+
+  function handleOverlayEsc(event) {
+    if (event.key === 'Escape') {
+      closeOverlay();
+    }
+  }
+
+  function handleOverlayBackdrop(event) {
+    const sheet = event.currentTarget.querySelector('.ac-sheet');
+    if (sheet && !sheet.contains(event.target)) {
+      closeOverlay();
+    }
+  }
+
+  function addListener(target, type, handler, options) {
+    if (!target) return;
+    target.addEventListener(type, handler, options);
+    listeners.push(() => target.removeEventListener(type, handler, options));
+  }
+
+  function handleCardClick(event) {
+    if (event.target.closest('[data-toggle-panel]')) return;
+    openPanel();
+  }
+
+  function handleTogglePanelButton(event) {
+    event.stopPropagation();
+    togglePanelState();
+  }
+
+  function handleToggleClick(event) {
+    if (!actions) return;
+    const button = event.target.closest('[data-toggle]');
+    if (!button) return;
+    const type = button.dataset.toggle;
+    if (type === 'sync') {
+      actions.toggleSync(!activeStore.getState().status.syncOn);
+    } else if (type === 'backup') {
+      actions.toggleBackup(!activeStore.getState().status.backupOn);
+    }
+  }
+
+  function handleOverlayOpen(event) {
+    const trigger = event.target.closest('[data-overlay-open]');
+    if (!trigger) return;
+    const id = trigger.dataset.overlayOpen;
+    openOverlay(id, trigger);
+  }
+
+  function handleOverlayClose(event) {
+    if (event.target.closest('[data-overlay-close]')) {
+      closeOverlay();
+    }
+  }
+
+  function handleLoginActions(event) {
+    if (!actions) return;
+    const actionBtn = event.target.closest('[data-action]');
+    if (!actionBtn) return;
+    const action = actionBtn.dataset.action;
+    if (action === 'login-save') {
+      const formData = new FormData(elements.login.form);
+      actions.saveLogin({
+        nomeCompleto: formData.get('nome') || '',
+        email: formData.get('email') || '',
+        telefone: formData.get('telefone') || '',
+      });
+    } else if (action === 'login-logoff') {
+      actions.logoff();
+    } else if (action === 'sessions-kill') {
+      actions.killSessions();
+    } else if (action === 'login-change-password') {
+      actions.changePassword();
+    }
+  }
+
+  function handleSessionDisconnect(event) {
+    if (!actions) return;
+    const trigger = event.target.closest('[data-session-disconnect]');
+    if (!trigger) return;
+    actions.disconnectSession(trigger.dataset.sessionDisconnect);
+  }
+
+  function handleSyncProviderChange(event) {
+    if (!actions) return;
+    if (event.target === elements.syncOverlay.provider) {
+      actions.setSyncProvider(event.target.value);
+    }
+  }
+
+  function handleSyncDeviceToggle(event) {
+    if (!actions) return;
+    const button = event.target.closest('[data-sync-device]');
+    if (!button) return;
+    const current = button.getAttribute('aria-pressed') === 'true';
+    actions.toggleSyncDevice(button.dataset.syncDevice, !current);
+  }
+
+  function handleEventsFilter() {
+    if (!activeStore) return;
+    uiState.eventsSearch = elements.events.search?.value || '';
+    renderEventsTable(activeStore.getState());
+  }
+
+  function handleEventsType() {
+    if (!activeStore) return;
+    uiState.eventsType = elements.events.type?.value || 'all';
+    renderEventsTable(activeStore.getState());
+  }
+
+  function handleSort(event) {
+    if (!activeStore) return;
+    const button = event.target.closest('[data-sort]');
+    if (!button) return;
+    const key = button.dataset.sort;
+    if (uiState.sort.key === key) {
+      uiState.sort.direction = uiState.sort.direction === 'asc' ? 'desc' : 'asc';
+    } else {
+      uiState.sort.key = key;
+      uiState.sort.direction = 'asc';
+    }
+    renderEventsTable(activeStore.getState());
+  }
+
+  function escapeCsvValue(value) {
+    if (value.includes(";") || value.includes("\"") || value.includes("\\n")) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  }
+
+  function handleExportTrigger(event) {
+    if (event.target.closest('[data-export-events]')) {
+      handleExport();
+    }
+  }
+
+  function handleExport() {
+    if (!actions) return;
+    const rows = currentEventsView;
+    const header = ['Hora', 'Tipo', 'Mensagem', 'Origem'];
+    const csvRows = [header.join(';')];
+    rows.forEach((row) => {
+      csvRows.push(
+        [row.time, row.type, row.msg, row.src]
+          .map((value) => escapeCsvValue(String(value)))
+          .join(';')
+      );
+    });
+      const blob = new Blob([csvRows.join('\n')], {
+        type: 'text/csv;charset=utf-8;',
+      });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
@@ -136,143 +1047,103 @@
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
-    logStub('events/export', { rows: rows.length });
+    actions.exportEvents(rows.length);
   }
 
-  function openOverlay() {
-    if (overlay.getAttribute('aria-hidden') === 'false') return;
-    lastFocusedElement = document.activeElement;
-    overlay.setAttribute('aria-hidden', 'false');
-    document.addEventListener('keydown', handleOverlayKeydown);
-    overlay.addEventListener('click', handleOverlayBackdrop);
-    requestAnimationFrame(() => {
-      title.focus();
+  function handleMenuClick(event) {
+    event.stopPropagation();
+    menuOpen = !menuOpen;
+    if (elements.systemMenu) {
+      elements.systemMenu.setAttribute('aria-expanded', String(menuOpen));
+    }
+    if (elements.systemMenuPanel) {
+      elements.systemMenuPanel.hidden = !menuOpen;
+    }
+  }
+
+  function handleDocumentClick(event) {
+    if (!menuOpen) return;
+    if (
+      event.target.closest('[data-system-menu]') ||
+      event.target.closest('[data-system-menu-panel]')
+    ) {
+      return;
+    }
+    menuOpen = false;
+    if (elements.systemMenu) {
+      elements.systemMenu.setAttribute('aria-expanded', 'false');
+    }
+    if (elements.systemMenuPanel) {
+      elements.systemMenuPanel.hidden = true;
+    }
+  }
+
+  function mount(container, storeInstance) {
+    cacheElements(container);
+    if (!elements.card || !elements.stage) return;
+    activeStore = storeInstance || defaultStore;
+    activeServices = storeInstance ? createServices(activeStore) : defaultServices;
+    actions = createActions(activeStore, activeServices);
+
+    listeners.forEach((remove) => remove());
+    listeners = [];
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+
+    addListener(elements.card, 'click', handleCardClick);
+    addListener(elements.togglePanel, 'click', handleTogglePanelButton);
+    addListener(elements.app, 'click', handleToggleClick);
+    addListener(elements.app, 'click', handleOverlayOpen);
+    addListener(elements.app, 'click', handleOverlayClose);
+    addListener(elements.app, 'click', handleLoginActions);
+    addListener(elements.app, 'click', handleSessionDisconnect);
+    addListener(elements.app, 'click', handleSyncDeviceToggle);
+    addListener(elements.syncOverlay.provider, 'change', handleSyncProviderChange);
+    addListener(elements.events.search, 'input', handleEventsFilter);
+    addListener(elements.events.type, 'change', handleEventsType);
+    elements.events.sortButtons.forEach((button) => {
+      addListener(button, 'click', handleSort);
     });
-    logStub('auth/login/open', { from: 'tile-login' });
+    addListener(elements.app, 'click', handleExportTrigger);
+    addListener(elements.systemMenu, 'click', handleMenuClick);
+    addListener(document, 'click', handleDocumentClick);
+
+    unsubscribe = activeStore.subscribe(render);
+    render(activeStore.getState());
+    openPanel();
   }
 
-  function closeOverlay() {
-    if (overlay.getAttribute('aria-hidden') === 'true') return;
-    overlay.setAttribute('aria-hidden', 'true');
-    document.removeEventListener('keydown', handleOverlayKeydown);
-    overlay.removeEventListener('click', handleOverlayBackdrop);
-    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
-      lastFocusedElement.focus();
+  function unmount() {
+    closeOverlay();
+    listeners.forEach((remove) => remove());
+    listeners = [];
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
     }
+    activeStore = null;
+    activeServices = null;
+    actions = null;
+    menuOpen = false;
+    if (elements.systemMenu) {
+      elements.systemMenu.setAttribute('aria-expanded', 'false');
+    }
+    if (elements.systemMenuPanel) {
+      elements.systemMenuPanel.hidden = true;
+    }
+    closePanel();
   }
 
-  function handleOverlayKeydown(event) {
-    if (event.key === 'Escape') {
-      closeOverlay();
-    }
-  }
+  window.PainelMiniApp = {
+    mount,
+    unmount,
+    store: defaultStore,
+    services: defaultServices,
+  };
 
-  function handleOverlayBackdrop(event) {
-    if (!sheet.contains(event.target)) {
-      closeOverlay();
-    }
-  }
-
-  function bindOverlayActions() {
-    const openButton = document.querySelector('.js-login-open');
-    if (openButton) {
-      openButton.addEventListener('click', openOverlay);
-    }
-
-    overlay.querySelectorAll('.js-close').forEach((btn) => {
-      btn.addEventListener('click', closeOverlay);
-    });
-
-    overlay
-      .querySelectorAll('.js-disconnect')
-      .forEach((btn) =>
-        btn.addEventListener('click', () => {
-          const deviceId = btn.dataset.device;
-          logStub('devices/disconnect', { deviceId });
-        })
-      );
-
-    const saveButton = overlay.querySelector('.js-save');
-    if (saveButton) {
-      saveButton.addEventListener('click', () => {
-        const data = new FormData(loginForm);
-        const payload = {
-          name: data.get('name') || '',
-          email: data.get('email') || '',
-          phone: data.get('phone') || '',
-        };
-        logStub('auth/login/save', payload);
-      });
-    }
-
-    const changePassword = overlay.querySelector('.js-chgpass');
-    if (changePassword) {
-      changePassword.addEventListener('click', () => {
-        logStub('auth/login/save', { action: 'change-password' });
-      });
-    }
-
-    const logoffButton = overlay.querySelector('.js-logoff');
-    if (logoffButton) {
-      logoffButton.addEventListener('click', () => {
-        logStub('auth/session/logout', {});
-      });
-    }
-
-    const killAllButton = overlay.querySelector('.js-killall');
-    if (killAllButton) {
-      killAllButton.addEventListener('click', () => {
-        logStub('devices/disconnect', { deviceId: 'all' });
-      });
-    }
-  }
-
-  function bindToggles() {
-    const syncButton = document.querySelector('.js-toggle-sync');
-    const backupButton = document.querySelector('.js-toggle-backup');
-    if (syncButton) {
-      syncButton.addEventListener('click', () => toggleSync(syncButton));
-      toggleSync(syncButton, false);
-    }
-    if (backupButton) {
-      backupButton.addEventListener('click', () => toggleBackup(backupButton));
-      toggleBackup(backupButton, false);
-    }
-  }
-
-  function bindTableControls() {
-    document.querySelectorAll('.ac-th[data-key]').forEach((button) => {
-      button.addEventListener('click', () => {
-        sortTable(button.dataset.key, button);
-      });
-    });
-    const exportBtn = document.querySelector('.js-export');
-    if (exportBtn) {
-      exportBtn.addEventListener('click', exportEvents);
-    }
-  }
-
-  function bindPanelFocus() {
-    const focusButton = document.querySelector('.js-panel-focus');
-    const panel = document.getElementById('panel-controles');
-    const heading = document.getElementById('panel-title-controles');
-    if (!focusButton || !panel) return;
-
-    focusButton.addEventListener('click', () => {
-      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      if (heading && typeof heading.focus === 'function') {
-        heading.focus();
-      }
-      logStub('ui/panel/focus', { id: 'painel-controles' });
-    });
-  }
-
-  function init() {
-    bindToggles();
-    bindTableControls();
-    bindOverlayActions();
-    bindPanelFocus();
-  }
-
-  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('DOMContentLoaded', () => {
+    window.PainelMiniApp.mount();
+  });
 })();

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -20,273 +20,325 @@
             />
           </div>
           <div class="ac-headings">
-            <div class="ac-h1">Projeto Marco</div>
-            <div class="ac-h2">Painel de Controles</div>
+            <span class="ac-h1">Projeto Marco</span>
+            <span class="ac-h2">Painel de controles</span>
           </div>
         </div>
         <nav class="ac-breadcrumbs" aria-label="Localização">
-          <span id="breadcrumbs-primary">Painel de Controles</span>
+          <span id="breadcrumbs-primary">Painel de controles</span>
           <span class="ac-bullet" aria-hidden="true">•</span>
-          <span class="ac-muted" id="breadcrumbs-secondary">Visão integrada</span>
+          <span class="ac-muted" id="breadcrumbs-secondary">Visão detalhada</span>
         </nav>
         <div class="ac-appbar__actions">
-          <span class="ac-beta-pill" role="status">Versão beta</span>
           <button
-            class="ac-iconbtn js-panel-focus"
+            class="ac-iconbtn"
             type="button"
-            aria-label="Abrir Painel de Controles"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-label="Abrir menu do sistema"
+            data-system-menu
           >
-            <span aria-hidden="true">⚙️</span>
+            <span aria-hidden="true">⋯</span>
           </button>
+          <menu class="ac-appbar__menu" data-system-menu-panel hidden>
+            <button type="button">Preferências</button>
+            <button type="button">Atalhos</button>
+            <button type="button">Ajuda</button>
+          </menu>
         </div>
       </header>
 
       <div class="ac-layout">
         <nav class="ac-rail" aria-label="Miniapps">
-          <div class="ac-rail__stack" role="list" aria-label="Miniapps fixos">
-            <article class="ac-miniapp is-active" role="listitem" aria-current="page">
-              <section
-                class="ac-miniapp__card ac-card ac-card--panel"
-                aria-labelledby="miniapp-panel-title"
+          <article
+            class="ac-miniapp-card"
+            data-miniapp="painel"
+            role="listitem"
+            aria-labelledby="miniapp-title"
+          >
+            <header class="ac-miniapp-card__head">
+              <div class="ac-miniapp-card__titles">
+                <p id="miniapp-title" class="ac-miniapp-card__title">Painel de controle</p>
+                <p class="ac-miniapp-card__subtitle" data-user-name>Fabio</p>
+              </div>
+              <button
+                class="ac-iconbtn ac-iconbtn--small"
+                type="button"
+                aria-label="Expandir painel de controle"
+                aria-expanded="false"
+                data-toggle-panel
               >
-                <header class="ac-miniapp__header">
-                  <div class="ac-miniapp__legend">
-                    <h3 class="ac-miniapp__title" id="miniapp-panel-title">
-                      Painel de Controles
-                    </h3>
-                    <div class="ac-miniapp__meta">
-                      <span class="ac-miniapp__tag">Principal</span>
-                      <span class="ac-miniapp__subtitle" id="user-name">Fabio</span>
-                    </div>
-                  </div>
-                  <div
-                    class="ac-miniapp__shortcuts"
-                    role="group"
-                    aria-label="Acessos rápidos"
-                  >
-                    <button
-                      class="ac-miniapp__shortcut"
-                      type="button"
-                      aria-label="Abrir painel de login"
-                    >
-                      Login
-                    </button>
-                    <button
-                      class="ac-miniapp__shortcut"
-                      type="button"
-                      aria-label="Abrir painel de sincronização"
-                    >
-                      Sync
-                    </button>
-                    <button
-                      class="ac-miniapp__shortcut"
-                      type="button"
-                      aria-label="Abrir painel de backup"
-                    >
-                      Backup
-                    </button>
-                  </div>
-                </header>
-                <div class="ac-miniapp__summary" aria-live="polite">
-                  <div class="ac-miniapp__summary-item">
-                    <span class="ac-miniapp__label">Último login</span>
-                    <span id="meta-login" class="ac-miniapp__value"
-                      >05/10/2025 09:12:00</span
-                    >
-                  </div>
-                  <div class="ac-miniapp__summary-item">
-                    <span class="ac-miniapp__label">Último sync</span>
-                    <span id="meta-sync" class="ac-miniapp__value"></span>
-                  </div>
-                  <div class="ac-miniapp__summary-item">
-                    <span class="ac-miniapp__label">Último backup</span>
-                    <span id="meta-backup" class="ac-miniapp__value"></span>
-                  </div>
-                </div>
-                <div class="ac-badges ac-miniapp__health">
-                  <span class="ac-badge">
-                    <span id="kpi-conn" class="ac-dot ac-dot--ok" aria-hidden="true"></span>
-                    <span class="ac-label">Conexão</span>
-                  </span>
-                  <span class="ac-badge">
-                    <span id="kpi-sync" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
-                    <span class="ac-label">Sync</span>
-                  </span>
-                  <span class="ac-badge">
-                    <span id="kpi-backup" class="ac-dot ac-dot--crit" aria-hidden="true"></span>
-                    <span class="ac-label">Backup</span>
-                  </span>
-                </div>
-              </section>
-            </article>
+                <span aria-hidden="true">⋯</span>
+              </button>
+            </header>
 
-            <article class="ac-miniapp ac-miniapp--empty" role="listitem">
-              <div class="ac-miniapp__placeholder">Slot livre para miniapp</div>
-            </article>
+            <dl class="ac-miniapp-card__meta">
+              <div data-meta="login">
+                <dt>Último login</dt>
+                <dd data-meta-value="login">05/10/2025 09:12:00</dd>
+              </div>
+              <div data-meta="sync" hidden>
+                <dt>Último sync</dt>
+                <dd data-meta-value="sync"></dd>
+              </div>
+              <div data-meta="backup" hidden>
+                <dt>Último backup</dt>
+                <dd data-meta-value="backup"></dd>
+              </div>
+            </dl>
 
-            <article class="ac-miniapp ac-miniapp--empty" role="listitem">
-              <div class="ac-miniapp__placeholder">Slot livre para miniapp</div>
-            </article>
-          </div>
+            <div class="ac-miniapp-card__kpis" role="group" aria-label="Status do painel">
+              <span class="ac-kpi" data-kpi="conexao">
+                <span class="ac-dot ac-dot--ok" aria-hidden="true"></span>
+                <span>Conexão</span>
+              </span>
+              <span class="ac-kpi" data-kpi="sync">
+                <span class="ac-dot ac-dot--crit" aria-hidden="true"></span>
+                <span>Sync</span>
+              </span>
+              <span class="ac-kpi" data-kpi="backup">
+                <span class="ac-dot ac-dot--crit" aria-hidden="true"></span>
+                <span>Backup</span>
+              </span>
+            </div>
+          </article>
         </nav>
 
         <main class="ac-stage" role="main">
+          <div class="ac-stage__empty" data-stage-empty>
+            <p>Selecione uma etiqueta para abrir o miniapp.</p>
+          </div>
+
           <section
-            id="panel-controles"
-            aria-labelledby="panel-title-controles"
+            id="painel-stage"
+            class="ac-stage__panel"
+            aria-labelledby="painel-stage-title"
+            hidden
           >
-            <div class="ac-stage__head">
+            <header class="ac-stage__head">
               <div class="ac-stage__titles">
-                <h2
-                  id="panel-title-controles"
-                  class="ac-title-lg"
-                  tabindex="-1"
-                >
-                  Painel de Controles
+                <h2 id="painel-stage-title" class="ac-title-lg" tabindex="-1">
+                  Painel de controle
                 </h2>
-                <div class="ac-sub">Visão integrada</div>
+                <p class="ac-subtitle">Visão detalhada</p>
               </div>
-            </div>
+              <div class="ac-stage__toolbar" role="group" aria-label="Ações do painel">
+                <button
+                  class="ac-pill-toggle"
+                  type="button"
+                  data-toggle="sync"
+                  data-label-on="Sync ativada"
+                  data-label-off="Sync desativada"
+                  aria-pressed="false"
+                >
+                  <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+                  <span class="ac-pill-toggle__text">Sync desativada</span>
+                </button>
+                <button
+                  class="ac-pill-toggle"
+                  type="button"
+                  data-toggle="backup"
+                  data-label-on="Backup ativado"
+                  data-label-off="Backup desativado"
+                  aria-pressed="false"
+                >
+                  <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+                  <span class="ac-pill-toggle__text">Backup desativado</span>
+                </button>
+                <button class="ac-btn" type="button" data-export-events>
+                  Exportar CSV
+                </button>
+              </div>
+            </header>
 
             <div class="ac-grid">
-              <div class="ac-tile span-4">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Login</p>
-                </div>
-                <p class="ac-v">Usuário: <strong>Fabio</strong></p>
-                <p class="ac-v">Conta: <span>5Horas</span></p>
-                <p class="ac-v">Último acesso: <span>05/10/2025 09:12:00</span></p>
-                <div class="ac-actions">
-                  <button class="ac-btn js-login-open" type="button">Gerenciar login</button>
-                </div>
-              </div>
-              <div class="ac-tile span-4">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Sincronização</p>
-                </div>
-                <p class="ac-v">Última: <span id="v-sync"></span></p>
-                <p class="ac-v">Provedor: <span id="v-sync-provider">Google Drive</span></p>
-                <p class="ac-v">Pendências offline: <span id="v-pending">0</span></p>
-                <div class="ac-actions">
-                  <button class="ac-switch js-toggle-sync is-off" type="button" aria-pressed="false">
-                    <span class="ac-dot" aria-hidden="true"></span>
-                    <span class="ac-switch__label">Sync desativada</span>
+              <article class="ac-tile ac-tile--span-4" data-tile="login">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Login</h3>
+                  <button
+                    type="button"
+                    class="ac-iconbtn ac-iconbtn--small"
+                    data-overlay-open="login"
+                    aria-label="Abrir detalhes de login"
+                  >
+                    <span aria-hidden="true">⋯</span>
                   </button>
-                </div>
-              </div>
-              <div class="ac-tile span-4">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Backup</p>
-                </div>
-                <p class="ac-v">Último: <span id="v-backup"></span></p>
-                <p class="ac-v">Destino: <span id="v-backdest">Servidor 5Horas</span></p>
-                <p class="ac-v">Tamanho total: <span id="v-backsize">128 GB</span></p>
-                <div class="ac-actions">
-                  <button class="ac-switch js-toggle-backup is-off" type="button" aria-pressed="false">
-                    <span class="ac-dot" aria-hidden="true"></span>
-                    <span class="ac-switch__label">Backup desativado</span>
+                </header>
+                <dl class="ac-tile__meta">
+                  <div>
+                    <dt>Usuário</dt>
+                    <dd data-login-user>Fabio</dd>
+                  </div>
+                  <div>
+                    <dt>Conta</dt>
+                    <dd data-login-account>5Horas</dd>
+                  </div>
+                  <div>
+                    <dt>Último acesso</dt>
+                    <dd data-login-last>05/10/2025 09:12:00</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="ac-tile ac-tile--span-4" data-tile="sync">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Sincronização</h3>
+                  <button
+                    type="button"
+                    class="ac-iconbtn ac-iconbtn--small"
+                    data-overlay-open="sync"
+                    aria-label="Abrir detalhes de sincronização"
+                  >
+                    <span aria-hidden="true">⋯</span>
                   </button>
-                </div>
-              </div>
+                </header>
+                <dl class="ac-tile__meta">
+                  <div>
+                    <dt>Última</dt>
+                    <dd data-sync-last></dd>
+                  </div>
+                  <div>
+                    <dt>Provedor</dt>
+                    <dd data-sync-provider>Google Drive</dd>
+                  </div>
+                  <div>
+                    <dt>Pendências offline</dt>
+                    <dd data-sync-pending>0</dd>
+                  </div>
+                </dl>
+              </article>
 
-              <div class="ac-tile span-6">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Conectividade</p>
-                </div>
-                <p class="ac-v">Endpoint: <span class="ac-mono">api.marco.local</span></p>
-                <p class="ac-v">Região: <span>br-south</span> · Latência: <span>42ms</span> · Perdas: <span>0%</span></p>
-              </div>
-              <div class="ac-tile span-6">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Segurança</p>
-                </div>
-                <p class="ac-v">Sessões ativas: <span>3</span></p>
-                <p class="ac-v">Token expira: <span>2025-12-31 23:59</span></p>
-              </div>
+              <article class="ac-tile ac-tile--span-4" data-tile="backup">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Backup</h3>
+                  <button
+                    type="button"
+                    class="ac-iconbtn ac-iconbtn--small"
+                    data-overlay-open="backup"
+                    aria-label="Abrir detalhes de backup"
+                  >
+                    <span aria-hidden="true">⋯</span>
+                  </button>
+                </header>
+                <dl class="ac-tile__meta">
+                  <div>
+                    <dt>Último</dt>
+                    <dd data-backup-last></dd>
+                  </div>
+                  <div>
+                    <dt>Destino</dt>
+                    <dd data-backup-destination>Servidor 5Horas</dd>
+                  </div>
+                  <div>
+                    <dt>Tamanho total</dt>
+                    <dd data-backup-total>—</dd>
+                  </div>
+                </dl>
+              </article>
 
-              <div class="ac-tile span-12">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Eventos</p>
-                </div>
-                <div class="ac-table-wrap" id="events-wrap">
-                  <table class="ac-table" id="events-table">
+              <article class="ac-tile ac-tile--span-6" data-tile="net">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Conectividade</h3>
+                </header>
+                <dl class="ac-tile__meta">
+                  <div>
+                    <dt>Endpoint</dt>
+                    <dd data-net-endpoint class="ac-mono">api.marco.local</dd>
+                  </div>
+                  <div>
+                    <dt>Região</dt>
+                    <dd data-net-region>br-south</dd>
+                  </div>
+                  <div>
+                    <dt>Latência</dt>
+                    <dd data-net-latency>42ms</dd>
+                  </div>
+                  <div>
+                    <dt>Perdas</dt>
+                    <dd data-net-loss>0%</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="ac-tile ac-tile--span-6" data-tile="sec">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Segurança</h3>
+                </header>
+                <dl class="ac-tile__meta">
+                  <div>
+                    <dt>Último acesso</dt>
+                    <dd data-sec-last>05/10/2025 09:12:00</dd>
+                  </div>
+                  <div>
+                    <dt>Sessões ativas</dt>
+                    <dd data-sec-sessions>3</dd>
+                  </div>
+                  <div>
+                    <dt>Token expira</dt>
+                    <dd data-sec-expire>31/12/2025 23:59</dd>
+                  </div>
+                  <div>
+                    <dt>Escopos</dt>
+                    <dd data-sec-scopes>read:store, write:sync</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="ac-tile ac-tile--span-12" data-tile="events">
+                <header class="ac-tile__head">
+                  <h3 class="ac-tile__title">Eventos</h3>
+                </header>
+                <form class="ac-events-filter" data-events-filter role="search">
+                  <label class="ac-field">
+                    <span class="ac-field__label">Filtro rápido</span>
+                    <input
+                      type="search"
+                      placeholder="Buscar (ex.: backup, login, 09:40)"
+                      autocomplete="off"
+                      data-events-search
+                    />
+                  </label>
+                  <label class="ac-field">
+                    <span class="ac-field__label">Tipo</span>
+                    <select data-events-type>
+                      <option value="all">Todos os tipos</option>
+                      <option value="Backup">Backup</option>
+                      <option value="Sync">Sync</option>
+                      <option value="Login">Login</option>
+                      <option value="Ping">Ping</option>
+                    </select>
+                  </label>
+                </form>
+                <div class="ac-table-wrap" data-events-table-wrap>
+                  <table class="ac-table" data-events-table>
                     <thead>
                       <tr>
                         <th scope="col">
-                          <button class="ac-th" type="button" data-key="time">Hora <span class="arrow">↕</span></button>
+                          <button type="button" class="ac-th" data-sort="time">
+                            Hora <span aria-hidden="true">↕</span>
+                          </button>
                         </th>
                         <th scope="col">
-                          <button class="ac-th" type="button" data-key="type">Tipo <span class="arrow">↕</span></button>
+                          <button type="button" class="ac-th" data-sort="type">
+                            Tipo <span aria-hidden="true">↕</span>
+                          </button>
                         </th>
                         <th scope="col">
-                          <button class="ac-th" type="button" data-key="msg">Mensagem <span class="arrow">↕</span></button>
+                          <button type="button" class="ac-th" data-sort="msg">
+                            Mensagem <span aria-hidden="true">↕</span>
+                          </button>
                         </th>
                         <th scope="col">
-                          <button class="ac-th" type="button" data-key="src">Origem <span class="arrow">↕</span></button>
+                          <button type="button" class="ac-th" data-sort="src">
+                            Origem <span aria-hidden="true">↕</span>
+                          </button>
                         </th>
                       </tr>
                     </thead>
-                    <tbody>
-                      <tr data-type="backup">
-                        <td>09:41</td>
-                        <td>Backup</td>
-                        <td>Backup concluído em 12s</td>
-                        <td>agente#1</td>
-                      </tr>
-                      <tr data-type="sync">
-                        <td>09:40</td>
-                        <td>Sync</td>
-                        <td>Sync aplicado: 3 registros</td>
-                        <td>cliente-web</td>
-                      </tr>
-                      <tr data-type="login">
-                        <td>09:12</td>
-                        <td>Login</td>
-                        <td>Login bem-sucedido</td>
-                        <td>Fabio · 187.22.10.4</td>
-                      </tr>
-                      <tr data-type="ping">
-                        <td>08:55</td>
-                        <td>Ping</td>
-                        <td>Ping servidor: 41ms</td>
-                        <td>probe</td>
-                      </tr>
-                    </tbody>
+                    <tbody data-events-body></tbody>
                   </table>
                 </div>
-                <div class="ac-actions">
-                  <button class="ac-btn js-export" type="button">Exportar CSV</button>
-                </div>
-              </div>
-
-              <div class="ac-tile span-6">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Marketplace</p>
-                  <span class="ac-status ac-status--ok">Catálogo online</span>
-                </div>
-                <p class="ac-v">Miniapps disponíveis e instalados recentemente.</p>
-                <ul class="ac-list">
-                  <li><strong>Novos:</strong> Auditoria Fiscal · Dashboard Financeiro</li>
-                  <li><strong>Atualizados:</strong> CRM Field · Inventário Mobile</li>
-                  <li><strong>Disponibilidade:</strong> 24 miniapps ativos</li>
-                </ul>
-              </div>
-
-              <div class="ac-tile span-6">
-                <div class="ac-tile__head">
-                  <p class="ac-tile__title">Configurações do Sistema</p>
-                  <span class="ac-status">Padrões monitorados</span>
-                </div>
-                <p class="ac-v">Preferências centrais consolidadas no painel.</p>
-                <ul class="ac-list">
-                  <li>Idioma: Português (Brasil)</li>
-                  <li>Fuso horário: GMT-3</li>
-                  <li>Atualizações automáticas: Ativas</li>
-                </ul>
-                <div class="ac-actions">
-                  <button class="ac-btn ac-btn--ghost" type="button">Abrir preferências</button>
-                </div>
-              </div>
+              </article>
             </div>
           </section>
         </main>
@@ -297,75 +349,206 @@
       </footer>
     </div>
 
-    <div class="ac-overlay" id="login-overlay" aria-hidden="true">
-      <section class="ac-sheet" role="dialog" aria-modal="true" aria-labelledby="login-sheet-title">
+    <div class="ac-overlay" data-overlay="login" aria-hidden="true">
+      <section
+        class="ac-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="login-dialog-title"
+      >
         <header class="ac-sheet__head">
-          <h4 id="login-sheet-title" class="ac-sheet__title" tabindex="-1">Login — Fabio</h4>
-          <button class="ac-sheet__close js-close" type="button" aria-label="Fechar">✖</button>
+          <h4 id="login-dialog-title" class="ac-sheet__title" tabindex="-1">
+            Login — Fabio
+          </h4>
+          <button
+            class="ac-iconbtn ac-iconbtn--small"
+            type="button"
+            aria-label="Fechar"
+            data-overlay-close
+          >
+            ✖
+          </button>
         </header>
         <div class="ac-sheet__body">
-          <form id="login-form" novalidate>
-            <div class="ac-form-grid">
-              <label class="ac-field">
-                <span class="ac-field__label">Nome completo</span>
-                <input id="login-name" name="name" type="text" value="Fabio Henrique" autocomplete="name" />
-              </label>
-              <label class="ac-field">
-                <span class="ac-field__label">E-mail</span>
-                <input id="login-email" name="email" type="email" value="fabio@5horas.com" autocomplete="email" />
-              </label>
-              <label class="ac-field">
-                <span class="ac-field__label">Telefone</span>
-                <input id="login-phone" name="phone" type="tel" value="+55 11 98888-0000" autocomplete="tel" />
-              </label>
-            </div>
+          <form class="ac-form-grid" data-login-form autocomplete="off">
+            <label class="ac-field">
+              <span class="ac-field__label">Nome completo</span>
+              <input name="nome" type="text" required />
+            </label>
+            <label class="ac-field">
+              <span class="ac-field__label">E-mail</span>
+              <input name="email" type="email" required />
+            </label>
+            <label class="ac-field">
+              <span class="ac-field__label">Telefone</span>
+              <input name="telefone" type="tel" />
+            </label>
+            <label class="ac-field">
+              <span class="ac-field__label">Senha</span>
+              <input name="senha" type="password" value="********" autocomplete="new-password" />
+            </label>
           </form>
-          <div class="ac-sheet__section">
+
+          <section class="ac-sheet__section">
             <h5 class="ac-sheet__subtitle">Dispositivos conectados</h5>
-            <table class="ac-table ac-table--compact">
-              <thead>
-                <tr>
-                  <th scope="col">Dispositivo</th>
-                  <th scope="col">Último acesso</th>
-                  <th scope="col">IP</th>
-                  <th scope="col" class="ac-table__actions">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Notebook Fabio</td>
-                  <td>05/10/2025 09:12:00</td>
-                  <td>187.22.10.4</td>
-                  <td class="ac-table__actions">
-                    <button class="ac-btn ac-btn--ghost js-disconnect" type="button" data-device="notebook-fabio">Desconectar</button>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Cliente web</td>
-                  <td>05/10/2025 09:40:00</td>
-                  <td>200.155.1.12</td>
-                  <td class="ac-table__actions">
-                    <button class="ac-btn ac-btn--ghost js-disconnect" type="button" data-device="cliente-web">Desconectar</button>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Mobile iOS</td>
-                  <td>04/10/2025 22:05:11</td>
-                  <td>189.60.33.9</td>
-                  <td class="ac-table__actions">
-                    <button class="ac-btn ac-btn--ghost js-disconnect" type="button" data-device="mobile-ios">Desconectar</button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+            <div class="ac-table-wrap ac-table-wrap--inner">
+              <table class="ac-table ac-table--compact" data-login-devices>
+                <thead>
+                  <tr>
+                    <th scope="col">Dispositivo</th>
+                    <th scope="col">Local</th>
+                    <th scope="col">Último acesso</th>
+                    <th scope="col" class="ac-table__actions">Ação</th>
+                  </tr>
+                </thead>
+                <tbody data-login-devices-body></tbody>
+              </table>
+            </div>
+          </section>
         </div>
         <footer class="ac-sheet__foot">
-          <button class="ac-btn js-save" type="button">Salvar</button>
-          <button class="ac-btn js-chgpass" type="button">Trocar senha</button>
-          <button class="ac-btn js-logoff" type="button">Fazer logoff</button>
-          <button class="ac-btn js-killall" type="button">Desconectar todos os dispositivos</button>
+          <button class="ac-btn" type="button" data-action="login-save">Salvar</button>
+          <button class="ac-btn" type="button" data-action="login-change-password">
+            Trocar senha
+          </button>
+          <button class="ac-btn" type="button" data-action="login-logoff">Fazer logoff</button>
+          <button class="ac-btn" type="button" data-action="sessions-kill">Desconectar todos os dispositivos</button>
         </footer>
+      </section>
+    </div>
+
+    <div class="ac-overlay" data-overlay="sync" aria-hidden="true">
+      <section
+        class="ac-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sync-dialog-title"
+      >
+        <header class="ac-sheet__head">
+          <h4 id="sync-dialog-title" class="ac-sheet__title" tabindex="-1">
+            Sincronização — Fabio
+          </h4>
+          <button
+            class="ac-iconbtn ac-iconbtn--small"
+            type="button"
+            aria-label="Fechar"
+            data-overlay-close
+          >
+            ✖
+          </button>
+        </header>
+        <div class="ac-sheet__body">
+          <section class="ac-sheet__section ac-sheet__section--stack">
+            <button
+              class="ac-pill-toggle"
+              type="button"
+              data-toggle="sync"
+              data-label-on="Sync ativada"
+              data-label-off="Sync desativada"
+              aria-pressed="false"
+            >
+              <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+              <span class="ac-pill-toggle__text">Sync desativada</span>
+            </button>
+            <label class="ac-field">
+              <span class="ac-field__label">Provedor</span>
+              <select data-sync-provider>
+                <option value="Google Drive">Google Drive</option>
+                <option value="OneDrive">OneDrive</option>
+              </select>
+            </label>
+          </section>
+
+          <section class="ac-sheet__section">
+            <h5 class="ac-sheet__subtitle">Dispositivos sincronizados</h5>
+            <div class="ac-table-wrap ac-table-wrap--inner">
+              <table class="ac-table ac-table--compact" data-sync-devices>
+                <thead>
+                  <tr>
+                    <th scope="col">Dispositivo</th>
+                    <th scope="col">Última sincronização</th>
+                    <th scope="col">Habilitado</th>
+                  </tr>
+                </thead>
+                <tbody data-sync-devices-body></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="ac-sheet__section">
+            <h5 class="ac-sheet__subtitle">Últimas sincronizações</h5>
+            <div class="ac-table-wrap ac-table-wrap--inner">
+              <table class="ac-table ac-table--compact" data-sync-history>
+                <thead>
+                  <tr>
+                    <th scope="col">Data</th>
+                    <th scope="col">Duração</th>
+                    <th scope="col">Itens</th>
+                  </tr>
+                </thead>
+                <tbody data-sync-history-body></tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+
+    <div class="ac-overlay" data-overlay="backup" aria-hidden="true">
+      <section
+        class="ac-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="backup-dialog-title"
+      >
+        <header class="ac-sheet__head">
+          <h4 id="backup-dialog-title" class="ac-sheet__title" tabindex="-1">
+            Backup — Fabio
+          </h4>
+          <button
+            class="ac-iconbtn ac-iconbtn--small"
+            type="button"
+            aria-label="Fechar"
+            data-overlay-close
+          >
+            ✖
+          </button>
+        </header>
+        <div class="ac-sheet__body">
+          <section class="ac-sheet__section ac-sheet__section--stack">
+            <button
+              class="ac-pill-toggle"
+              type="button"
+              data-toggle="backup"
+              data-label-on="Backup ativado"
+              data-label-off="Backup desativado"
+              aria-pressed="false"
+            >
+              <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+              <span class="ac-pill-toggle__text">Backup desativado</span>
+            </button>
+            <p class="ac-sheet__status">
+              Servidor seguro 5Horas • Criptografia automática
+            </p>
+          </section>
+
+          <section class="ac-sheet__section">
+            <h5 class="ac-sheet__subtitle">Últimos backups</h5>
+            <div class="ac-table-wrap ac-table-wrap--inner">
+              <table class="ac-table ac-table--compact" data-backup-history>
+                <thead>
+                  <tr>
+                    <th scope="col">Data</th>
+                    <th scope="col">Tipo</th>
+                    <th scope="col">Tamanho</th>
+                    <th scope="col">Status</th>
+                  </tr>
+                </thead>
+                <tbody data-backup-history-body></tbody>
+              </table>
+            </div>
+          </section>
+        </div>
       </section>
     </div>
   </body>


### PR DESCRIPTION
## Resumo
- recria o layout do MiniApp “Painel de controle” com etiqueta dinâmica, toolbar completa e palco responsivo
- adiciona store reativa, serviços mock e ações sincronizadas entre rail, palco e overlays
- implementa overlays acessíveis para Login, Sync e Backup, além de tabela de eventos com filtro, ordenação e exportação CSV
- atualiza estilos globais para o novo grid, pills coloridas e tabelas com cabeçalho sticky, ajustando também o README

## Testes
- inspeção manual no navegador (sem testes automatizados)

------
https://chatgpt.com/codex/tasks/task_e_68e2eab970a08320bbf76cc9c6746563