### PR TITLE
Adjust tablet grid layout

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -477,9 +477,17 @@ select {
 }
 
 @media (max-width: 1200px) {
+  .ac-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
   .ac-tile--span-4,
   .ac-tile--span-6 {
     grid-column: span 6;
+  }
+
+  .ac-tile--span-4 {
+    grid-column: span 3;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the tablet breakpoint grid to use two wider columns
- adjust tile spans to keep half-width cards readable on tablets

## Testing
- visual inspection in tablet landscape (1024×768) and portrait (834×1112) viewports

------
https://chatgpt.com/codex/tasks/task_e_68e2f5e17ba08320aabfa02a5908eec6