### PR TITLE
Add panel close control to stage header

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -381,6 +381,17 @@ select {
   align-items: flex-start;
 }
 
+.ac-stage__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+}
+
+.ac-stage__close {
+  flex-shrink: 0;
+}
+
 .ac-stage__titles {
   display: grid;
   gap: 4px;

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -419,6 +419,7 @@
       stage,
       stageEmpty,
       stageTitle: stage?.querySelector('#painel-stage-title') || null,
+      stageClose: stage?.querySelector('[data-stage-close]') || null,
       loginUser: stage?.querySelector('[data-login-user]') || null,
       loginAccount: stage?.querySelector('[data-login-account]') || null,
       loginLast: stage?.querySelector('[data-login-last]') || null,
@@ -907,6 +908,11 @@
     togglePanelState();
   }
 
+  function handleStageClose(event) {
+    event.preventDefault();
+    closePanel();
+  }
+
   function handleToggleClick(event) {
     if (!actions) return;
     const button = event.target.closest('[data-toggle]');
@@ -1084,6 +1090,7 @@
 
     addListener(elements.card, 'click', handleCardClick);
     addListener(elements.togglePanel, 'click', handleTogglePanelButton);
+    addListener(elements.stageClose, 'click', handleStageClose);
     addListener(elements.app, 'click', handleToggleClick);
     addListener(elements.app, 'click', handleOverlayOpen);
     addListener(elements.app, 'click', handleOverlayClose);

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -125,31 +125,41 @@
                 </h2>
                 <p class="ac-subtitle">Visão detalhada</p>
               </div>
-              <div class="ac-stage__toolbar" role="group" aria-label="Ações do painel">
+              <div class="ac-stage__actions">
+                <div class="ac-stage__toolbar" role="group" aria-label="Ações do painel">
+                  <button
+                    class="ac-pill-toggle"
+                    type="button"
+                    data-toggle="sync"
+                    data-label-on="Sync ativada"
+                    data-label-off="Sync desativada"
+                    aria-pressed="false"
+                  >
+                    <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+                    <span class="ac-pill-toggle__text">Sync desativada</span>
+                  </button>
+                  <button
+                    class="ac-pill-toggle"
+                    type="button"
+                    data-toggle="backup"
+                    data-label-on="Backup ativado"
+                    data-label-off="Backup desativado"
+                    aria-pressed="false"
+                  >
+                    <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
+                    <span class="ac-pill-toggle__text">Backup desativado</span>
+                  </button>
+                  <button class="ac-btn" type="button" data-export-events>
+                    Exportar CSV
+                  </button>
+                </div>
                 <button
-                  class="ac-pill-toggle"
+                  class="ac-iconbtn ac-iconbtn--small ac-stage__close"
                   type="button"
-                  data-toggle="sync"
-                  data-label-on="Sync ativada"
-                  data-label-off="Sync desativada"
-                  aria-pressed="false"
+                  aria-label="Fechar painel de controle"
+                  data-stage-close
                 >
-                  <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
-                  <span class="ac-pill-toggle__text">Sync desativada</span>
-                </button>
-                <button
-                  class="ac-pill-toggle"
-                  type="button"
-                  data-toggle="backup"
-                  data-label-on="Backup ativado"
-                  data-label-off="Backup desativado"
-                  aria-pressed="false"
-                >
-                  <span class="ac-pill-toggle__dot" aria-hidden="true"></span>
-                  <span class="ac-pill-toggle__text">Backup desativado</span>
-                </button>
-                <button class="ac-btn" type="button" data-export-events>
-                  Exportar CSV
+                  <span aria-hidden="true">×</span>
                 </button>
               </div>
             </header>


### PR DESCRIPTION
## Summary
- add a close button to the stage header next to the toolbar for accessibility
- hook the new control into the cached elements and closePanel handler
- tweak header layout styles to keep the toolbar and close button aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3965f984883208094c1324a98e26e