### PR TITLE
Allow toggling panel from card click

### DIFF
--- a/appbase/app.js
+++ b/appbase/app.js
@@ -898,7 +898,9 @@
 
   function handleCardClick(event) {
     if (event.target.closest('[data-toggle-panel]')) return;
-    if (!panelOpen) {
+    if (panelOpen) {
+      togglePanelState();
+    } else {
       openPanel();
     }
   }


### PR DESCRIPTION
## Summary
- allow clicking the dashboard card to close the panel when it is already open while retaining the toggle button exception

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e398fe76648320841fae40e3fdcf7e