### PR TITLE
Configure Playwright static server helper

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,19 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: 'tests',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'node tests/static-server.js',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/panel-card.spec.js
+++ b/tests/panel-card.spec.js
@@ -1,94 +1,7 @@
 const { test, expect } = require('@playwright/test');
-const http = require('http');
-const path = require('path');
-const fs = require('fs');
-
-const MIME_TYPES = {
-  '.html': 'text/html',
-  '.css': 'text/css',
-  '.js': 'text/javascript',
-  '.json': 'application/json',
-  '.png': 'image/png',
-  '.svg': 'image/svg+xml',
-  '.ico': 'image/x-icon',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.webp': 'image/webp',
-  '.woff': 'font/woff',
-  '.woff2': 'font/woff2',
-};
-
-async function startStaticServer(rootDir) {
-  const server = http.createServer(async (req, res) => {
-    try {
-      const requestUrl = new URL(req.url, 'http://localhost');
-      const pathname = decodeURIComponent(requestUrl.pathname);
-      let filePath = path.resolve(rootDir, `.${pathname}`);
-
-      if (!filePath.startsWith(rootDir)) {
-        res.writeHead(403);
-        res.end();
-        return;
-      }
-
-      let stat = await fs.promises.stat(filePath).catch(() => null);
-
-      if (stat && stat.isDirectory()) {
-        filePath = path.join(filePath, 'index.html');
-        stat = await fs.promises.stat(filePath).catch(() => null);
-      }
-
-      if (!stat && (pathname === '/' || pathname.endsWith('/'))) {
-        filePath = path.join(path.resolve(rootDir, `.${pathname}`), 'index.html');
-        stat = await fs.promises.stat(filePath).catch(() => null);
-      }
-
-      if (!stat) {
-        throw Object.assign(new Error('Not found'), { code: 'ENOENT' });
-      }
-
-      const data = await fs.promises.readFile(filePath);
-      const ext = path.extname(filePath);
-      const contentType = MIME_TYPES[ext] || 'application/octet-stream';
-      res.writeHead(200, {
-        'Content-Type': contentType,
-        'Cache-Control': 'no-store',
-      });
-      res.end(data);
-    } catch (error) {
-      if (error.code === 'ENOENT') {
-        res.writeHead(404);
-        res.end('Not found');
-      } else {
-        res.writeHead(500);
-        res.end('Server error');
-      }
-    }
-  });
-
-  await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve);
-  });
-
-  const { port } = server.address();
-  return { server, port };
-}
-
-async function closeServer(server) {
-  if (!server) return;
-  await new Promise((resolve, reject) => {
-    server.close((error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
-}
-
-let serverInstance;
-let baseURL;
 
 async function resetApp(page) {
-  await page.goto(`${baseURL}/index.html`);
+  await page.goto('/index.html');
   await page.evaluate(() => window.localStorage.clear());
   await page.reload();
 }
@@ -117,17 +30,6 @@ async function registerUser(page, { nome, email, telefone = '' }) {
   await closeButton.click();
   await expect(overlay).toHaveAttribute('aria-hidden', 'true');
 }
-
-test.beforeAll(async () => {
-  const rootDir = path.resolve(__dirname, '..', 'appbase');
-  const { server, port } = await startStaticServer(rootDir);
-  serverInstance = server;
-  baseURL = `http://127.0.0.1:${port}`;
-});
-
-test.afterAll(async () => {
-  await closeServer(serverInstance);
-});
 
 test('cadastro atualiza etiqueta, painel e breadcrumbs', async ({ page }) => {
   await resetApp(page);

--- a/tests/static-server.js
+++ b/tests/static-server.js
@@ -1,0 +1,130 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+function resolveFile(rootDir, pathname) {
+  let filePath = path.resolve(rootDir, `.${pathname}`);
+
+  if (!filePath.startsWith(rootDir)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+async function serveFile(res, filePath) {
+  const data = await fs.promises.readFile(filePath);
+  const ext = path.extname(filePath);
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+  res.writeHead(200, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-store',
+  });
+  res.end(data);
+}
+
+async function handleRequest(rootDir, req, res) {
+  try {
+    const requestUrl = new URL(req.url, 'http://localhost');
+    const pathname = decodeURIComponent(requestUrl.pathname);
+
+    let filePath = resolveFile(rootDir, pathname);
+
+    if (!filePath) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
+
+    let stat = await fs.promises.stat(filePath).catch(() => null);
+
+    if (stat && stat.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+      stat = await fs.promises.stat(filePath).catch(() => null);
+    }
+
+    if (!stat && (pathname === '/' || pathname.endsWith('/'))) {
+      filePath = path.join(resolveFile(rootDir, pathname) || '', 'index.html');
+      stat = await fs.promises.stat(filePath).catch(() => null);
+    }
+
+    if (!stat) {
+      throw Object.assign(new Error('Not found'), { code: 'ENOENT' });
+    }
+
+    await serveFile(res, filePath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(500);
+      res.end('Server error');
+    }
+  }
+}
+
+async function createStaticServer({
+  port = Number(process.env.PORT) || 4173,
+  host = '127.0.0.1',
+} = {}) {
+  const rootDir = path.resolve(__dirname, '..', 'appbase');
+  const server = http.createServer((req, res) => {
+    handleRequest(rootDir, req, res);
+  });
+
+  await new Promise((resolve) => {
+    server.listen(port, host, resolve);
+  });
+
+  const close = () =>
+    new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+  return {
+    server,
+    port: server.address().port,
+    host,
+    close,
+  };
+}
+
+module.exports = { createStaticServer };
+
+if (require.main === module) {
+  createStaticServer()
+    .then(({ port, host, close }) => {
+      const shutdown = async () => {
+        await close();
+        process.exit(0);
+      };
+
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
+
+      console.log(`Static server running at http://${host}:${port}`);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- extract the ad-hoc HTTP helper into `tests/static-server.js`
- configure Playwright to start the static server and expose a base URL via `playwright.config.js`
- update the panel card spec to rely on the configured base URL

## Testing
- `npm test` *(fails: Host system is missing dependencies to run Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68e4369247988320be15616dedaf0728