### PR TITLE
Ajusta comportamento de painel e overlay do AppBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ MiniApp “Painel de controle”.
    - O `index.html` na raiz redireciona automaticamente para essa versão.
    - Para consultar a versão legada modular, abra `src/index.html` diretamente.
 3. Ao abrir, o palco permanece vazio até que um usuário seja cadastrado. Use o
-   botão “Começar cadastro” ou clique na etiqueta “Painel de controle” para
-   abrir o formulário de Login.
+   botão “Começar cadastro” para acessar o formulário de Login. A etiqueta
+   “Painel de controle” apenas abre o painel principal, que expõe o botão ⋯
+   interno para reabrir o overlay quando necessário.
 4. Os dados cadastrados são guardados apenas no `localStorage` do navegador. Ao
    salvar, o painel é exibido com o nome, a conta derivada do e-mail e a data do
    último acesso, e essas informações permanecem disponíveis em visitas
    futuras.
 5. Utilize o botão ⋯ da etiqueta para recolher/exibir o painel quando houver um
-   cadastro ativo. O overlay de Login pode ser reaberto para editar o usuário a
-   qualquer momento.
+   cadastro ativo. Para editar o cadastro, abra o painel pela etiqueta e acione
+   novamente o botão ⋯ disponível dentro da tile de Login (ou o CTA do estado
+   vazio do palco) para reabrir o overlay.
 6. Dentro do painel do miniapp, utilize os botões “Encerrar sessão” e “Encerrar e
    remover dados” para registrar logoff preservando ou eliminando as
    informações. O histórico de acessos exibe os eventos mais recentes de login e

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -270,7 +270,7 @@
     const hasData = hasUser();
     const loggedIn = isLoggedIn();
     if (elements.card) {
-      elements.card.classList.toggle('is-active', loggedIn && panelOpen);
+      elements.card.classList.toggle('is-active', panelOpen);
     }
     if (elements.cardSubtitle) {
       elements.cardSubtitle.textContent = hasData
@@ -290,10 +290,9 @@
 
   function updateStage() {
     const hasData = hasUser();
-    const loggedIn = isLoggedIn();
 
     if (elements.stageEmpty) {
-      elements.stageEmpty.hidden = loggedIn;
+      elements.stageEmpty.hidden = panelOpen;
     }
 
     if (elements.stageEmptyMessage) {
@@ -309,17 +308,13 @@
     }
 
     if (elements.toggleButton) {
-      const expanded = loggedIn && panelOpen;
+      const expanded = panelOpen;
       elements.toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       elements.toggleButton.disabled = !hasData;
     }
 
     if (elements.stage) {
-      if (loggedIn && panelOpen) {
-        elements.stage.hidden = false;
-      } else {
-        elements.stage.hidden = true;
-      }
+      elements.stage.hidden = !panelOpen;
     }
 
     if (elements.loginUser) {
@@ -557,11 +552,7 @@
     });
   }
 
-  function openPanel(trigger) {
-    if (!isLoggedIn()) {
-      openLoginOverlay(trigger);
-      return;
-    }
+  function openPanel() {
     const wasClosed = !panelOpen;
     panelOpen = true;
     updateUI();
@@ -570,11 +561,7 @@
     }
   }
 
-  function togglePanel(trigger) {
-    if (!isLoggedIn()) {
-      openLoginOverlay(trigger);
-      return;
-    }
+  function togglePanel() {
     panelOpen = !panelOpen;
     updateUI();
     if (panelOpen) {
@@ -589,7 +576,7 @@
     if (toggle && (event.target === toggle || toggle.contains(event.target))) {
       return;
     }
-    openPanel(elements.toggleButton || null);
+    openPanel();
   }
 
   function handleStageClose() {
@@ -653,7 +640,7 @@
   if (elements.toggleButton) {
     elements.toggleButton.addEventListener('click', (event) => {
       event.preventDefault();
-      togglePanel(elements.toggleButton);
+      togglePanel();
     });
   }
 

--- a/tests/panel-card.spec.js
+++ b/tests/panel-card.spec.js
@@ -70,7 +70,9 @@ test('cadastro atualiza etiqueta, painel e breadcrumbs', async ({ page }) => {
   await expect(stage).toBeVisible();
 });
 
-test('etiqueta abre o painel e o botão ⋯ alterna o estado', async ({ page }) => {
+test('etiqueta controla o painel sem acionar o overlay automaticamente', async ({
+  page,
+}) => {
   await resetApp(page);
   await registerUser(page, {
     nome: 'Carlos Souza',
@@ -78,25 +80,84 @@ test('etiqueta abre o painel e o botão ⋯ alterna o estado', async ({ page }) 
   });
 
   const stage = page.locator('#painel-stage');
+  const stageEmpty = page.locator('[data-stage-empty]');
   const cardTitle = page.locator('[data-miniapp="painel"] .ac-miniapp-card__title');
   const toggleButton = page.locator('[data-miniapp="painel"] [data-toggle-panel]');
+  const overlay = page.locator('[data-overlay="login"]');
 
   await expect(stage).toBeVisible();
+  await expect(stageEmpty).toBeHidden();
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
 
   await toggleButton.click();
   await expect(stage).toBeHidden();
+  await expect(stageEmpty).toBeVisible();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
 
   await cardTitle.click();
   await expect(stage).toBeVisible();
+  await expect(stageEmpty).toBeHidden();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
 
   await cardTitle.click();
   await expect(stage).toBeVisible();
+  await expect(stageEmpty).toBeHidden();
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
 
   await toggleButton.click();
   await expect(stage).toBeHidden();
+  await expect(stageEmpty).toBeVisible();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
 
   await toggleButton.click();
   await expect(stage).toBeVisible();
+  await expect(stageEmpty).toBeHidden();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+});
+
+test('sessão encerrada mantém painel sob controle da etiqueta', async ({ page }) => {
+  await resetApp(page);
+  await registerUser(page, {
+    nome: 'Joana Prado',
+    email: 'joana@example.com',
+  });
+
+  const overlay = await openLoginOverlay(page);
+  await overlay.locator('[data-action="logout-preserve"]').click();
+  await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+
+  const card = page.locator('[data-miniapp="painel"]');
+  const stage = page.locator('#painel-stage');
+  const stageEmpty = page.locator('[data-stage-empty]');
+  const toggleButton = page.locator('[data-miniapp="painel"] [data-toggle-panel]');
+  const internalTrigger = stage.locator('[data-overlay-open="login"]').first();
+
+  await expect(stage).toBeHidden();
+  await expect(stageEmpty).toBeVisible();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+  await card.click();
+  await expect(stage).toBeVisible();
+  await expect(stageEmpty).toBeHidden();
+  await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('[data-overlay="login"]')).toHaveAttribute(
+    'aria-hidden',
+    'true'
+  );
+
+  await internalTrigger.click();
+  await expect(page.locator('[data-overlay="login"]')).toHaveAttribute(
+    'aria-hidden',
+    'false'
+  );
+
+  await page.locator('[data-overlay-close]').first().click();
+  await expect(page.locator('[data-overlay="login"]')).toHaveAttribute(
+    'aria-hidden',
+    'true'
+  );
 });
 
 test('histórico registra login e logoff com preservação e limpeza de dados', async ({


### PR DESCRIPTION
## Summary
- ajusta o painel para que o cartão e o botão ⋯ apenas controlem `panelOpen`, mantendo o overlay limitado aos gatilhos dedicados
- atualiza o estado do palco vazio e o botão de alternância, garantindo `aria-expanded` coerente e acesso ao formulário pelo botão interno
- amplia os testes Playwright e o README para cobrir o novo fluxo de abertura do painel e reabertura do overlay

## Testing
- npm install
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e43a49d9a08320a327d4548f532606