### PR TITLE
Streamline app bar theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,19 @@ MiniApp “Painel de controle”.
    salvar, o painel é exibido com o nome, a conta derivada do e-mail e a data do
    último acesso, e essas informações permanecem disponíveis em visitas
    futuras.
-5. Utilize o botão ⋯ da etiqueta para recolher/exibir o painel quando houver um
+5. A AppBar traz um botão de alternância de tema que troca entre os modos claro
+   e escuro. A escolha é reaplicada automaticamente em visitas futuras.
+6. Utilize o botão ⋯ da etiqueta para recolher/exibir o painel quando houver um
    cadastro ativo. O overlay de Login pode ser reaberto para editar o usuário a
    qualquer momento.
-6. Dentro do painel do miniapp, utilize os botões “Encerrar sessão” e “Encerrar e
+7. Dentro do painel do miniapp, utilize os botões “Encerrar sessão” e “Encerrar e
    remover dados” para registrar logoff preservando ou eliminando as
    informações. O histórico de acessos exibe os eventos mais recentes de login e
    logoff na mesma área detalhada, sinalizando a ausência de registros tanto na
    tabela quanto no estado vazio do palco.
-7. Para rodar os testes de regressão, execute `npm install` seguido de `npm test`
-   (a suíte Playwright valida cadastro, persistência e comportamento da etiqueta).
+8. Para rodar os testes de regressão, execute `npm install` seguido de `npm test`
+   (a suíte Playwright valida cadastro, persistência, comportamento da etiqueta e
+   alternância de tema).
 
 ## MiniApp “Painel de controle” — destaques
 
@@ -61,6 +64,9 @@ MiniApp “Painel de controle”.
 - **Overlay de Login acessível** (`role="dialog"`, `aria-modal`, foco gerenciado
   e fechamento por Esc/backdrop) com feedback imediato de sucesso ou erro ao
   salvar.
+- **Alternância de tema persistente**: a AppBar inclui um botão que alterna os
+  tokens claros/escuros e grava a preferência no `localStorage` para manter a
+  experiência consistente entre visitas.
 - **Persistência local leve**: os dados são gravados no `localStorage`,
   reaplicados automaticamente na próxima visita e podem ser editados a qualquer
   momento sem dependências de sync/backup.

--- a/appbase/app.css
+++ b/appbase/app.css
@@ -16,6 +16,30 @@
   --ac-crit-bg: #fee2e2;
   --ac-hover: #e0e7ff;
   --ac-shadow: rgba(15, 23, 42, 0.1);
+  --ac-on-primary: #ffffff;
+  --ac-on-danger: #ffffff;
+  --ac-border-soft: rgba(15, 23, 42, 0.25);
+}
+
+:root[data-theme='dark'] {
+  --ac-bg: #0f172a;
+  --ac-surface: #020617;
+  --ac-text: #e2e8f0;
+  --ac-muted: #94a3b8;
+  --ac-primary: #60a5fa;
+  --ac-border: #1e3a8a;
+  --ac-accent: #fbbf24;
+  --ac-card-bg: #1e293b;
+  --ac-card-ink: #f8fafc;
+  --ac-ok: #34d399;
+  --ac-ok-bg: #0f3d2e;
+  --ac-crit: #f87171;
+  --ac-crit-bg: #3f1d20;
+  --ac-hover: #1d4ed8;
+  --ac-shadow: rgba(2, 6, 23, 0.4);
+  --ac-on-primary: #0b1120;
+  --ac-on-danger: #fff7ed;
+  --ac-border-soft: rgba(148, 163, 184, 0.4);
 }
 
 *,
@@ -68,8 +92,8 @@ select {
   padding: 10px 14px;
   border-radius: 12px;
   border: var(--ac-border-width) solid var(--ac-border);
-  background: #fff;
-  color: inherit;
+  background: var(--ac-bg);
+  color: var(--ac-text);
 }
 
 select {
@@ -93,7 +117,7 @@ select {
 
 .ac-appbar,
 .ac-footer {
-  background: #fff;
+  background: var(--ac-bg);
   border: var(--ac-border-width-strong) solid var(--ac-border);
   border-radius: 16px;
   padding: 16px 24px;
@@ -122,7 +146,7 @@ select {
   border: var(--ac-border-width-strong) solid var(--ac-border);
   display: grid;
   place-items: center;
-  background: #fff;
+  background: var(--ac-bg);
   overflow: hidden;
 }
 
@@ -148,24 +172,42 @@ select {
   color: var(--ac-muted);
 }
 
-.ac-breadcrumbs {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--ac-text);
-}
-
-.ac-bullet {
-  color: var(--ac-muted);
-}
-
-.ac-muted {
-  color: var(--ac-muted);
-}
-
 .ac-appbar__actions {
   position: relative;
+  margin-left: auto;
+}
+
+.ac-theme-toggle {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-border);
+  background: var(--ac-bg);
+  color: var(--ac-text);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ac-theme-toggle__icon {
+  display: block;
+}
+
+.ac-theme-toggle[aria-pressed='true'] {
+  background: var(--ac-card-bg);
+  color: var(--ac-card-ink);
+  border-color: var(--ac-border);
+}
+
+.ac-theme-toggle:hover,
+.ac-theme-toggle:focus-visible {
+  background: var(--ac-primary);
+  color: var(--ac-on-primary);
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 4px rgba(31, 58, 138, 0.24);
 }
 
 .ac-iconbtn {
@@ -173,7 +215,7 @@ select {
   height: 40px;
   border-radius: 12px;
   border: var(--ac-border-width) solid var(--ac-border);
-  background: #fff;
+  background: var(--ac-bg);
   display: grid;
   place-items: center;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
@@ -188,38 +230,8 @@ select {
 .ac-iconbtn:hover,
 .ac-iconbtn:focus-visible {
   background: var(--ac-primary);
-  color: #fff;
+  color: var(--ac-on-primary);
   border-color: var(--ac-primary);
-}
-
-.ac-appbar__menu {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 8px);
-  display: grid;
-  gap: 4px;
-  padding: 12px;
-  background: #fff;
-  border: var(--ac-border-width) solid var(--ac-border);
-  border-radius: 12px;
-  box-shadow: 0 18px 36px var(--ac-shadow);
-  z-index: 10;
-}
-
-.ac-appbar__menu[hidden] {
-  display: none;
-}
-
-.ac-appbar__menu button {
-  padding: 8px 12px;
-  border-radius: 10px;
-  text-align: left;
-  background: transparent;
-}
-
-.ac-appbar__menu button:hover,
-.ac-appbar__menu button:focus-visible {
-  background: var(--ac-hover);
 }
 
 .ac-layout {
@@ -350,7 +362,7 @@ select {
 }
 
 .ac-stage {
-  background: #fff;
+  background: var(--ac-bg);
   border: var(--ac-border-width-strong) solid var(--ac-border);
   border-radius: 18px;
   padding: 0;
@@ -429,7 +441,7 @@ select {
 }
 
 .ac-tile {
-  background: #fff;
+  background: var(--ac-bg);
   border: var(--ac-border-width) solid var(--ac-border);
   border-radius: 16px;
   padding: 20px;
@@ -585,7 +597,7 @@ select {
   border: var(--ac-border-width) solid var(--ac-border);
   border-radius: 14px;
   overflow: hidden;
-  background: #fff;
+  background: var(--ac-bg);
   max-height: 320px;
   overflow-y: auto;
 }
@@ -650,16 +662,17 @@ select {
 .ac-btn {
   border-radius: 14px;
   border: var(--ac-border-width) solid var(--ac-border);
-  background: #fff;
+  background: var(--ac-bg);
   padding: 10px 18px;
   font-weight: 600;
+  color: var(--ac-text);
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
     box-shadow 0.2s ease;
 }
 
 .ac-btn--ghost {
   background: transparent;
-  border-color: rgba(15, 23, 42, 0.25);
+  border-color: var(--ac-border-soft);
   color: var(--ac-primary);
   box-shadow: none;
 }
@@ -679,7 +692,7 @@ select {
 
 .ac-btn--danger:hover,
 .ac-btn--danger:focus-visible {
-  color: #fff;
+  color: var(--ac-on-danger);
   background: var(--ac-crit);
   border-color: var(--ac-crit);
   box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.18);
@@ -688,7 +701,7 @@ select {
 .ac-btn:hover,
 .ac-btn:focus-visible {
   background: var(--ac-primary);
-  color: #fff;
+  color: var(--ac-on-primary);
   border-color: var(--ac-primary);
   box-shadow: 0 0 0 4px rgba(31, 58, 138, 0.24);
 }
@@ -755,7 +768,7 @@ select {
 .ac-sheet {
   width: min(720px, 96vw);
   max-height: 78vh;
-  background: #fff;
+  background: var(--ac-bg);
   border-radius: 18px;
   border: var(--ac-border-width-strong) solid var(--ac-border);
   display: flex;

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -1,8 +1,19 @@
 (function () {
   const STORAGE_KEY = 'marco-appbase:user';
+  const THEME_STORAGE_KEY = 'marco-appbase:theme';
   const DEFAULT_TITLE = 'Projeto Marco — AppBase';
   const FEEDBACK_TIMEOUT = 2200;
   const VALID_HISTORY_TYPES = ['login', 'logout'];
+  const THEMES = { LIGHT: 'light', DARK: 'dark' };
+  const BRAND_ICONS = {
+    [THEMES.LIGHT]: '../assets/app/brand/icon-light-500.png',
+    [THEMES.DARK]: '../assets/app/brand/icon-dark-500.png',
+  };
+  const THEME_ICONS = { [THEMES.LIGHT]: '🌙', [THEMES.DARK]: '☀️' };
+  const THEME_LABELS = {
+    [THEMES.LIGHT]: 'Ativar modo escuro',
+    [THEMES.DARK]: 'Ativar modo claro',
+  };
 
   const elements = {
     card: document.querySelector('[data-miniapp="painel"]'),
@@ -23,12 +34,14 @@
     overlayTitle: document.getElementById('login-dialog-title'),
     overlayForm: document.querySelector('[data-login-form]'),
     feedback: document.querySelector('[data-login-feedback]'),
-    breadcrumbsSecondary: document.getElementById('breadcrumbs-secondary'),
     logTableWrap: document.querySelector('[data-login-log-table]'),
     logTableBody: document.querySelector('[data-login-log-body]'),
     logEmpty: Array.from(document.querySelectorAll('[data-login-log-empty]')),
     logoutButton: document.querySelector('[data-action="logout-preserve"]'),
     logoutClearButton: document.querySelector('[data-action="logout-clear"]'),
+    themeToggle: document.querySelector('[data-theme-toggle]'),
+    themeToggleIcon: document.querySelector('[data-theme-toggle-icon]'),
+    brandIcon: document.querySelector('[data-brand-icon]'),
   };
 
   const overlayOpenButtons = Array.from(
@@ -38,6 +51,7 @@
     document.querySelectorAll('[data-overlay-close]')
   );
 
+  let currentTheme = normaliseTheme(resolveInitialTheme());
   let state = normaliseState(loadState());
   let panelOpen = hasUser(state) && state.sessionActive;
   let activeOverlayTrigger = null;
@@ -49,6 +63,98 @@
       return typeof window !== 'undefined' && 'localStorage' in window;
     } catch (error) {
       return false;
+    }
+  }
+
+  function normaliseTheme(theme) {
+    return theme === THEMES.DARK ? THEMES.DARK : THEMES.LIGHT;
+  }
+
+  function loadThemePreference() {
+    if (!canUseStorage()) {
+      return null;
+    }
+    try {
+      const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+      if (stored === THEMES.DARK || stored === THEMES.LIGHT) {
+        return stored;
+      }
+      return null;
+    } catch (error) {
+      console.warn('AppBase: falha ao carregar tema persistido', error);
+      return null;
+    }
+  }
+
+  function saveThemePreference(theme) {
+    if (!canUseStorage()) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch (error) {
+      console.warn('AppBase: falha ao salvar tema persistido', error);
+    }
+  }
+
+  function resolveInitialTheme() {
+    const stored = loadThemePreference();
+    if (stored) {
+      return stored;
+    }
+    return detectSystemTheme();
+  }
+
+  function detectSystemTheme() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return THEMES.LIGHT;
+    }
+    try {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? THEMES.DARK
+        : THEMES.LIGHT;
+    } catch (error) {
+      return THEMES.LIGHT;
+    }
+  }
+
+  function setTheme(theme, { persist = true } = {}) {
+    const nextTheme = normaliseTheme(theme);
+    currentTheme = nextTheme;
+    document.documentElement.setAttribute('data-theme', nextTheme);
+    updateThemeAssets(nextTheme);
+    if (persist) {
+      saveThemePreference(nextTheme);
+    }
+  }
+
+  function updateThemeAssets(theme) {
+    updateBrandIcon(theme);
+    updateThemeToggle(theme);
+  }
+
+  function updateBrandIcon(theme) {
+    if (!elements.brandIcon) {
+      return;
+    }
+    const source = BRAND_ICONS[theme] || BRAND_ICONS[THEMES.LIGHT];
+    if (elements.brandIcon.getAttribute('src') !== source) {
+      elements.brandIcon.setAttribute('src', source);
+    }
+  }
+
+  function updateThemeToggle(theme) {
+    if (!elements.themeToggle) {
+      return;
+    }
+    const isDark = theme === THEMES.DARK;
+    const label = THEME_LABELS[theme] || THEME_LABELS[THEMES.LIGHT];
+    const icon = THEME_ICONS[theme] || THEME_ICONS[THEMES.LIGHT];
+    elements.themeToggle.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+    elements.themeToggle.setAttribute('aria-label', label);
+    elements.themeToggle.setAttribute('title', label);
+    if (elements.themeToggleIcon) {
+      elements.themeToggleIcon.textContent = icon;
     }
   }
 
@@ -249,11 +355,11 @@
   }
 
   function updateUI() {
+    updateThemeAssets(currentTheme);
     updateDocumentTitle();
     updateCard();
     updateStage();
     updateOverlayTitle();
-    updateBreadcrumbs();
     updateLoginFormFields();
     updateLogHistory();
     updateLogControls();
@@ -345,19 +451,6 @@
     }
     const label = hasUser() ? getDisplayName(state.user) : 'Não configurado';
     elements.overlayTitle.textContent = `Login — ${label}`;
-  }
-
-  function updateBreadcrumbs() {
-    if (!elements.breadcrumbsSecondary) {
-      return;
-    }
-    if (hasUser()) {
-      elements.breadcrumbsSecondary.textContent = `Cadastro de ${getFirstName(
-        state.user
-      )}`;
-    } else {
-      elements.breadcrumbsSecondary.textContent = 'Cadastro';
-    }
   }
 
   function updateLoginFormFields() {
@@ -644,10 +737,20 @@
     closeLoginOverlay();
   }
 
+  setTheme(currentTheme, { persist: false });
   updateUI();
 
   if (elements.card) {
     elements.card.addEventListener('click', handleCardClick);
+  }
+
+  if (elements.themeToggle) {
+    elements.themeToggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      const nextTheme =
+        currentTheme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+      setTheme(nextTheme);
+    });
   }
 
   if (elements.toggleButton) {

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -17,6 +17,7 @@
               alt=""
               width="48"
               height="48"
+              data-brand-icon
             />
           </div>
           <div class="ac-headings">
@@ -24,27 +25,19 @@
             <span class="ac-h2">Painel de controles</span>
           </div>
         </div>
-        <nav class="ac-breadcrumbs" aria-label="Localização">
-          <span id="breadcrumbs-primary">Painel de controles</span>
-          <span class="ac-bullet" aria-hidden="true">•</span>
-          <span class="ac-muted" id="breadcrumbs-secondary">Cadastro</span>
-        </nav>
         <div class="ac-appbar__actions">
           <button
-            class="ac-iconbtn"
+            class="ac-theme-toggle"
             type="button"
-            aria-haspopup="menu"
-            aria-expanded="false"
-            aria-label="Abrir menu do sistema"
-            data-system-menu
+            data-theme-toggle
+            aria-pressed="false"
+            aria-label="Ativar modo escuro"
+            title="Ativar modo escuro"
           >
-            <span aria-hidden="true">⋯</span>
+            <span class="ac-theme-toggle__icon" data-theme-toggle-icon aria-hidden="true"
+              >🌙</span
+            >
           </button>
-          <menu class="ac-appbar__menu" data-system-menu-panel hidden>
-            <button type="button">Preferências</button>
-            <button type="button">Atalhos</button>
-            <button type="button">Ajuda</button>
-          </menu>
         </div>
       </header>
 

--- a/tests/panel-card.spec.js
+++ b/tests/panel-card.spec.js
@@ -31,7 +31,7 @@ async function registerUser(page, { nome, email, telefone = '' }) {
   await expect(overlay).toHaveAttribute('aria-hidden', 'true');
 }
 
-test('cadastro atualiza etiqueta, painel e breadcrumbs', async ({ page }) => {
+test('cadastro atualiza etiqueta e painel', async ({ page }) => {
   await resetApp(page);
 
   const stage = page.locator('#painel-stage');
@@ -60,9 +60,6 @@ test('cadastro atualiza etiqueta, painel e breadcrumbs', async ({ page }) => {
   await expect(page.locator('[data-login-account]')).toHaveText('maria');
   await expect(page.locator('[data-login-last]')).not.toHaveText('—');
   await expect(page.locator('[data-meta-value="login"]')).not.toHaveText('—');
-  await expect(page.locator('#breadcrumbs-secondary')).toHaveText(
-    'Cadastro de Maria'
-  );
   await expect(page).toHaveTitle('Projeto Marco — Maria');
 
   await page.reload();

--- a/tests/theme-toggle.spec.js
+++ b/tests/theme-toggle.spec.js
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+
+async function resetApp(page) {
+  await page.goto('/index.html');
+  await page.evaluate(() => window.localStorage.clear());
+  await page.reload();
+}
+
+test('alternância de tema atualiza UI e persiste preferência', async ({ page }) => {
+  await resetApp(page);
+
+  await page.evaluate(() => {
+    window.localStorage.setItem('marco-appbase:theme', 'light');
+  });
+  await page.reload();
+
+  const html = page.locator('html');
+  const toggle = page.locator('[data-theme-toggle]');
+  const toggleIcon = toggle.locator('[data-theme-toggle-icon]');
+  const brandIcon = page.locator('[data-brand-icon]');
+
+  await expect(html).toHaveAttribute('data-theme', 'light');
+  await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  await expect(toggle).toHaveAttribute('aria-label', 'Ativar modo escuro');
+  await expect(toggle).toHaveAttribute('title', 'Ativar modo escuro');
+  await expect(toggleIcon).toHaveText('🌙');
+
+  const lightSrc = await brandIcon.getAttribute('src');
+  expect(lightSrc).toContain('icon-light-500');
+
+  await toggle.click();
+
+  await expect(html).toHaveAttribute('data-theme', 'dark');
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(toggle).toHaveAttribute('aria-label', 'Ativar modo claro');
+  await expect(toggle).toHaveAttribute('title', 'Ativar modo claro');
+  await expect(toggleIcon).toHaveText('☀️');
+  await expect(brandIcon).toHaveAttribute('src', /icon-dark-500/);
+
+  await page.reload();
+
+  await expect(html).toHaveAttribute('data-theme', 'dark');
+  await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(toggle).toHaveAttribute('aria-label', 'Ativar modo claro');
+  await expect(toggle).toHaveAttribute('title', 'Ativar modo claro');
+  await expect(toggleIcon).toHaveText('☀️');
+
+  const storedTheme = await page.evaluate(() =>
+    window.localStorage.getItem('marco-appbase:theme')
+  );
+  expect(storedTheme).toBe('dark');
+
+  const darkSrc = await brandIcon.getAttribute('src');
+  expect(darkSrc).not.toBe(lightSrc);
+});


### PR DESCRIPTION
## Summary
- remove the AppBar breadcrumbs and switch the theme toggle to an icon-only control with circular styling
- adjust theme management logic and Playwright coverage to match the simplified toggle behavior

## Testing
- npm test *(fails: Playwright browser binaries require system packages unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43a5cd4648320b3bf94157fc21ddb