### PR TITLE
Adjust viewport handling for app shell

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -60,7 +60,7 @@ body {
   background: var(--ac-surface);
   color: var(--ac-text);
   line-height: 1.5;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 a {
@@ -109,13 +109,24 @@ select {
 }
 
 .ac-app {
-  height: 100vh;
-  max-height: 100vh;
+  min-height: 100vh;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 0;
   padding: 0;
   overflow: hidden;
+}
+
+@supports (height: 100svh) {
+  .ac-app {
+    min-height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  .ac-app {
+    min-height: 100dvh;
+  }
 }
 
 .ac-appbar,


### PR DESCRIPTION
## Summary
- allow the page body to scroll vertically instead of being clipped
- ensure the app shell relies on min-height with viewport unit fallbacks so the footer stays reachable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4da6c2aac8320a4711a24cf780b5a