### PR TITLE
Add fullscreen toggle support

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -178,9 +178,13 @@ select {
 .ac-appbar__actions {
   position: relative;
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-.ac-theme-toggle {
+.ac-theme-toggle,
+.ac-fullscreen-toggle {
   display: grid;
   place-items: center;
   width: 44px;
@@ -205,8 +209,17 @@ select {
   border-color: var(--ac-border);
 }
 
+.ac-fullscreen-toggle[aria-pressed='true'] {
+  background: var(--ac-primary);
+  color: var(--ac-on-primary);
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 4px rgba(31, 58, 138, 0.24);
+}
+
 .ac-theme-toggle:hover,
-.ac-theme-toggle:focus-visible {
+.ac-theme-toggle:focus-visible,
+.ac-fullscreen-toggle:hover,
+.ac-fullscreen-toggle:focus-visible {
   background: var(--ac-primary);
   color: var(--ac-on-primary);
   border-color: var(--ac-primary);

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -38,6 +38,22 @@
               >☀️</span
             >
           </button>
+          <button
+            class="ac-theme-toggle ac-fullscreen-toggle"
+            type="button"
+            data-fullscreen-toggle
+            aria-pressed="false"
+            aria-label="Ativar tela cheia"
+            title="Ativar tela cheia"
+            hidden
+          >
+            <span
+              class="ac-theme-toggle__icon"
+              data-fullscreen-toggle-icon
+              aria-hidden="true"
+              >⛶</span
+            >
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- add a fullscreen toggle button beside the theme control and share its styling
- implement Fullscreen API helpers with state tracking, accessibility updates, and graceful fallbacks
- keep the control hidden or disabled when fullscreen is unavailable and surface error notifications

## Testing
- npm test *(fails: playwright not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4db96083c832090c4eea062b4d816