### PR TITLE
Reorganize painel into single-plane layout with inline cadastro

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,21 @@ MiniApp “Painel de controle”.
    - O `index.html` na raiz redireciona automaticamente para essa versão.
    - Para consultar a versão legada modular, abra `src/index.html` diretamente.
 3. Ao abrir, o palco permanece vazio até que um usuário seja cadastrado. Use o
-   botão “Começar cadastro” para acessar o formulário de Login. A etiqueta
-   “Painel de controle” apenas abre o painel principal, que expõe o botão ⋯
-   interno para reabrir o overlay quando necessário.
+   botão “Começar cadastro” para abrir o painel detalhado e preencher o
+   formulário diretamente no palco. A etiqueta “Painel de controle” alterna
+   entre o estado vazio e o painel quando existir cadastro salvo.
 4. Os dados cadastrados são guardados apenas no `localStorage` do navegador. Ao
    salvar, o painel é exibido com o nome, a conta derivada do e-mail e a data do
    último acesso, e essas informações permanecem disponíveis em visitas
    futuras.
 5. Utilize o botão ⋯ da etiqueta para recolher/exibir o painel quando houver um
-   cadastro ativo. Para editar o cadastro, abra o painel pela etiqueta e acione
-   novamente o botão ⋯ disponível dentro da tile de Login (ou o CTA do estado
-   vazio do palco) para reabrir o overlay.
+   cadastro ativo. A edição do cadastro acontece no mesmo painel, bastando
+   atualizar os campos e salvar.
 6. Dentro do painel do miniapp, utilize os botões “Encerrar sessão” e “Encerrar e
    remover dados” para registrar logoff preservando ou eliminando as
    informações. O histórico de acessos exibe os eventos mais recentes de login e
-   logoff na mesma área detalhada, sinalizando a ausência de registros tanto na
-   tabela quanto no estado vazio do palco.
+   logoff logo abaixo do formulário, sinalizando a ausência de registros tanto
+   na tabela quanto no estado vazio do palco.
 7. Para rodar os testes de regressão, execute `npm install` seguido de `npm test`
    (a suíte Playwright valida cadastro, persistência e comportamento da etiqueta).
 
@@ -65,14 +64,12 @@ permitindo que a preferência seja restaurada automaticamente na próxima visita
 ## MiniApp “Painel de controle” — destaques
 
 - **Etiqueta simplificada** exibe o primeiro nome cadastrado, o último acesso e
-  o status (vermelho quando vazio, verde quando configurado), mantendo o rail
-  coerente com o palco.
-- **Palco dedicado ao Login**, com tile único que mostra nome completo, conta e
-  horário do último acesso. O botão ⋯ recolhe/exibe o painel sem perder o
-  cadastro.
-- **Overlay de Login acessível** (`role="dialog"`, `aria-modal`, foco gerenciado
-  e fechamento por Esc/backdrop) com feedback imediato de sucesso ou erro ao
-  salvar.
+  o status do painel, mantendo o rail coerente com o palco.
+- **Painel unificado** organiza indicadores, resumo do cadastro, formulário e
+  histórico em cards empilhados no mesmo plano, eliminando pop-ups e reforçando
+  a leitura sequencial.
+- **Cadastro direto no palco**, com campos pré-preenchidos, feedback inline e
+  controles de sessão (encerrar ou limpar dados) na mesma seção.
 - **Alternância de tema persistente**: a AppBar traz o mesmo botão circular sem
   texto, com ícones ☀️/🌙 alinhados ao tema ativo, tooltip contextual e rótulos
   acessíveis que descrevem a ação disponível. A marca também alterna entre os
@@ -84,8 +81,8 @@ permitindo que a preferência seja restaurada automaticamente na próxima visita
   momento sem dependências de sync/backup.
 - **Histórico de acessos e controles de sessão**: o painel detalhado lista os
   registros de login/logoff com rolagem a partir de cinco eventos. Os botões de
-  encerrar sessão agora ficam dentro do overlay de cadastro, permitindo manter os
-  dados salvos para um retorno futuro ou limpar tudo do navegador.
+  encerrar sessão permanecem ao lado do formulário, permitindo manter os dados
+  salvos para um retorno futuro ou limpar tudo do navegador.
 
 ## Tecnologias adotadas e compatibilidade
 
@@ -96,9 +93,10 @@ permitindo que a preferência seja restaurada automaticamente na próxima visita
 - **Persistência via `localStorage`**: garante que o cadastro funcione offline,
   sem dependências de sincronização ou backend. A normalização de dados cuida de
   nomes, contas e datas para manter a UI consistente.
-- **Acessibilidade nativa**: o overlay utiliza `role="dialog"`, `aria-modal` e
-  gerenciamento de foco em JavaScript puro para oferecer uma experiência
-  compatível com leitores de tela sem exigir bibliotecas externas.
+- **Acessibilidade nativa**: o formulário e os controles compartilham rótulos,
+  `aria-live` para feedback e foco gerenciado ao abrir o painel, garantindo uma
+  experiência compatível com leitores de tela sem depender de bibliotecas
+  externas.
 - **Testes Playwright**: a suíte end-to-end roda com Node.js apenas em
   desenvolvimento, validando o fluxo principal. Como as dependências ficam em
   `devDependencies`, o deploy estático permanece leve.

--- a/appbase/app.css
+++ b/appbase/app.css
@@ -487,6 +487,10 @@ select {
   background: var(--ac-ok);
 }
 
+.ac-dot--warn {
+  background: var(--ac-accent);
+}
+
 .ac-dot--crit {
   background: var(--ac-crit);
 }
@@ -593,6 +597,174 @@ select {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+}
+
+.ac-panel {
+  padding: 24px;
+  display: grid;
+  gap: 24px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: linear-gradient(
+    160deg,
+    rgba(148, 163, 184, 0.08) 0%,
+    rgba(59, 130, 246, 0.12) 45%,
+    transparent 100%
+  );
+}
+
+.ac-panel-card {
+  background: var(--ac-card-bg);
+  border: var(--ac-border-width) solid var(--ac-border);
+  border-radius: 20px;
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+}
+
+.ac-panel-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.ac-panel-card__titles {
+  display: grid;
+  gap: 4px;
+}
+
+.ac-panel-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ac-primary);
+}
+
+.ac-panel-card__subtitle {
+  margin: 0;
+  color: var(--ac-muted);
+  font-weight: 500;
+}
+
+.ac-panel-kpis {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.ac-kpi-card {
+  background: var(--ac-bg);
+  border: var(--ac-border-width) solid var(--ac-border-soft);
+  border-radius: 16px;
+  padding: 18px 20px;
+  display: grid;
+  gap: 8px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+}
+
+.ac-kpi-card__label {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ac-muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.ac-kpi-card__value {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--ac-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ac-kpi-card__meta {
+  margin: 0;
+  color: var(--ac-muted);
+  font-size: 0.95rem;
+}
+
+.ac-panel-form__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.ac-panel-session {
+  border-top: var(--ac-border-width) solid var(--ac-border);
+  padding-top: 16px;
+}
+
+.ac-panel-card--history {
+  padding-bottom: 28px;
+}
+
+.ac-panel-card--kpis {
+  background: linear-gradient(
+      140deg,
+      rgba(59, 130, 246, 0.18) 0%,
+      rgba(59, 130, 246, 0.08) 30%,
+      var(--ac-card-bg) 70%
+    ),
+    var(--ac-card-bg);
+}
+
+.ac-panel-card--kpis .ac-kpi-card {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+:root[data-theme='dark'] .ac-panel-card--kpis .ac-kpi-card {
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.ac-panel-summary {
+  margin: 0;
+}
+
+.ac-panel-card--form .ac-feedback {
+  border-style: dashed;
+}
+
+@media (max-width: 960px) {
+  .ac-panel {
+    padding: 20px;
+  }
+
+  .ac-panel-card {
+    padding: 20px;
+  }
+
+  .ac-panel-kpis {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .ac-panel {
+    padding: 16px;
+  }
+
+  .ac-panel-card__title {
+    font-size: 1.1rem;
+  }
+
+  .ac-panel-card__subtitle {
+    font-size: 0.95rem;
+  }
+
+  .ac-panel-card {
+    gap: 16px;
+  }
+
+  .ac-panel-kpis {
+    grid-template-columns: 1fr;
+  }
 }
 
 .ac-tile {

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -164,7 +164,6 @@
               <button
                 class="ac-btn"
                 type="button"
-                data-overlay-open="login"
                 data-stage-empty-action
               >
                 Começar cadastro
@@ -197,20 +196,68 @@
               </div>
             </header>
 
-            <div class="ac-grid">
-              <article class="ac-tile ac-tile--span-12" data-tile="login">
-                <header class="ac-tile__head">
-                  <h3 class="ac-tile__title">Login</h3>
-                  <button
-                    type="button"
-                    class="ac-iconbtn ac-iconbtn--small"
-                    data-overlay-open="login"
-                    aria-label="Abrir detalhes de login"
-                  >
-                    <span aria-hidden="true">⋯</span>
-                  </button>
+            <div class="ac-panel" data-panel>
+              <article
+                class="ac-panel-card ac-panel-card--kpis"
+                aria-labelledby="painel-insights-title"
+              >
+                <header class="ac-panel-card__head">
+                  <div class="ac-panel-card__titles">
+                    <h3 id="painel-insights-title" class="ac-panel-card__title">
+                      Indicadores
+                    </h3>
+                    <p class="ac-panel-card__subtitle">
+                      Resumo do painel em tempo real.
+                    </p>
+                  </div>
                 </header>
-                <dl class="ac-tile__meta">
+                <div class="ac-panel-kpis" role="group" aria-label="Indicadores do painel">
+                  <article class="ac-kpi-card" data-panel-kpi="status">
+                    <p class="ac-kpi-card__label">Status do painel</p>
+                    <div class="ac-kpi-card__value">
+                      <span
+                        class="ac-dot ac-dot--crit"
+                        aria-hidden="true"
+                        data-panel-status-dot
+                      ></span>
+                      <span data-panel-status-label>Desconectado</span>
+                    </div>
+                    <p class="ac-kpi-card__meta" data-panel-status-hint>
+                      Cadastre um usuário para iniciar a sessão.
+                    </p>
+                  </article>
+                  <article class="ac-kpi-card" data-panel-kpi="last-login">
+                    <p class="ac-kpi-card__label">Último acesso</p>
+                    <p class="ac-kpi-card__value" data-panel-last-login>—</p>
+                    <p class="ac-kpi-card__meta" data-panel-last-login-hint>
+                      Nenhum registro disponível.
+                    </p>
+                  </article>
+                  <article class="ac-kpi-card" data-panel-kpi="events">
+                    <p class="ac-kpi-card__label">Eventos registrados</p>
+                    <p class="ac-kpi-card__value" data-panel-login-count>0</p>
+                    <p class="ac-kpi-card__meta" data-panel-login-hint>
+                      Aguardando primeiro registro.
+                    </p>
+                  </article>
+                </div>
+              </article>
+
+              <article
+                class="ac-panel-card ac-panel-card--form"
+                aria-labelledby="painel-cadastro-title"
+              >
+                <header class="ac-panel-card__head">
+                  <div class="ac-panel-card__titles">
+                    <h3 id="painel-cadastro-title" class="ac-panel-card__title">
+                      Cadastro
+                    </h3>
+                    <p class="ac-panel-card__subtitle">
+                      Atualize os dados salvos neste dispositivo.
+                    </p>
+                  </div>
+                </header>
+                <dl class="ac-panel-summary ac-tile__meta" role="list">
                   <div>
                     <dt>Usuário</dt>
                     <dd data-login-user>Não configurado</dd>
@@ -224,18 +271,95 @@
                     <dd data-login-last>—</dd>
                   </div>
                 </dl>
+                <form
+                  id="login-form"
+                  class="ac-form-grid"
+                  data-login-form
+                  autocomplete="off"
+                >
+                  <label class="ac-field">
+                    <span class="ac-field__label">Nome completo</span>
+                    <input name="nome" type="text" required />
+                  </label>
+                  <label class="ac-field">
+                    <span class="ac-field__label">E-mail</span>
+                    <input name="email" type="email" required />
+                  </label>
+                  <label class="ac-field">
+                    <span class="ac-field__label">Telefone (opcional)</span>
+                    <input
+                      name="telefone"
+                      type="tel"
+                      inputmode="tel"
+                      placeholder="(99) 99999-9999"
+                    />
+                  </label>
+                  <label class="ac-field">
+                    <span class="ac-field__label">Senha</span>
+                    <input
+                      name="senha"
+                      type="password"
+                      value="********"
+                      autocomplete="new-password"
+                    />
+                  </label>
+                  <div class="ac-panel-form__actions">
+                    <button
+                      class="ac-btn ac-btn--primary"
+                      type="submit"
+                      data-action="login-save"
+                    >
+                      Salvar alterações
+                    </button>
+                  </div>
+                </form>
+                <p
+                  class="ac-feedback"
+                  data-login-feedback
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <section class="ac-session ac-panel-session">
+                  <div class="ac-session__intro">
+                    <p class="ac-sheet__status">Sessão atual</p>
+                    <p class="ac-session__description">
+                      Encerre a sessão mantendo os dados armazenados neste navegador
+                      ou remova todas as informações do cadastro.
+                    </p>
+                  </div>
+                  <div
+                    class="ac-session__actions"
+                    role="group"
+                    aria-label="Ações da sessão"
+                  >
+                    <button
+                      class="ac-btn ac-btn--ghost"
+                      type="button"
+                      data-action="logout-preserve"
+                    >
+                      Encerrar sessão
+                    </button>
+                    <button
+                      class="ac-btn ac-btn--danger"
+                      type="button"
+                      data-action="logout-clear"
+                    >
+                      Encerrar e remover dados
+                    </button>
+                  </div>
+                </section>
               </article>
+
               <article
-                class="ac-tile ac-tile--span-12 ac-history"
-                data-login-log
+                class="ac-panel-card ac-panel-card--history ac-history"
                 aria-labelledby="login-log-title"
               >
-                <header class="ac-tile__head ac-history__head">
-                  <div class="ac-history__titles">
-                    <h3 id="login-log-title" class="ac-tile__title">
+                <header class="ac-panel-card__head ac-history__head">
+                  <div class="ac-panel-card__titles ac-history__titles">
+                    <h3 id="login-log-title" class="ac-panel-card__title">
                       Histórico de acessos
                     </h3>
-                    <p class="ac-history__subtitle">
+                    <p class="ac-panel-card__subtitle ac-history__subtitle">
                       Acompanhe logins e logoffs registrados neste navegador.
                     </p>
                   </div>
@@ -283,103 +407,5 @@
       </footer>
     </div>
 
-    <div class="ac-overlay" data-overlay="login" aria-hidden="true">
-      <section
-        class="ac-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="login-dialog-title"
-      >
-        <header class="ac-sheet__head">
-          <h4 id="login-dialog-title" class="ac-sheet__title" tabindex="-1">
-            Login • Não configurado
-          </h4>
-          <button
-            class="ac-iconbtn ac-iconbtn--small"
-            type="button"
-            aria-label="Fechar"
-            data-overlay-close
-          >
-            ✖
-          </button>
-        </header>
-        <div class="ac-sheet__body">
-          <form
-            id="login-form"
-            class="ac-form-grid"
-            data-login-form
-            autocomplete="off"
-          >
-            <label class="ac-field">
-              <span class="ac-field__label">Nome completo</span>
-              <input name="nome" type="text" required />
-            </label>
-            <label class="ac-field">
-              <span class="ac-field__label">E-mail</span>
-              <input name="email" type="email" required />
-            </label>
-            <label class="ac-field">
-              <span class="ac-field__label">Telefone (opcional)</span>
-              <input name="telefone" type="tel" inputmode="tel" placeholder="(99) 99999-9999" />
-            </label>
-            <label class="ac-field">
-              <span class="ac-field__label">Senha</span>
-              <input name="senha" type="password" value="********" autocomplete="new-password" />
-            </label>
-          </form>
-
-          <p
-            class="ac-feedback"
-            data-login-feedback
-            role="status"
-            aria-live="polite"
-          ></p>
-
-          <section class="ac-sheet__section">
-            <h5 class="ac-sheet__subtitle">Resumo</h5>
-            <p>Os dados permanecem salvos apenas neste navegador.</p>
-          </section>
-
-          <section class="ac-sheet__section ac-session">
-            <div class="ac-session__intro">
-              <p class="ac-sheet__status">Sessão atual</p>
-              <p class="ac-session__description">
-                Encerre a sessão mantendo os dados armazenados neste navegador ou
-                remova todas as informações do cadastro.
-              </p>
-            </div>
-            <div
-              class="ac-session__actions"
-              role="group"
-              aria-label="Ações da sessão"
-            >
-              <button
-                class="ac-btn ac-btn--ghost"
-                type="button"
-                data-action="logout-preserve"
-              >
-                Encerrar sessão
-              </button>
-              <button
-                class="ac-btn ac-btn--danger"
-                type="button"
-                data-action="logout-clear"
-              >
-                Encerrar e remover dados
-              </button>
-            </div>
-          </section>
-
-        </div>
-        <footer class="ac-sheet__foot">
-          <button class="ac-btn ac-btn--primary" type="submit" form="login-form" data-action="login-save">
-            Salvar
-          </button>
-          <button class="ac-btn" type="button" data-overlay-close>
-            Cancelar
-          </button>
-        </footer>
-      </section>
-    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the painel stage into stacked cards with indicators, cadastro form, and history in a single plane
- adjust styles and JavaScript logic to drive the inline experience and new status indicators
- refresh end-to-end tests and documentation to reflect the no-overlay workflow

## Testing
- npm test *(fails: Playwright not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f467c07483209bc237d8cab22b3d