### PR TITLE
feat: add footer dirty status indicator

### DIFF
--- a/appbase/i18n/en-US.json
+++ b/appbase/i18n/en-US.json
@@ -134,6 +134,11 @@
         "connected": "Connected",
         "disconnected": "Disconnected"
       },
+      "dirty": {
+        "label": "Changes:",
+        "clean": "Saved",
+        "dirty": "Unsaved changes"
+      },
       "meta": "Developed by 5Horas • Marco Project — AppBase R1.1",
       "login": { "ok": "Connected" }
     },

--- a/appbase/i18n/es-ES.json
+++ b/appbase/i18n/es-ES.json
@@ -134,6 +134,11 @@
         "connected": "Conectado",
         "disconnected": "Desconectado"
       },
+      "dirty": {
+        "label": "Cambios:",
+        "clean": "Sincronizado",
+        "dirty": "Cambios pendientes"
+      },
       "meta": "Desarrollado por 5Horas • Proyecto Marco — AppBase R1.1",
       "login": { "ok": "Conectado" }
     },

--- a/appbase/i18n/pt-BR.json
+++ b/appbase/i18n/pt-BR.json
@@ -134,6 +134,11 @@
         "connected": "Conectado",
         "disconnected": "Desconectado"
       },
+      "dirty": {
+        "label": "Alterações:",
+        "clean": "Sincronizado",
+        "dirty": "Alterações pendentes"
+      },
       "meta": "Desenvolvido por 5Horas • Projeto Marco — AppBase R1.1",
       "login": { "ok": "Conectado" }
     },

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -10,7 +10,7 @@
       name="appbase-i18n"
       content="defaultLocale=pt-BR; supportedLocales=pt-BR,en-US,es-ES"
     />
-    <script defer src="./app.js"></script>
+    <script type="module" src="./app.js"></script>
     <script defer src="./i18n/i18n.js"></script>
     <script defer src="./uiext/uiext.js"></script>
     <script defer src="./settings/settings.js"></script>
@@ -481,7 +481,7 @@
       </div>
 
       <footer class="ac-footer" role="contentinfo">
-        <span class="ac-footer__status" data-footer-status>
+        <span class="ac-footer__status" data-footer-status data-footer-session-status>
           <span
             class="ac-dot ac-dot--crit"
             aria-hidden="true"
@@ -489,6 +489,7 @@
           ></span>
           <span
             class="ac-footer__status-text"
+            data-footer-status-text
             data-i18n="app.footer.status.label"
           >
             Status:
@@ -499,6 +500,27 @@
             data-i18n="app.footer.status.disconnected"
           >
             Desconectado
+          </span>
+        </span>
+        <span class="ac-footer__status" data-footer-dirty-status>
+          <span
+            class="ac-dot ac-dot--ok"
+            aria-hidden="true"
+            data-footer-dirty-dot
+          ></span>
+          <span
+            class="ac-footer__status-text"
+            data-footer-dirty-text
+            data-i18n="app.footer.dirty.label"
+          >
+            Alterações:
+          </span>
+          <span
+            class="ac-footer__status-label"
+            data-footer-dirty-label
+            data-i18n="app.footer.dirty.clean"
+          >
+            Sincronizado
           </span>
         </span>
         <span class="ac-footer__meta" data-i18n="app.footer.meta">

--- a/appbase/storage/indexeddb.js
+++ b/appbase/storage/indexeddb.js
@@ -1,0 +1,197 @@
+const DB_NAME = 'marco-appbase';
+const DB_VERSION = 1;
+const STORE_NAME = 'state';
+const STORAGE_KEY = 'marco-appbase:user';
+
+let openDatabasePromise = null;
+
+function hasIndexedDB() {
+  try {
+    return typeof window !== 'undefined' && 'indexedDB' in window;
+  } catch (error) {
+    return false;
+  }
+}
+
+function hasLocalStorage() {
+  try {
+    return typeof window !== 'undefined' && 'localStorage' in window;
+  } catch (error) {
+    return false;
+  }
+}
+
+function readLegacyState() {
+  if (!hasLocalStorage()) {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    return JSON.parse(stored);
+  } catch (error) {
+    console.warn('AppBaseStorage: falha ao ler dados legados do localStorage', error);
+    return null;
+  }
+}
+
+function writeLegacyState(value) {
+  if (!hasLocalStorage()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch (error) {
+    console.warn('AppBaseStorage: falha ao gravar dados no localStorage de contingência', error);
+  }
+}
+
+function clearLegacyState() {
+  if (!hasLocalStorage()) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('AppBaseStorage: falha ao limpar dados legados do localStorage', error);
+  }
+}
+
+function openDatabase() {
+  if (!hasIndexedDB()) {
+    return Promise.resolve(null);
+  }
+  if (openDatabasePromise) {
+    return openDatabasePromise;
+  }
+  openDatabasePromise = new Promise((resolve) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const database = event.target.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME);
+      }
+    };
+
+    request.onsuccess = () => {
+      const database = request.result;
+      database.onversionchange = () => {
+        database.close();
+      };
+      resolve(database);
+    };
+
+    request.onerror = () => {
+      console.warn('AppBaseStorage: falha ao abrir IndexedDB, utilizando localStorage', request.error);
+      resolve(null);
+    };
+
+    request.onblocked = () => {
+      console.warn('AppBaseStorage: abertura do IndexedDB bloqueada por outra aba');
+    };
+  });
+  return openDatabasePromise;
+}
+
+function putState(database, value) {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(value, STORAGE_KEY);
+
+    transaction.oncomplete = () => {
+      resolve();
+    };
+
+    transaction.onerror = () => {
+      reject(transaction.error || request.error);
+    };
+
+    transaction.onabort = () => {
+      reject(transaction.error || request.error);
+    };
+
+    request.onerror = () => {
+      // O erro também será capturado pelos handlers de transação.
+    };
+  });
+}
+
+async function migrateLegacyState(database) {
+  const legacyState = readLegacyState();
+  if (!legacyState) {
+    return null;
+  }
+  if (!database) {
+    return legacyState;
+  }
+  try {
+    await putState(database, legacyState);
+    clearLegacyState();
+  } catch (error) {
+    console.warn('AppBaseStorage: falha ao migrar dados do localStorage para IndexedDB', error);
+  }
+  return legacyState;
+}
+
+export async function loadState() {
+  const database = await openDatabase();
+  if (!database) {
+    return readLegacyState();
+  }
+
+  return new Promise((resolve) => {
+    const transaction = database.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(STORAGE_KEY);
+
+    let resolved = false;
+
+    const finish = (value) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(value || null);
+      }
+    };
+
+    request.onsuccess = () => {
+      const value = request.result;
+      if (typeof value === 'undefined') {
+        transaction.oncomplete = async () => {
+          const migrated = await migrateLegacyState(database);
+          finish(migrated);
+        };
+        return;
+      }
+      finish(value);
+    };
+
+    request.onerror = () => {
+      console.warn('AppBaseStorage: falha ao ler dados no IndexedDB, retornando localStorage', request.error);
+      finish(readLegacyState());
+    };
+
+    transaction.onerror = () => {
+      console.warn('AppBaseStorage: falha na transação de leitura do IndexedDB', transaction.error);
+      finish(readLegacyState());
+    };
+  });
+}
+
+export async function saveState(value) {
+  const database = await openDatabase();
+  if (!database) {
+    writeLegacyState(value);
+    return;
+  }
+  try {
+    await putState(database, value);
+    clearLegacyState();
+  } catch (error) {
+    console.warn('AppBaseStorage: falha ao salvar dados no IndexedDB, usando localStorage', error);
+    writeLegacyState(value);
+  }
+}

--- a/src/scripts/bus.js
+++ b/src/scripts/bus.js
@@ -1,0 +1,99 @@
+const subscribers = new Map();
+const history = new Map();
+const scheduleTask =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (callback) => {
+        Promise.resolve()
+          .then(callback)
+          .catch((error) => console.error('bus replay scheduling error', error));
+      };
+
+function getBucket(type) {
+  if (!subscribers.has(type)) {
+    subscribers.set(type, new Set());
+  }
+  return subscribers.get(type);
+}
+
+function subscribe(type, handler, options = {}) {
+  if (typeof type !== 'string' || !type) {
+    throw new Error('bus.subscribe requer um tipo de evento válido.');
+  }
+  if (typeof handler !== 'function') {
+    throw new Error('bus.subscribe requer uma função de callback.');
+  }
+  const bucket = getBucket(type);
+  bucket.add(handler);
+  const replay = options.replay === true;
+  if (replay && history.has(type)) {
+    scheduleTask(() => {
+      try {
+        handler(history.get(type));
+      } catch (error) {
+        console.error('bus subscriber replay error', error);
+      }
+    });
+  }
+  return () => {
+    unsubscribe(type, handler);
+  };
+}
+
+function unsubscribe(type, handler) {
+  if (!subscribers.has(type)) {
+    return false;
+  }
+  const bucket = subscribers.get(type);
+  const result = bucket.delete(handler);
+  if (bucket.size === 0) {
+    subscribers.delete(type);
+  }
+  return result;
+}
+
+function emit(type, detail) {
+  if (typeof type !== 'string' || !type) {
+    throw new Error('bus.emit requer um tipo de evento válido.');
+  }
+  const event = Object.freeze({
+    type,
+    detail,
+    timestamp: Date.now(),
+  });
+  history.set(type, event);
+  const bucket = subscribers.get(type);
+  if (bucket) {
+    bucket.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (error) {
+        console.error('bus subscriber error', error);
+      }
+    });
+  }
+  const wildcard = subscribers.get('*');
+  if (wildcard) {
+    wildcard.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (error) {
+        console.error('bus wildcard subscriber error', error);
+      }
+    });
+  }
+  return event;
+}
+
+function getLastEvent(type) {
+  return history.get(type) ?? null;
+}
+
+export const bus = Object.freeze({
+  subscribe,
+  unsubscribe,
+  emit,
+  getLastEvent,
+});
+
+export default bus;

--- a/src/scripts/template-module.js
+++ b/src/scripts/template-module.js
@@ -1,3 +1,11 @@
+/**
+ * Cria um módulo de painel baseado em templates. Os módulos produzidos expõem eventos
+ * no barramento global (`context.bus`) para que miniapps possam coordenar estados.
+ * Eventos principais:
+ * - miniapp:panel:init → { key, container, meta }
+ * - miniapp:panel:disposed → { key }
+ * - ui:panel:show/ui:panel:hide (emitidos pelo núcleo, disponíveis para assinatura)
+ */
 export function createTemplateModule(config) {
   if (!config || typeof config !== 'object') {
     throw new Error('createTemplateModule requer um objeto de configuração válido.');
@@ -28,10 +36,47 @@ export function createTemplateModule(config) {
 
       const templateId = meta.panel?.template;
       const uiContext = context.ui ?? {};
+      const eventBus = context.bus;
       const applyTranslations = typeof uiContext.applyTranslations === 'function' ? uiContext.applyTranslations : null;
       const translateWithFallback =
         typeof uiContext.translateWithFallback === 'function' ? uiContext.translateWithFallback : null;
       const translate = typeof uiContext.translate === 'function' ? uiContext.translate : null;
+
+      let teardown = null;
+
+      if (eventBus?.emit) {
+        try {
+          eventBus.emit('miniapp:panel:init', { key: meta.key, container, meta });
+        } catch (error) {
+          console.error('Erro ao emitir miniapp:panel:init', error);
+        }
+      }
+
+      if (typeof eventBus?.subscribe === 'function') {
+        let unsubscribeHide = null;
+        unsubscribeHide = eventBus.subscribe('ui:panel:hide', (event) => {
+          if (event.detail?.key !== meta.key) {
+            return;
+          }
+          if (unsubscribeHide) {
+            unsubscribeHide();
+            unsubscribeHide = null;
+          }
+          if (eventBus?.emit) {
+            try {
+              eventBus.emit('miniapp:panel:disposed', { key: meta.key });
+            } catch (error) {
+              console.error('Erro ao emitir miniapp:panel:disposed', error);
+            }
+          }
+        });
+        teardown = () => {
+          if (unsubscribeHide) {
+            unsubscribeHide();
+            unsubscribeHide = null;
+          }
+        };
+      }
 
       if (templateId) {
         const template = document.getElementById(templateId);
@@ -75,6 +120,8 @@ export function createTemplateModule(config) {
         fallback.textContent = fallbackText;
         container.appendChild(fallback);
       }
+
+      return teardown ?? undefined;
     },
   };
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -111,6 +111,15 @@ header.app-header {
   min-width: 140px;
 }
 
+.locale-switcher[data-loading='true'] {
+  opacity: 0.8;
+  transition: opacity 120ms ease;
+}
+
+.locale-switcher select[data-loading='true'] {
+  cursor: progress;
+}
+
 .theme-toggle {
   display: inline-flex;
   align-items: center;

--- a/tests/src-localization.spec.js
+++ b/tests/src-localization.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require('@playwright/test');
+
+const LOCALE_LOADING_POLL_INTERVAL = 50;
+
+async function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test.describe('Localização da interface (src/)', () => {
+  test('aplica apenas a última troca de idioma ao abortar requisições antigas', async ({ page }) => {
+    let firstLocaleRequest = true;
+
+    await page.route('**/src/locales/en-US.json', async (route) => {
+      if (firstLocaleRequest) {
+        firstLocaleRequest = false;
+        await wait(300);
+        try {
+          await route.continue();
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return;
+          }
+          const message = error?.message ?? '';
+          if (
+            message.includes('aborted') ||
+            message.includes('Request is already handled') ||
+            message.includes('Target closed')
+          ) {
+            return;
+          }
+          throw error;
+        }
+        return;
+      }
+      await route.continue();
+    });
+
+    const abortEvent = page.waitForEvent('requestfailed', (request) =>
+      request.url().includes('/src/locales/en-US.json')
+    );
+
+    await page.goto('/src/index.html');
+
+    const select = page.locator('[data-action="change-locale"]');
+    await expect(select).toBeVisible();
+    await expect(select).toHaveValue('pt-BR');
+
+    await select.selectOption('en-US');
+    await expect(select).toHaveAttribute('aria-busy', 'true');
+    await expect
+      .poll(
+        () => page.evaluate(() => document.documentElement.dataset.localeLoading ?? ''),
+        { interval: LOCALE_LOADING_POLL_INTERVAL }
+      )
+      .toBe('true');
+
+    await select.selectOption('pt-BR');
+
+    await abortEvent;
+
+    await expect
+      .poll(
+        () => page.evaluate(() => document.documentElement.lang),
+        { interval: LOCALE_LOADING_POLL_INTERVAL }
+      )
+      .toBe('pt-BR');
+
+    await expect
+      .poll(
+        () => page.evaluate(() => document.documentElement.dataset.localeLoading ?? ''),
+        { interval: LOCALE_LOADING_POLL_INTERVAL }
+      )
+      .toBe('');
+
+    await expect(select).not.toHaveAttribute('aria-busy', 'true');
+    await expect(select).toHaveValue('pt-BR');
+
+    const statusIndicator = page.locator('[data-ref="status-indicator"]');
+    await expect(statusIndicator).toContainText('Sessão ativa');
+    await expect(statusIndicator).not.toContainText('Active session');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated footer indicator for unsaved login form changes and keep the session label hydrated with translations
- track form edits against the persisted user payload so the dirty flag clears after setState/autosave completes
- localize the new dirty indicator strings for pt-BR, en-US, and es-ES

## Testing
- npm test *(fails: playwright: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5519c0b9c8320974f91d495d2c8ba