### PR TITLE
Revamp control panel layout

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -10,6 +10,7 @@
   --ac-accent: #f97316;
   --ac-card-bg: #eef2ff;
   --ac-card-ink: #0f172a;
+  --ac-card-border: rgba(30, 64, 175, 0.22);
   --ac-ok: #16a34a;
   --ac-ok-bg: #ecfdf5;
   --ac-crit: #ef4444;
@@ -19,6 +20,14 @@
   --ac-on-primary: #ffffff;
   --ac-on-danger: #ffffff;
   --ac-border-soft: rgba(15, 23, 42, 0.25);
+  --ac-chip-bg: rgba(59, 130, 246, 0.12);
+  --ac-chip-border: rgba(30, 64, 175, 0.2);
+  --ac-chip-ink: #1f3a8a;
+  --ac-chip-active-bg: #1f3a8a;
+  --ac-chip-active-ink: #ffffff;
+  --ac-info-muted: rgba(30, 41, 59, 0.7);
+  --ac-panel-soft-bg: #eff6ff;
+  --ac-table-border: rgba(30, 64, 175, 0.16);
   --ac-shell-gradient: linear-gradient(
     160deg,
     rgba(59, 130, 246, 0.18) 0%,
@@ -48,6 +57,23 @@
   --ac-panel-head-sub: rgba(255, 255, 255, 0.76);
   --ac-panel-head-border: rgba(255, 255, 255, 0.24);
   --ac-panel-border: rgba(59, 130, 246, 0.35);
+  --ac-sync-toggle-bg: var(--ac-bg);
+  --ac-sync-toggle-border: var(--ac-card-border);
+  --ac-sync-toggle-ink: var(--ac-text);
+  --ac-sync-toggle-muted: var(--ac-muted);
+  --ac-sync-toggle-active-bg: var(--ac-primary);
+  --ac-sync-toggle-active-border: var(--ac-border);
+  --ac-sync-toggle-active-ink: var(--ac-on-primary);
+  --ac-sync-toggle-error-bg: var(--ac-crit-bg);
+  --ac-sync-toggle-error-ink: var(--ac-crit);
+  --ac-sync-indicator-off: var(--ac-muted);
+  --ac-sync-indicator-on: var(--ac-ok);
+  --ac-sync-indicator-error: var(--ac-crit);
+  --ac-sync-badge-bg: var(--ac-primary);
+  --ac-sync-badge-ink: var(--ac-on-primary);
+  --ac-sync-badge-muted-bg: rgba(148, 163, 184, 0.16);
+  --ac-sync-badge-muted-ink: var(--ac-muted);
+  --ac-sync-device-border: var(--ac-border-soft);
 }
 
 :root[data-theme='dark'] {
@@ -60,6 +86,7 @@
   --ac-accent: #fbbf24;
   --ac-card-bg: #1e293b;
   --ac-card-ink: #f8fafc;
+  --ac-card-border: rgba(148, 163, 184, 0.32);
   --ac-ok: #34d399;
   --ac-ok-bg: #0f3d2e;
   --ac-crit: #f87171;
@@ -69,6 +96,14 @@
   --ac-on-primary: #0b1120;
   --ac-on-danger: #fff7ed;
   --ac-border-soft: rgba(148, 163, 184, 0.4);
+  --ac-chip-bg: rgba(59, 130, 246, 0.24);
+  --ac-chip-border: rgba(148, 163, 184, 0.4);
+  --ac-chip-ink: #e2e8f0;
+  --ac-chip-active-bg: #e2e8f0;
+  --ac-chip-active-ink: #0b1120;
+  --ac-info-muted: rgba(226, 232, 240, 0.7);
+  --ac-panel-soft-bg: #0f172a;
+  --ac-table-border: rgba(148, 163, 184, 0.2);
   --ac-shell-gradient: linear-gradient(
     160deg,
     rgba(2, 6, 23, 0.95) 0%,
@@ -98,6 +133,7 @@
   --ac-panel-head-sub: rgba(226, 232, 240, 0.75);
   --ac-panel-head-border: rgba(148, 163, 184, 0.35);
   --ac-panel-border: rgba(59, 130, 246, 0.4);
+  --ac-sync-badge-muted-bg: rgba(148, 163, 184, 0.25);
 }
 
 *,
@@ -659,6 +695,34 @@ select {
   align-items: center;
   gap: 12px;
   margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.ac-stage__chips {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ac-stage__export {
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-chip-border);
+  background: var(--ac-bg);
+  color: var(--ac-chip-ink);
+  font-weight: 600;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.ac-stage__export:hover,
+.ac-stage__export:focus-visible {
+  background: var(--ac-chip-active-bg);
+  color: var(--ac-chip-active-ink);
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
 }
 
 .ac-stage__close {
@@ -729,6 +793,10 @@ select {
   .ac-stage__panel {
     border-radius: 28px;
   }
+
+  .ac-panel__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 640px) {
@@ -763,24 +831,46 @@ select {
 }
 
 .ac-panel {
-  padding: 16px 24px 32px;
-  display: grid;
-  gap: 24px;
+  padding: 24px 28px 36px;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  background: var(--ac-panel-surface), var(--ac-panel-gradient);
-  border-top: var(--ac-border-width) solid var(--ac-panel-head-border);
+  background: linear-gradient(
+      180deg,
+      rgba(59, 130, 246, 0.08) 0%,
+      rgba(59, 130, 246, 0.03) 45%,
+      rgba(239, 246, 255, 0) 100%
+    ),
+    var(--ac-panel-soft-bg);
+  border-top: var(--ac-border-width) solid rgba(30, 64, 175, 0.12);
+}
+
+:root[data-theme='dark'] .ac-panel {
+  background: linear-gradient(
+      180deg,
+      rgba(30, 64, 175, 0.35) 0%,
+      rgba(15, 23, 42, 0.3) 40%,
+      rgba(15, 23, 42, 0.6) 100%
+    ),
+    var(--ac-panel-soft-bg);
+  border-top: var(--ac-border-width) solid rgba(148, 163, 184, 0.24);
+}
+
+.ac-panel__grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-content: start;
 }
 
 .ac-panel-card {
   background: var(--ac-card-bg);
-  border: var(--ac-border-width) solid var(--ac-border);
-  border-radius: 24px;
-  padding: 24px;
+  border: var(--ac-border-width) solid var(--ac-card-border);
+  border-radius: 20px;
+  padding: 24px 26px;
   display: grid;
   gap: 20px;
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
 }
 
 .ac-panel-card__head {
@@ -793,6 +883,19 @@ select {
 .ac-panel-card__titles {
   display: grid;
   gap: 4px;
+}
+
+.ac-panel-card__badge {
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ac-chip-ink);
+  background: var(--ac-chip-bg);
+  border: var(--ac-border-width) solid var(--ac-chip-border);
 }
 
 .ac-panel-card__title {
@@ -808,10 +911,62 @@ select {
   font-weight: 500;
 }
 
+.ac-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-chip-border);
+  background: var(--ac-chip-bg);
+  color: var(--ac-chip-ink);
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.ac-status-chip__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.ac-status-chip__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ac-status-chip--interactive {
+  cursor: pointer;
+  background: var(--ac-bg);
+}
+
+.ac-status-chip--interactive:hover,
+.ac-status-chip--interactive:focus-visible {
+  background: var(--ac-chip-active-bg);
+  color: var(--ac-chip-active-ink);
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.ac-status-chip--interactive[aria-pressed='true'] {
+  background: var(--ac-chip-active-bg);
+  color: var(--ac-chip-active-ink);
+  border-color: transparent;
+}
+
 .ac-panel-kpis {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.ac-panel-card__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ac-info-muted);
+  line-height: 1.5;
 }
 
 .ac-kpi-card {
@@ -869,24 +1024,38 @@ select {
 
 .ac-panel-card--history {
   padding-bottom: 28px;
+  grid-column: 1 / -1;
 }
 
-.ac-panel-card--kpis {
+.ac-panel-card--form {
+  grid-column: auto;
+  align-self: start;
+}
+
+.ac-panel-card--system {
+  align-self: stretch;
+}
+
+.ac-panel-card--overview {
   background: linear-gradient(
-      140deg,
+      145deg,
       rgba(59, 130, 246, 0.18) 0%,
-      rgba(59, 130, 246, 0.08) 30%,
-      var(--ac-card-bg) 70%
+      rgba(239, 246, 255, 0.75) 60%,
+      var(--ac-card-bg) 100%
     ),
     var(--ac-card-bg);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.12);
 }
 
-.ac-panel-card--kpis .ac-kpi-card {
-  background: rgba(255, 255, 255, 0.85);
-}
-
-:root[data-theme='dark'] .ac-panel-card--kpis .ac-kpi-card {
-  background: rgba(15, 23, 42, 0.7);
+:root[data-theme='dark'] .ac-panel-card--overview {
+  background: linear-gradient(
+      145deg,
+      rgba(37, 99, 235, 0.32) 0%,
+      rgba(15, 23, 42, 0.75) 65%,
+      var(--ac-card-bg) 100%
+    ),
+    var(--ac-card-bg);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
 }
 
 .ac-panel-summary {
@@ -899,11 +1068,20 @@ select {
 
 @media (max-width: 960px) {
   .ac-panel {
-    padding: 16px 20px 24px;
+    padding: 20px 20px 28px;
   }
 
   .ac-panel-card {
-    padding: 20px;
+    padding: 20px 22px;
+  }
+
+  .ac-stage__actions {
+    justify-content: flex-start;
+  }
+
+  .ac-stage__chips {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .ac-panel-kpis {
@@ -965,31 +1143,80 @@ select {
   color: var(--ac-primary);
 }
 
-.ac-tile__meta {
+.ac-tile__meta,
+.ac-info-list {
   margin: 0;
   display: grid;
   gap: 12px;
 }
 
+.ac-info-list div,
 .ac-tile__meta div {
   display: flex;
   justify-content: space-between;
   gap: 12px;
   font-size: 0.97rem;
+  color: var(--ac-info-muted);
 }
 
+.ac-info-list dt,
 .ac-tile__meta dt {
   font-weight: 600;
+  color: inherit;
 }
 
+.ac-info-list dd,
 .ac-tile__meta dd {
   margin: 0;
   text-align: right;
-  font-weight: 500;
+  font-weight: 600;
+  color: var(--ac-card-ink);
 }
 
 .ac-history {
   gap: 20px;
+}
+
+.ac-session-status {
+  display: grid;
+  gap: 12px;
+}
+
+.ac-session-status__item {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: var(--ac-border-width) solid var(--ac-table-border);
+  background: rgba(255, 255, 255, 0.65);
+  display: grid;
+  gap: 6px;
+}
+
+:root[data-theme='dark'] .ac-session-status__item {
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.ac-session-status__label {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ac-muted);
+  font-weight: 700;
+}
+
+.ac-session-status__value {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--ac-card-ink);
+}
+
+.ac-session-status__meta {
+  margin: 0;
+  color: var(--ac-info-muted);
+  font-size: 0.9rem;
 }
 
 .ac-history__head {
@@ -997,6 +1224,60 @@ select {
   flex-direction: column;
   gap: 12px;
   width: 100%;
+}
+
+.ac-history__filters {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.ac-history__search input,
+.ac-history__select select {
+  appearance: none;
+  border: var(--ac-border-width) solid var(--ac-card-border);
+  border-radius: 999px;
+  padding: 8px 18px;
+  background: var(--ac-bg);
+  color: var(--ac-card-ink);
+  font-size: 0.9rem;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  min-width: 220px;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.ac-history__select select {
+  padding-right: 40px;
+  background-image: linear-gradient(45deg, transparent 50%, var(--ac-card-ink) 50%),
+    linear-gradient(135deg, var(--ac-card-ink) 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 4px),
+    calc(100% - 12px) calc(50% - 4px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.ac-history__search input::placeholder {
+  color: var(--ac-muted);
+}
+
+.ac-history__search input:focus-visible,
+.ac-history__select select:focus-visible {
+  outline: none;
+  border-color: var(--ac-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+:root[data-theme='dark'] .ac-history__search input,
+:root[data-theme='dark'] .ac-history__select select {
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--ac-card-ink);
+}
+
+:root[data-theme='dark'] .ac-history__select select {
+  background-image: linear-gradient(45deg, transparent 50%, var(--ac-card-ink) 50%),
+    linear-gradient(135deg, var(--ac-card-ink) 50%, transparent 50%);
 }
 
 .ac-history__titles {
@@ -1024,6 +1305,263 @@ select {
 .ac-history__empty--stage {
   margin-top: 24px;
   max-width: 320px;
+}
+
+.ac-sync {
+  display: grid;
+  gap: 20px;
+}
+
+.ac-sync__chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.ac-sync__requirements {
+  display: grid;
+  gap: 8px;
+  padding: 16px 20px;
+  border-radius: 18px;
+  border: var(--ac-border-width) dashed var(--ac-sync-toggle-border);
+  background: var(--ac-sync-toggle-bg);
+  color: var(--ac-sync-toggle-muted);
+}
+
+.ac-sync__requirements p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.ac-sync__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--ac-sync-badge-bg);
+  color: var(--ac-sync-badge-ink);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ac-sync__toggles {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.ac-sync-toggle {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 20px;
+  border: var(--ac-border-width) solid var(--ac-sync-toggle-border);
+  background: var(--ac-sync-toggle-bg);
+  color: var(--ac-sync-toggle-ink);
+  text-align: left;
+  transition: background 180ms ease, border-color 180ms ease, color 180ms ease,
+    box-shadow 180ms ease;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.ac-sync-toggle:hover {
+  border-color: var(--ac-border);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+}
+
+.ac-sync-toggle__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  background: var(--ac-sync-badge-muted-bg);
+  color: var(--ac-sync-toggle-ink);
+}
+
+.ac-sync-toggle__body {
+  display: grid;
+  gap: 4px;
+}
+
+.ac-sync-toggle__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.ac-sync-toggle__note {
+  font-size: 0.85rem;
+  color: var(--ac-sync-toggle-muted);
+}
+
+.ac-sync-toggle__status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--ac-sync-badge-muted-bg);
+  color: var(--ac-sync-badge-muted-ink);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.ac-sync-toggle__indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--ac-sync-indicator-off);
+  transition: background 180ms ease;
+}
+
+.ac-sync-toggle__status {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+}
+
+.ac-sync-toggle[aria-pressed='true'] {
+  background: var(--ac-sync-toggle-active-bg);
+  color: var(--ac-sync-toggle-active-ink);
+  border-color: var(--ac-sync-toggle-active-border);
+  box-shadow: 0 18px 42px var(--ac-shadow);
+}
+
+.ac-sync-toggle[aria-pressed='true'] .ac-sync-toggle__status-badge {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--ac-sync-toggle-active-ink);
+}
+
+.ac-sync-toggle[aria-pressed='true'] .ac-sync-toggle__indicator {
+  background: var(--ac-sync-indicator-on);
+}
+
+.ac-sync-toggle--error {
+  background: var(--ac-sync-toggle-error-bg);
+  border-color: var(--ac-crit);
+  color: var(--ac-sync-toggle-error-ink);
+}
+
+.ac-sync-toggle--error .ac-sync-toggle__status-badge {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--ac-sync-toggle-error-ink);
+}
+
+.ac-sync-toggle--error .ac-sync-toggle__indicator {
+  background: var(--ac-sync-indicator-error);
+}
+
+.ac-sync-toggle--error .ac-sync-toggle__status {
+  color: var(--ac-sync-toggle-error-ink);
+}
+
+.ac-sync__status-message-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.ac-sync__status-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--ac-card-ink);
+}
+
+.ac-sync__status-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ac-info-muted);
+}
+
+.ac-sync__metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.ac-sync-metric {
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: var(--ac-border-width) solid var(--ac-sync-toggle-border);
+  background: var(--ac-sync-toggle-bg);
+  display: grid;
+  gap: 8px;
+}
+
+.ac-sync-metric__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ac-sync-toggle-muted);
+  font-weight: 600;
+}
+
+.ac-sync-metric__value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ac-primary);
+}
+
+.ac-sync__devices {
+  display: grid;
+  gap: 12px;
+}
+
+.ac-sync__devices-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ac-sync__devices-title {
+  font-weight: 700;
+  color: var(--ac-primary);
+  font-size: 1rem;
+}
+
+.ac-sync-device-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.ac-sync-device-list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: var(--ac-border-width) solid var(--ac-sync-device-border);
+  background: var(--ac-sync-toggle-bg);
+  color: var(--ac-sync-toggle-ink);
+}
+
+.ac-sync-device-list__item .ac-mono {
+  font-size: 0.85rem;
+}
+
+.ac-sync-device-list__item--empty {
+  color: var(--ac-sync-toggle-muted);
+  font-style: italic;
+  justify-content: flex-start;
+}
+
+.ac-sync__signout {
+  align-self: center;
 }
 
 .ac-mono {
@@ -1128,12 +1666,13 @@ select {
 }
 
 .ac-table-wrap {
-  border: var(--ac-border-width) solid var(--ac-border);
-  border-radius: 14px;
+  border: var(--ac-border-width) solid var(--ac-table-border);
+  border-radius: 18px;
   overflow: hidden;
   background: var(--ac-bg);
   max-height: 320px;
   overflow-y: auto;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .ac-table-wrap--inner {
@@ -1154,7 +1693,7 @@ select {
   color: var(--ac-primary);
   text-align: left;
   padding: 12px 16px;
-  border-bottom: var(--ac-border-width) solid var(--ac-border);
+  border-bottom: var(--ac-border-width) solid var(--ac-table-border);
   z-index: 1;
 }
 
@@ -1224,6 +1763,20 @@ select {
   border-color: var(--ac-border-soft);
   color: var(--ac-primary);
   box-shadow: none;
+}
+
+.ac-btn--outline {
+  background: transparent;
+  border-color: var(--ac-card-border);
+  color: var(--ac-chip-ink);
+  box-shadow: none;
+}
+
+.ac-btn--outline:hover,
+.ac-btn--outline:focus-visible {
+  background: var(--ac-chip-active-bg);
+  color: var(--ac-chip-active-ink);
+  border-color: transparent;
 }
 
 .ac-btn--ghost:hover,

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -174,8 +174,12 @@ import {
     loginLast: document.querySelector('[data-login-last]'),
     loginForm: document.querySelector('[data-login-form]'),
     feedback: document.querySelector('[data-login-feedback]'),
-    panelStatusDot: document.querySelector('[data-panel-status-dot]'),
-    panelStatusLabel: document.querySelector('[data-panel-status-label]'),
+    panelStatusDot: Array.from(
+      document.querySelectorAll('[data-panel-status-dot]') || []
+    ),
+    panelStatusLabel: Array.from(
+      document.querySelectorAll('[data-panel-status-label]') || []
+    ),
     panelStatusHint: document.querySelector('[data-panel-status-hint]'),
     panelLastLogin: document.querySelector('[data-panel-last-login]'),
     panelLastLoginHint: document.querySelector('[data-panel-last-login-hint]'),
@@ -333,6 +337,10 @@ import {
 
   function setElementTextFromKey(element, key, options = {}) {
     if (!element) {
+      return;
+    }
+    if (Array.isArray(element)) {
+      element.forEach((item) => setElementTextFromKey(item, key, options));
       return;
     }
     if (!key) {
@@ -1079,13 +1087,15 @@ import {
     const historyCount = getHistoryCount();
     const lastLoginValue = hasData ? formatDateTime(state.lastLogin) : '—';
 
-    if (elements.panelStatusDot) {
-      elements.panelStatusDot.classList.toggle('ac-dot--ok', loggedIn);
-      elements.panelStatusDot.classList.toggle('ac-dot--crit', !loggedIn && !hasData);
-      elements.panelStatusDot.classList.toggle('ac-dot--warn', hasData && !loggedIn);
+    if (Array.isArray(elements.panelStatusDot) && elements.panelStatusDot.length) {
+      elements.panelStatusDot.forEach((dot) => {
+        dot.classList.toggle('ac-dot--ok', loggedIn);
+        dot.classList.toggle('ac-dot--crit', !loggedIn && !hasData);
+        dot.classList.toggle('ac-dot--warn', hasData && !loggedIn);
+      });
     }
 
-    if (elements.panelStatusLabel) {
+    if (Array.isArray(elements.panelStatusLabel) && elements.panelStatusLabel.length) {
       const statusKey = loggedIn
         ? PANEL_STATUS_LABEL_KEYS.connected
         : PANEL_STATUS_LABEL_KEYS.disconnected;

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -177,6 +177,19 @@
                 </p>
               </div>
               <div class="ac-stage__actions">
+                <div class="ac-stage__chips" role="group" aria-label="Status das integrações">
+                  <span class="ac-status-chip" role="status">
+                    <span class="ac-status-chip__icon" aria-hidden="true">☁️</span>
+                    <span class="ac-status-chip__label">Sync desativada</span>
+                  </span>
+                  <span class="ac-status-chip" role="status">
+                    <span class="ac-status-chip__icon" aria-hidden="true">💾</span>
+                    <span class="ac-status-chip__label">Backup desativado</span>
+                  </span>
+                  <button class="ac-btn ac-btn--outline ac-stage__export" type="button">
+                    Exportar
+                  </button>
+                </div>
                 <button
                   class="ac-iconbtn ac-iconbtn--small ac-stage__close"
                   type="button"
@@ -189,308 +202,606 @@
             </header>
 
             <div class="ac-panel" data-panel>
-              <article
-                class="ac-panel-card ac-panel-card--kpis"
-                aria-labelledby="painel-insights-title"
-              >
-                <header class="ac-panel-card__head">
-                  <div class="ac-panel-card__titles">
-                    <h3
-                      id="painel-insights-title"
-                      class="ac-panel-card__title"
-                      data-i18n="app.panel.kpis.title"
-                    >
-                      Indicadores
-                    </h3>
-                    <p
-                      class="ac-panel-card__subtitle"
-                      data-i18n="app.panel.kpis.subtitle"
-                    >
-                      Resumo do painel em tempo real.
-                    </p>
-                  </div>
-                </header>
-                <div
-                  class="ac-panel-kpis"
-                  role="group"
-                  aria-label="Indicadores do painel"
-                  data-panel-kpis-group
+              <div class="ac-panel__grid">
+                <article
+                  class="ac-panel-card ac-panel-card--overview"
+                  aria-labelledby="painel-login-title"
                 >
-                  <article class="ac-kpi-card" data-panel-kpi="status">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.status.label"
-                    >
-                      Status do painel
-                    </p>
-                    <div class="ac-kpi-card__value">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        id="painel-login-title"
+                        class="ac-panel-card__title"
+                      >
+                        Login
+                      </h3>
+                      <p class="ac-panel-card__subtitle">
+                        Usuário, conta e últimas credenciais registradas.
+                      </p>
+                    </div>
+                    <span class="ac-status-chip" role="status">
                       <span
                         class="ac-dot ac-dot--crit"
                         aria-hidden="true"
                         data-panel-status-dot
                       ></span>
                       <span
+                        class="ac-status-chip__label"
                         data-panel-status-label
                         data-i18n="app.panel.kpis.status.states.disconnected"
                       >
                         Desconectado
                       </span>
+                    </span>
+                  </header>
+                  <dl class="ac-panel-summary ac-info-list" role="list">
+                    <div>
+                      <dt data-i18n="app.panel.summary.user">Usuário</dt>
+                      <dd data-login-user data-i18n="app.panel.summary.empty">
+                        Não configurado
+                      </dd>
                     </div>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-status-hint
-                      data-i18n="app.panel.kpis.status.hint.empty"
-                    >
-                      Cadastre um usuário para iniciar a sessão.
-                    </p>
-                  </article>
-                  <article class="ac-kpi-card" data-panel-kpi="last-login">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.last_login.label"
-                    >
-                      Último acesso
-                    </p>
-                    <p class="ac-kpi-card__value" data-panel-last-login>—</p>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-last-login-hint
-                      data-i18n="app.panel.kpis.last_login.hint.empty"
-                    >
-                      Nenhum registro disponível.
-                    </p>
-                  </article>
-                  <article class="ac-kpi-card" data-panel-kpi="events">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.events.label"
-                    >
-                      Eventos registrados
-                    </p>
-                    <p class="ac-kpi-card__value" data-panel-login-count>0</p>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-login-hint
-                      data-i18n="app.panel.kpis.events.hint.empty"
-                    >
-                      Aguardando primeiro registro.
-                    </p>
-                  </article>
-                </div>
-              </article>
-
-              <article
-                class="ac-panel-card ac-panel-card--form"
-                aria-labelledby="painel-cadastro-title"
-              >
-                <header class="ac-panel-card__head">
-                  <div class="ac-panel-card__titles">
-                    <h3
-                      id="painel-cadastro-title"
-                      class="ac-panel-card__title"
-                      data-i18n="app.panel.form.title"
-                    >
-                      Cadastro
-                    </h3>
-                    <p
-                      class="ac-panel-card__subtitle"
-                      data-i18n="app.panel.form.subtitle"
-                    >
-                      Atualize os dados salvos neste dispositivo.
-                    </p>
-                  </div>
-                </header>
-                <dl class="ac-panel-summary ac-tile__meta" role="list">
-                  <div>
-                    <dt data-i18n="app.panel.summary.user">Usuário</dt>
-                    <dd data-login-user data-i18n="app.panel.summary.empty">
-                      Não configurado
-                    </dd>
-                  </div>
-                  <div>
-                    <dt data-i18n="app.panel.summary.account">Conta</dt>
-                    <dd data-login-account>—</dd>
-                  </div>
-                  <div>
-                    <dt data-i18n="app.panel.summary.last_login">Último acesso</dt>
-                    <dd data-login-last>—</dd>
-                  </div>
-                </dl>
-                <form
-                  id="login-form"
-                  class="ac-form-grid"
-                  data-login-form
-                  autocomplete="off"
-                >
-                  <label class="ac-field">
-                    <span
-                      class="ac-field__label"
-                      data-i18n="app.panel.form.fields.name"
-                    >
-                      Nome completo
-                    </span>
-                    <input name="nome" type="text" required />
-                  </label>
-                  <label class="ac-field">
-                    <span
-                      class="ac-field__label"
-                      data-i18n="app.panel.form.fields.email"
-                    >
-                      E-mail
-                    </span>
-                    <input name="email" type="email" required />
-                  </label>
-                  <label class="ac-field">
-                    <span
-                      class="ac-field__label"
-                      data-i18n="app.panel.form.fields.phone"
-                    >
-                      Telefone (opcional)
-                    </span>
-                    <input
-                      name="telefone"
-                      type="tel"
-                      inputmode="tel"
-                      placeholder="(99) 99999-9999"
-                      data-phone-input
-                    />
-                  </label>
-                  <label class="ac-field">
-                    <span
-                      class="ac-field__label"
-                      data-i18n="app.panel.form.fields.password"
-                    >
-                      Senha
-                    </span>
-                    <div class="ac-field__control">
-                      <input
-                        name="senha"
-                        type="password"
-                        autocomplete="new-password"
-                        required
-                        data-password-input
-                      />
-                      <button
-                        class="ac-password-toggle"
-                        type="button"
-                        data-password-toggle
-                        aria-pressed="false"
-                        aria-label="Mostrar senha"
-                        title="Mostrar senha"
+                    <div>
+                      <dt data-i18n="app.panel.summary.account">Conta</dt>
+                      <dd data-login-account>—</dd>
+                    </div>
+                    <div>
+                      <dt data-i18n="app.panel.summary.last_login">Último acesso</dt>
+                      <dd data-login-last>—</dd>
+                    </div>
+                  </dl>
+                  <div
+                    class="ac-session-status"
+                    role="group"
+                    aria-label="Indicadores do painel"
+                    data-panel-kpis-group
+                  >
+                    <article class="ac-session-status__item" data-panel-kpi="status">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.status.label"
                       >
-                        <span aria-hidden="true" data-password-toggle-icon>👁</span>
+                        Status da sessão
+                      </p>
+                      <p class="ac-session-status__value">
+                        <span
+                          class="ac-dot ac-dot--crit"
+                          aria-hidden="true"
+                          data-panel-status-dot
+                        ></span>
+                        <span
+                          data-panel-status-label
+                          data-i18n="app.panel.kpis.status.states.disconnected"
+                        >
+                          Desconectado
+                        </span>
+                      </p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-status-hint
+                        data-i18n="app.panel.kpis.status.hint.empty"
+                      >
+                        Cadastre um usuário para iniciar a sessão.
+                      </p>
+                    </article>
+                    <article class="ac-session-status__item" data-panel-kpi="last-login">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.last_login.label"
+                      >
+                        Último acesso
+                      </p>
+                      <p class="ac-session-status__value ac-mono" data-panel-last-login>
+                        —
+                      </p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-last-login-hint
+                        data-i18n="app.panel.kpis.last_login.hint.empty"
+                      >
+                        Nenhum registro disponível.
+                      </p>
+                    </article>
+                    <article class="ac-session-status__item" data-panel-kpi="events">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.events.label"
+                      >
+                        Eventos registrados
+                      </p>
+                      <p class="ac-session-status__value" data-panel-login-count>0</p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-login-hint
+                        data-i18n="app.panel.kpis.events.hint.empty"
+                      >
+                        Aguardando primeiro registro.
+                      </p>
+                    </article>
+                  </div>
+                </article>
+
+                <article
+                  class="ac-panel-card ac-panel-card--sync"
+                  aria-labelledby="painel-sistema-title"
+                >
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3 id="painel-sistema-title" class="ac-panel-card__title">
+                        Sincronização
+                      </h3>
+                      <p class="ac-panel-card__subtitle">
+                        Conecte o painel aos provedores suportados e distribua os dados.
+                      </p>
+                    </div>
+                    <div class="ac-sync__chips">
+                      <button
+                        class="ac-status-chip ac-status-chip--interactive"
+                        type="button"
+                        data-sync-chip="google-drive"
+                        aria-pressed="false"
+                        aria-describedby="sync-requirements-note"
+                      >
+                        <span class="ac-status-chip__icon" aria-hidden="true">☁️</span>
+                        <span class="ac-status-chip__label">Sync desativada</span>
+                      </button>
+                      <button
+                        class="ac-status-chip ac-status-chip--interactive"
+                        type="button"
+                        data-sync-chip="one-drive"
+                        aria-pressed="false"
+                        aria-describedby="sync-requirements-note"
+                      >
+                        <span class="ac-status-chip__icon" aria-hidden="true">🗂️</span>
+                        <span class="ac-status-chip__label">Backup desativado</span>
                       </button>
                     </div>
-                  </label>
-                  <div
-                    class="ac-panel-form__actions"
-                    role="group"
-                    aria-labelledby="panel-session-label"
-                    aria-describedby="panel-session-hint"
-                    data-session-actions
-                  >
-                    <span
-                      class="ac-visually-hidden"
-                      id="panel-session-label"
-                      data-i18n="app.panel.session.current"
-                    >
-                      Sessão atual
-                    </span>
-                    <button
-                      class="ac-btn ac-btn--primary"
-                      type="submit"
-                      data-action="login-save"
-                      data-i18n="app.panel.form.submit"
-                    >
-                      Salvar alterações
-                    </button>
-                    <button
-                      class="ac-btn ac-btn--ghost"
-                      type="button"
-                      data-action="logout-preserve"
-                      data-i18n="app.panel.session.actions.logout"
-                    >
-                      Encerrar sessão
-                    </button>
-                    <button
-                      class="ac-btn ac-btn--danger"
-                      type="button"
-                      data-action="logout-clear"
-                      data-i18n="app.panel.session.actions.logout_clear"
-                    >
-                      Encerrar e remover dados
-                    </button>
-                    <p
-                      class="ac-panel-form__hint"
-                      id="panel-session-hint"
-                      data-i18n="app.panel.session.description"
-                    >
-                      Encerre a sessão mantendo os dados armazenados neste navegador
-                      ou remova todas as informações do cadastro.
-                    </p>
+                  </header>
+                  <div class="ac-sync" data-sync-panel>
+                    <div class="ac-sync__requirements" id="sync-requirements-note">
+                      <span class="ac-sync__badge">Requisito</span>
+                      <p>
+                        É necessário ter o app instalado e logado para ativar a
+                        sincronização automática.
+                      </p>
+                    </div>
+                    <div class="ac-sync__status-message-wrap">
+                      <p
+                        class="ac-sync__status-message ac-mono"
+                        data-sync-status-message
+                        aria-live="polite"
+                      >
+                        Nenhuma sincronização ativa no momento.
+                      </p>
+                      <p class="ac-sync__status-note">
+                        Cada integração requer o app instalado e sessão ativa no
+                        dispositivo.
+                      </p>
+                    </div>
+                    <div class="ac-sync__toggles" role="group" aria-label="Provedores">
+                      <button
+                        class="ac-sync-toggle"
+                        type="button"
+                        data-sync-toggle="google-drive"
+                        aria-pressed="false"
+                        aria-describedby="sync-requirements-note"
+                      >
+                        <span class="ac-sync-toggle__icon" aria-hidden="true">☁️</span>
+                        <span class="ac-sync-toggle__body">
+                          <span class="ac-sync-toggle__label">Google Drive</span>
+                          <span class="ac-sync-toggle__note">
+                            Integração oficial com autenticação Google.
+                          </span>
+                        </span>
+                        <span class="ac-sync-toggle__status-badge">
+                          <span
+                            class="ac-sync-toggle__indicator"
+                            data-sync-indicator
+                            aria-hidden="true"
+                          ></span>
+                          <span
+                            class="ac-sync-toggle__status ac-mono"
+                            data-sync-status
+                            aria-live="polite"
+                          >
+                            Inativo
+                          </span>
+                        </span>
+                      </button>
+                      <button
+                        class="ac-sync-toggle"
+                        type="button"
+                        data-sync-toggle="one-drive"
+                        aria-pressed="false"
+                        aria-describedby="sync-requirements-note"
+                      >
+                        <span class="ac-sync-toggle__icon" aria-hidden="true">🗂️</span>
+                        <span class="ac-sync-toggle__body">
+                          <span class="ac-sync-toggle__label">OneDrive</span>
+                          <span class="ac-sync-toggle__note">
+                            Sincronize com contas corporativas Microsoft.
+                          </span>
+                        </span>
+                        <span class="ac-sync-toggle__status-badge">
+                          <span
+                            class="ac-sync-toggle__indicator"
+                            data-sync-indicator
+                            aria-hidden="true"
+                          ></span>
+                          <span
+                            class="ac-sync-toggle__status ac-mono"
+                            data-sync-status
+                            aria-live="polite"
+                          >
+                            Inativo
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div class="ac-sync__metrics" role="group" aria-label="Status da sincronização">
+                      <div class="ac-sync-metric" tabindex="0" aria-live="polite">
+                        <span class="ac-sync-metric__label">Última atualização</span>
+                        <span class="ac-sync-metric__value ac-mono" data-sync-last-update>
+                          —
+                        </span>
+                      </div>
+                      <div class="ac-sync-metric" tabindex="0" aria-live="polite">
+                        <span class="ac-sync-metric__label">Servidor</span>
+                        <span class="ac-sync-metric__value ac-mono" data-sync-server>
+                          api.marco.local
+                        </span>
+                      </div>
+                      <div class="ac-sync-metric" tabindex="0" aria-live="polite">
+                        <span class="ac-sync-metric__label">Dispositivos conectados</span>
+                        <span
+                          class="ac-sync-metric__value ac-mono"
+                          data-sync-connected-count
+                        >
+                          0
+                        </span>
+                      </div>
+                    </div>
+                    <div class="ac-sync__devices">
+                      <div class="ac-sync__devices-head">
+                        <span class="ac-sync__devices-title">Dispositivos conectados</span>
+                        <button
+                          class="ac-btn ac-btn--ghost ac-sync__signout"
+                          type="button"
+                          data-sync-signout-all
+                        >
+                          Deslogar de todos
+                        </button>
+                      </div>
+                      <ul class="ac-sync-device-list" data-sync-devices aria-live="polite">
+                        <li
+                          class="ac-sync-device-list__item ac-sync-device-list__item--empty"
+                          data-sync-devices-empty
+                        >
+                          Nenhum dispositivo conectado.
+                        </li>
+                      </ul>
+                    </div>
                   </div>
-                </form>
-                <p
-                  class="ac-feedback"
-                  data-login-feedback
-                  role="status"
-                  aria-live="polite"
-                ></p>
-              </article>
+                </article>
 
-              <article
-                class="ac-panel-card ac-panel-card--history ac-history"
-                aria-labelledby="login-log-title"
-              >
-                <header class="ac-panel-card__head ac-history__head">
-                  <div class="ac-panel-card__titles ac-history__titles">
-                    <h3
-                      id="login-log-title"
-                      class="ac-panel-card__title"
-                      data-i18n="app.panel.history.title"
+                <article class="ac-panel-card ac-panel-card--backup">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3 class="ac-panel-card__title">Backup</h3>
+                      <p class="ac-panel-card__subtitle">
+                        Proteja registros críticos e restaure configurações em segundos.
+                      </p>
+                    </div>
+                    <span class="ac-status-chip" role="status">
+                      <span class="ac-status-chip__icon" aria-hidden="true">💾</span>
+                      <span class="ac-status-chip__label">Backup desativado</span>
+                    </span>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Último backup</dt>
+                      <dd class="ac-mono" data-backup-last>—</dd>
+                    </div>
+                    <div>
+                      <dt>Armazenamento</dt>
+                      <dd class="ac-mono" data-backup-target>Sem destino</dd>
+                    </div>
+                    <div>
+                      <dt>Tamanho estimado</dt>
+                      <dd class="ac-mono" data-backup-size>0 KB</dd>
+                    </div>
+                  </dl>
+                  <p class="ac-panel-card__note">
+                    Configure uma conta de nuvem ou exporte manualmente os dados para
+                    garantir redundância.
+                  </p>
+                </article>
+
+                <article class="ac-panel-card ac-panel-card--connectivity">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3 class="ac-panel-card__title">Conectividade</h3>
+                      <p class="ac-panel-card__subtitle">
+                        Parâmetros ativos e latência dos serviços em tempo real.
+                      </p>
+                    </div>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Endpoint</dt>
+                      <dd class="ac-mono" data-connect-endpoint>api.marco.local</dd>
+                    </div>
+                    <div>
+                      <dt>Região</dt>
+                      <dd class="ac-mono" data-connect-region>br-south</dd>
+                    </div>
+                    <div>
+                      <dt>Latência média</dt>
+                      <dd class="ac-mono" data-connect-latency>—</dd>
+                    </div>
+                  </dl>
+                  <p class="ac-panel-card__note">
+                    Monitore tempo de resposta e priorize links redundantes durante janelas
+                    críticas de operação.
+                  </p>
+                </article>
+
+                <article class="ac-panel-card ac-panel-card--security">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3 class="ac-panel-card__title">Segurança</h3>
+                      <p class="ac-panel-card__subtitle">
+                        Sessões autenticadas, políticas aplicadas e eventos recentes.
+                      </p>
+                    </div>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Última revisão</dt>
+                      <dd class="ac-mono" data-security-last>—</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd class="ac-mono" data-security-status>Em análise</dd>
+                    </div>
+                    <div>
+                      <dt>Alertas ativos</dt>
+                      <dd class="ac-mono" data-security-alerts>0</dd>
+                    </div>
+                  </dl>
+                  <p class="ac-panel-card__note">
+                    Garanta autenticação multifator nos dispositivos conectados e revise
+                    logs semanalmente.
+                  </p>
+                </article>
+
+                <article
+                  class="ac-panel-card ac-panel-card--form"
+                  aria-labelledby="painel-cadastro-title"
+                >
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        id="painel-cadastro-title"
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.form.title"
+                      >
+                        Cadastro
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.form.subtitle"
+                      >
+                        Atualize os dados salvos neste dispositivo.
+                      </p>
+                    </div>
+                    <span class="ac-panel-card__badge">Editar</span>
+                  </header>
+                  <form
+                    id="login-form"
+                    class="ac-form-grid"
+                    data-login-form
+                    autocomplete="off"
+                  >
+                    <label class="ac-field">
+                      <span
+                        class="ac-field__label"
+                        data-i18n="app.panel.form.fields.name"
+                      >
+                        Nome completo
+                      </span>
+                      <input name="nome" type="text" required />
+                    </label>
+                    <label class="ac-field">
+                      <span
+                        class="ac-field__label"
+                        data-i18n="app.panel.form.fields.email"
+                      >
+                        E-mail
+                      </span>
+                      <input name="email" type="email" required />
+                    </label>
+                    <label class="ac-field">
+                      <span
+                        class="ac-field__label"
+                        data-i18n="app.panel.form.fields.phone"
+                      >
+                        Telefone (opcional)
+                      </span>
+                      <input
+                        name="telefone"
+                        type="tel"
+                        inputmode="tel"
+                        placeholder="(99) 99999-9999"
+                        data-phone-input
+                      />
+                    </label>
+                    <label class="ac-field">
+                      <span
+                        class="ac-field__label"
+                        data-i18n="app.panel.form.fields.password"
+                      >
+                        Senha
+                      </span>
+                      <div class="ac-field__control">
+                        <input
+                          name="senha"
+                          type="password"
+                          autocomplete="new-password"
+                          required
+                          data-password-input
+                        />
+                        <button
+                          class="ac-password-toggle"
+                          type="button"
+                          data-password-toggle
+                          aria-pressed="false"
+                          aria-label="Mostrar senha"
+                          title="Mostrar senha"
+                        >
+                          <span aria-hidden="true" data-password-toggle-icon>👁</span>
+                        </button>
+                      </div>
+                    </label>
+                    <div
+                      class="ac-panel-form__actions"
+                      role="group"
+                      aria-labelledby="panel-session-label"
+                      aria-describedby="panel-session-hint"
+                      data-session-actions
                     >
-                      Histórico de atividades
-                    </h3>
+                      <span
+                        class="ac-visually-hidden"
+                        id="panel-session-label"
+                        data-i18n="app.panel.session.current"
+                      >
+                        Sessão atual
+                      </span>
+                      <button
+                        class="ac-btn ac-btn--primary"
+                        type="submit"
+                        data-action="login-save"
+                        data-i18n="app.panel.form.submit"
+                      >
+                        Salvar alterações
+                      </button>
+                      <button
+                        class="ac-btn ac-btn--ghost"
+                        type="button"
+                        data-action="logout-preserve"
+                        data-i18n="app.panel.session.actions.logout"
+                      >
+                        Encerrar sessão
+                      </button>
+                      <button
+                        class="ac-btn ac-btn--danger"
+                        type="button"
+                        data-action="logout-clear"
+                        data-i18n="app.panel.session.actions.logout_clear"
+                      >
+                        Encerrar e remover dados
+                      </button>
+                      <p
+                        class="ac-panel-form__hint"
+                        id="panel-session-hint"
+                        data-i18n="app.panel.session.description"
+                      >
+                        Encerre a sessão mantendo os dados armazenados neste navegador
+                        ou remova todas as informações do cadastro.
+                      </p>
+                    </div>
+                  </form>
+                  <p
+                    class="ac-feedback"
+                    data-login-feedback
+                    role="status"
+                    aria-live="polite"
+                  ></p>
+                </article>
+
+                <article
+                  class="ac-panel-card ac-panel-card--history ac-history"
+                  aria-labelledby="login-log-title"
+                >
+                  <header class="ac-panel-card__head ac-history__head">
+                    <div class="ac-panel-card__titles ac-history__titles">
+                      <h3
+                        id="login-log-title"
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.history.title"
+                      >
+                        Eventos
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle ac-history__subtitle"
+                        data-i18n="app.panel.history.subtitle"
+                      >
+                        Acompanhe logins, backups e alertas registrados neste dispositivo.
+                      </p>
+                    </div>
+                    <form class="ac-history__filters" role="search">
+                      <label class="ac-history__search">
+                        <span class="ac-visually-hidden">Filtrar eventos</span>
+                        <input
+                          type="search"
+                          name="history-search"
+                          placeholder="Eventos (ex.: backup, login, 09)"
+                          autocomplete="off"
+                          data-history-search
+                        />
+                      </label>
+                      <label class="ac-history__select">
+                        <span class="ac-visually-hidden">Tipo de evento</span>
+                        <select name="history-type" data-history-filter>
+                          <option value="all">Todos os tipos</option>
+                          <option value="login">Logins</option>
+                          <option value="logout">Logoffs</option>
+                          <option value="backup">Backups</option>
+                          <option value="alert">Alertas</option>
+                        </select>
+                      </label>
+                    </form>
+                  </header>
+                  <div class="ac-history__body">
+                    <div
+                      class="ac-table-wrap ac-table-wrap--inner"
+                      data-login-log-table
+                    >
+                      <table
+                        class="ac-table ac-table--compact"
+                        aria-live="polite"
+                      >
+                        <thead>
+                          <tr>
+                            <th
+                              scope="col"
+                              data-i18n="app.panel.history.table.event"
+                            >
+                              Evento
+                            </th>
+                            <th
+                              scope="col"
+                              data-i18n="app.panel.history.table.time"
+                            >
+                              Horário
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody data-login-log-body></tbody>
+                      </table>
+                    </div>
                     <p
-                      class="ac-panel-card__subtitle ac-history__subtitle"
-                      data-i18n="app.panel.history.subtitle"
+                      class="ac-history__empty"
+                      data-login-log-empty
+                      data-i18n="app.history.empty"
                     >
-                      Acompanhe logins, logoffs e trocas de idioma registradas
-                      neste navegador.
+                      Sem registros.
                     </p>
                   </div>
-                </header>
-                <div class="ac-history__body">
-                  <div
-                    class="ac-table-wrap ac-table-wrap--inner"
-                    data-login-log-table
-                  >
-                    <table class="ac-table ac-table--compact" aria-live="polite">
-                      <thead>
-                        <tr>
-                          <th scope="col" data-i18n="app.panel.history.table.event">
-                            Evento
-                          </th>
-                          <th scope="col" data-i18n="app.panel.history.table.time">
-                            Horário
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody data-login-log-body></tbody>
-                    </table>
-                  </div>
-                  <p
-                    class="ac-history__empty"
-                    data-login-log-empty
-                    data-i18n="app.history.empty"
-                  >
-                    Sem registros.
-                  </p>
-                </div>
-              </article>
-            </div>
-          </section>
-        </main>
+                </article>
+              </div>
+            </section>
+          </main>
       </div>
 
       <footer class="ac-footer" role="contentinfo">


### PR DESCRIPTION
## Summary
- redesign the stage header with integration status chips and export action to mirror the reference layout
- rebuild the panel grid with dedicated overview, sync, backup, connectivity, security, and event cards plus search and filter controls
- expand styling tokens for chips, cards, and sync widgets and adjust JS to update duplicated status indicators safely

## Testing
- npm test *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e58bd3bd3c8320a89aceb5948ff433