### PR TITLE
Reconcile panel layout with sync controls

### DIFF
--- a/appbase/app.css
+++ b/appbase/app.css
@@ -659,6 +659,49 @@ select {
   align-items: center;
   gap: 12px;
   margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.ac-stage__chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.ac-stage__export {
+  white-space: nowrap;
+}
+
+.ac-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: var(--ac-border-width) solid var(--ac-border-soft);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--ac-muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+:root[data-theme='dark'] .ac-status-chip {
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--ac-panel-head-ink);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.ac-status-chip__icon {
+  font-size: 1rem;
+}
+
+.ac-status-chip__label {
+  display: inline-flex;
+  align-items: center;
 }
 
 .ac-stage__close {
@@ -773,6 +816,11 @@ select {
   border-top: var(--ac-border-width) solid var(--ac-panel-head-border);
 }
 
+.ac-panel__grid {
+  display: grid;
+  gap: 24px;
+}
+
 .ac-panel-card {
   background: var(--ac-card-bg);
   border: var(--ac-border-width) solid var(--ac-border);
@@ -781,6 +829,18 @@ select {
   display: grid;
   gap: 20px;
   box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+}
+
+.ac-panel-card__badge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--ac-primary);
+  color: var(--ac-on-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .ac-panel-card__head {
@@ -808,13 +868,27 @@ select {
   font-weight: 500;
 }
 
+.ac-panel-card__note {
+  margin: 0;
+  color: var(--ac-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 .ac-panel-kpis {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
-.ac-kpi-card {
+.ac-session-status {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.ac-kpi-card,
+.ac-session-status__item {
   background: var(--ac-bg);
   border: var(--ac-border-width) solid var(--ac-border-soft);
   border-radius: 16px;
@@ -824,7 +898,31 @@ select {
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
 }
 
-.ac-kpi-card__label {
+@media (min-width: 960px) {
+  .ac-panel__grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+
+  .ac-panel__grid > .ac-panel-card {
+    grid-column: span 12;
+  }
+}
+
+@media (min-width: 1200px) {
+  .ac-panel-card--overview,
+  .ac-panel-card--sync {
+    grid-column: span 6;
+  }
+
+  .ac-panel-card--backup,
+  .ac-panel-card--connectivity,
+  .ac-panel-card--security {
+    grid-column: span 4;
+  }
+}
+
+.ac-kpi-card__label,
+.ac-session-status__label {
   margin: 0;
   font-size: 0.9rem;
   color: var(--ac-muted);
@@ -832,7 +930,8 @@ select {
   text-transform: uppercase;
 }
 
-.ac-kpi-card__value {
+.ac-kpi-card__value,
+.ac-session-status__value {
   margin: 0;
   font-size: 1.5rem;
   font-weight: 700;
@@ -842,7 +941,8 @@ select {
   gap: 10px;
 }
 
-.ac-kpi-card__meta {
+.ac-kpi-card__meta,
+.ac-session-status__meta {
   margin: 0;
   color: var(--ac-muted);
   font-size: 0.95rem;
@@ -887,6 +987,131 @@ select {
 
 :root[data-theme='dark'] .ac-panel-card--kpis .ac-kpi-card {
   background: rgba(15, 23, 42, 0.7);
+}
+
+.ac-panel-card--sync {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.ac-sync-providers {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .ac-sync-providers {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.ac-sync-card {
+  border: var(--ac-border-width) solid var(--ac-border-soft);
+  border-radius: 20px;
+  padding: 20px;
+  background: var(--ac-panel-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+:root[data-theme='dark'] .ac-sync-card {
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.ac-sync-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.ac-sync-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ac-sync-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.ac-sync-card__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ac-muted);
+}
+
+.ac-sync-card__indicator {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.ac-sync-card__message {
+  margin: 0;
+}
+
+.ac-sync-card__last {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ac-muted);
+}
+
+.ac-sync-card__devices-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.ac-sync-card__devices {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ac-sync-card__device {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+:root[data-theme='dark'] .ac-sync-card__device {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.ac-sync-card__device-name {
+  font-weight: 600;
+}
+
+.ac-sync-card__device-model,
+.ac-sync-card__device-last {
+  font-size: 0.85rem;
+  color: var(--ac-muted);
+}
+
+.ac-sync-card__devices-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ac-muted);
+}
+
+.ac-sync-card__toggle,
+.ac-sync-card__logout {
+  align-self: flex-start;
+}
+
+.ac-sync-card__logout {
+  margin-top: 4px;
 }
 
 .ac-panel-summary {
@@ -997,6 +1222,35 @@ select {
   flex-direction: column;
   gap: 12px;
   width: 100%;
+}
+
+.ac-history__filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.ac-history__search,
+.ac-history__select {
+  display: inline-flex;
+  align-items: center;
+}
+
+.ac-history__search input,
+.ac-history__select select {
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: var(--ac-border-width) solid var(--ac-border-soft);
+  background: var(--ac-bg);
+  font: inherit;
+  color: inherit;
+  min-height: 38px;
+}
+
+.ac-history__search input {
+  min-width: 220px;
 }
 
 .ac-history__titles {

--- a/appbase/app.js
+++ b/appbase/app.js
@@ -2,13 +2,30 @@ import {
   loadState as loadPersistedState,
   saveState as persistState,
 } from './storage/indexeddb.js';
+import {
+  ensureProvider,
+  syncProvider,
+  disconnectAll,
+} from './sync/providers.js';
 
 (function () {
   const THEME_STORAGE_KEY = 'marco-appbase:theme';
   const FEEDBACK_TIMEOUT = 2200;
   const BUTTON_FEEDBACK_DURATION = 900;
   const BUTTON_FEEDBACK_CLASS = 'ac-feedback-active';
-  const VALID_HISTORY_TYPES = ['login', 'logout', 'locale'];
+  const VALID_HISTORY_TYPES = ['login', 'logout', 'locale', 'sync'];
+  const SUPPORTED_SYNC_PROVIDERS = ['googleDrive', 'oneDrive'];
+  const VALID_SYNC_ACTIONS = ['enabled', 'disabled', 'logoutAll', 'error'];
+  const SYNC_STATUS_KEYS = {
+    idle: 'app.sync.status.idle',
+    ready: 'app.sync.status.ready',
+    syncing: 'app.sync.status.syncing',
+    error: 'app.sync.status.error',
+  };
+  const SYNC_TOGGLE_LABEL_KEYS = {
+    enable: 'app.sync.toggle.enable',
+    disable: 'app.sync.toggle.disable',
+  };
   const THEMES = { LIGHT: 'light', DARK: 'dark' };
   const DEFAULT_TITLE_KEY = 'app.document.title.default';
   const TITLE_WITH_USER_KEY = 'app.document.title.user';
@@ -68,6 +85,33 @@ import {
     logoutPreserve: 'app.history.event.logout_preserve',
     logoutClear: 'app.history.event.logout_clear',
     locale: 'app.history.event.locale_change',
+    syncEnabled: 'app.history.event.sync.enabled',
+    syncDisabled: 'app.history.event.sync.disabled',
+    syncLogoutAll: 'app.history.event.sync.logout_all',
+    syncError: 'app.history.event.sync.error',
+  };
+  const SYNC_PROVIDER_LABEL_KEYS = {
+    googleDrive: 'app.sync.provider.googleDrive',
+    oneDrive: 'app.sync.provider.oneDrive',
+  };
+  const SYNC_DEVICES_TITLE_KEY = 'app.sync.devices.title';
+  const SYNC_DEVICES_EMPTY_KEY = 'app.sync.devices.empty';
+  const SYNC_LAST_NEVER_KEY = 'app.sync.last_sync.never';
+  const SYNC_LAST_LABEL_KEY = 'app.sync.last_sync.label';
+  const SYNC_DEVICES_LAST_SEEN_KEY = 'app.sync.devices.last_seen';
+  const SYNC_LOGOUT_KEY = 'app.sync.logout_all';
+  const SYNC_FEEDBACK_KEYS = {
+    providerMissing: 'app.sync.feedback.provider_missing',
+    networkError: 'app.sync.feedback.network_error',
+    enabled: 'app.sync.feedback.enabled',
+    disabled: 'app.sync.feedback.disabled',
+    logoutAll: 'app.sync.feedback.logout_all_success',
+  };
+  const SYNC_STATUS_CLASSNAMES = {
+    ready: 'ac-dot--ok',
+    syncing: 'ac-dot--warn',
+    idle: 'ac-dot--idle',
+    error: 'ac-dot--crit',
   };
   const LOCALE_NAME_FALLBACKS = {
     'pt-BR': 'Brasil',
@@ -76,6 +120,7 @@ import {
   };
   const FOOTER_STATUS_KEYS = {
     connected: 'app.footer.status.connected',
+    connectedSync: 'app.footer.status.connected_sync',
     disconnected: 'app.footer.status.disconnected',
   };
   const FOOTER_STATUS_LABEL_KEY = 'app.footer.status.label';
@@ -137,11 +182,74 @@ import {
     [HISTORY_EVENT_KEYS.logoutPreserve]: 'Logoff (dados mantidos)',
     [HISTORY_EVENT_KEYS.logoutClear]: 'Logoff (dados removidos)',
     [HISTORY_EVENT_KEYS.locale]: 'Idioma alterado para {{locale}}',
+    [HISTORY_EVENT_KEYS.syncEnabled]: '{{provider}} habilitado',
+    [HISTORY_EVENT_KEYS.syncDisabled]: '{{provider}} desabilitado',
+    [HISTORY_EVENT_KEYS.syncLogoutAll]: '{{provider}} desconectado em todos os dispositivos',
+    [HISTORY_EVENT_KEYS.syncError]: 'Falha de sincronização em {{provider}}',
+    'app.sync.panel.title': 'Sincronização de arquivos',
+    'app.sync.panel.subtitle': 'Gerencie integrações com Google Drive e OneDrive.',
+    [SYNC_PROVIDER_LABEL_KEYS.googleDrive]: 'Google Drive',
+    [SYNC_PROVIDER_LABEL_KEYS.oneDrive]: 'OneDrive',
+    [SYNC_TOGGLE_LABEL_KEYS.enable]: 'Ativar {{provider}}',
+    [SYNC_TOGGLE_LABEL_KEYS.disable]: 'Desativar {{provider}}',
+    [SYNC_STATUS_KEYS.idle]: 'Inativo',
+    [SYNC_STATUS_KEYS.ready]: 'Sincronizado',
+    [SYNC_STATUS_KEYS.syncing]: 'Sincronizando…',
+    [SYNC_STATUS_KEYS.error]: 'Falha na sincronização',
+    [SYNC_DEVICES_TITLE_KEY]: 'Dispositivos autorizados',
+    [SYNC_DEVICES_EMPTY_KEY]: 'Nenhum dispositivo conectado.',
+    [SYNC_DEVICES_LAST_SEEN_KEY]: 'Último acesso em {{time}}',
+    [SYNC_LAST_NEVER_KEY]: 'Nunca sincronizado',
+    [SYNC_LAST_LABEL_KEY]: 'Última sincronização: {{time}}',
+    [SYNC_LOGOUT_KEY]: 'Deslogar de todos',
+    [SYNC_FEEDBACK_KEYS.providerMissing]:
+      'Instale o cliente {{provider}} e faça login para continuar.',
+    [SYNC_FEEDBACK_KEYS.networkError]:
+      'Não foi possível sincronizar com {{provider}}. Verifique sua conexão e tente novamente.',
+    [SYNC_FEEDBACK_KEYS.enabled]: '{{provider}} ativado.',
+    [SYNC_FEEDBACK_KEYS.disabled]: '{{provider}} desativado.',
+    [SYNC_FEEDBACK_KEYS.logoutAll]: 'Sessões de {{provider}} foram desconectadas.',
+    'app.sync.status.message.idle': 'Sincronização aguardando acionamento.',
+    'app.sync.status.message.ready': 'Sincronização concluída com sucesso.',
+    'app.sync.status.message.syncing': 'Sincronização em andamento…',
+    'app.sync.status.message.error': 'Revise a instalação do conector e tente novamente.',
+    'app.stage.integrations.sync_disabled': 'Sync desativada',
+    'app.stage.integrations.backup_disabled': 'Backup desativado',
+    'app.stage.export': 'Exportar',
+    'app.panel.overview.title': 'Login',
+    'app.panel.overview.subtitle': 'Usuário, conta e últimas credenciais registradas.',
+    'app.panel.backup.title': 'Backup',
+    'app.panel.backup.subtitle':
+      'Proteja registros críticos e restaure configurações em segundos.',
+    'app.panel.backup.note':
+      'Configure uma conta de nuvem ou exporte manualmente os dados para garantir redundância.',
+    'app.panel.backup.status.disabled': 'Backup desativado',
+    'app.panel.connectivity.title': 'Conectividade',
+    'app.panel.connectivity.subtitle':
+      'Parâmetros ativos e latência dos serviços em tempo real.',
+    'app.panel.connectivity.note':
+      'Monitore tempo de resposta e priorize links redundantes durante janelas críticas de operação.',
+    'app.panel.security.title': 'Segurança',
+    'app.panel.security.subtitle':
+      'Sessões autenticadas, políticas aplicadas e eventos recentes.',
+    'app.panel.security.note':
+      'Garanta autenticação multifator nos dispositivos conectados e revise logs semanalmente.',
+    'app.panel.form.badge': 'Editar',
+    'app.panel.history.title': 'Eventos',
+    'app.panel.history.subtitle':
+      'Acompanhe logins, backups e alertas registrados neste dispositivo.',
+    'app.panel.history.search.placeholder': 'Eventos (ex.: backup, login, 09)',
+    'app.panel.history.filter.all': 'Todos os tipos',
+    'app.panel.history.filter.login': 'Logins',
+    'app.panel.history.filter.logout': 'Logoffs',
+    'app.panel.history.filter.backup': 'Backups',
+    'app.panel.history.filter.alert': 'Alertas',
     'app.locale.menu.title': 'Idioma do AppBase',
     'app.locale.menu.options.pt-BR': 'Brasil',
     'app.locale.menu.options.en-US': 'Estados Unidos',
     'app.locale.menu.options.es-ES': 'Espanha',
     [FOOTER_STATUS_KEYS.connected]: 'Conectado',
+    [FOOTER_STATUS_KEYS.connectedSync]: 'Conectado • Sync ativo',
     [FOOTER_STATUS_KEYS.disconnected]: 'Desconectado',
     [FOOTER_STATUS_LABEL_KEY]: 'Status:',
     [FOOTER_DIRTY_LABEL_KEY]: 'Alterações:',
@@ -174,8 +282,8 @@ import {
     loginLast: document.querySelector('[data-login-last]'),
     loginForm: document.querySelector('[data-login-form]'),
     feedback: document.querySelector('[data-login-feedback]'),
-    panelStatusDot: document.querySelector('[data-panel-status-dot]'),
-    panelStatusLabel: document.querySelector('[data-panel-status-label]'),
+    panelStatusDot: document.querySelectorAll('[data-panel-status-dot]'),
+    panelStatusLabel: document.querySelectorAll('[data-panel-status-label]'),
     panelStatusHint: document.querySelector('[data-panel-status-hint]'),
     panelLastLogin: document.querySelector('[data-panel-last-login]'),
     panelLastLoginHint: document.querySelector('[data-panel-last-login-hint]'),
@@ -201,6 +309,23 @@ import {
     footerDirtyDot: document.querySelector('[data-footer-dirty-dot]'),
     footerDirtyLabel: document.querySelector('[data-footer-dirty-label]'),
     footerDirtyStatus: document.querySelector('[data-footer-dirty-status]'),
+    systemPanel: document.querySelector('[data-system-panel]'),
+    syncProviders: SUPPORTED_SYNC_PROVIDERS.reduce((accumulator, provider) => {
+      const selector = (name) =>
+        document.querySelector(`[data-sync-${name}="${provider}"]`);
+      accumulator[provider] = {
+        root: document.querySelector(`[data-sync-provider="${provider}"]`),
+        toggle: selector('toggle'),
+        status: selector('status'),
+        statusIndicator: selector('status-indicator'),
+        message: selector('message'),
+        lastUpdate: selector('last-update'),
+        devices: selector('devices'),
+        devicesEmpty: selector('devices-empty'),
+        logoutAll: selector('logout-all'),
+      };
+      return accumulator;
+    }, {}),
     phoneInput: document.querySelector('[data-phone-input]'),
     passwordInput: document.querySelector('[data-password-input]'),
     passwordToggle: document.querySelector('[data-password-toggle]'),
@@ -331,28 +456,61 @@ import {
     setPasswordVisibility(!passwordVisible);
   }
 
-  function setElementTextFromKey(element, key, options = {}) {
-    if (!element) {
+  function toElementArray(target) {
+    if (!target) {
+      return [];
+    }
+    if (Array.isArray(target)) {
+      return target.filter(Boolean);
+    }
+    if (typeof NodeList !== 'undefined' && target instanceof NodeList) {
+      return Array.from(target).filter(Boolean);
+    }
+    if (typeof HTMLCollection !== 'undefined' && target instanceof HTMLCollection) {
+      return Array.from(target).filter(Boolean);
+    }
+    if (typeof Element !== 'undefined' && target instanceof Element) {
+      return [target];
+    }
+    return [];
+  }
+
+  function setElementTextFromKey(target, key, options = {}) {
+    const elementsToUpdate = toElementArray(target);
+    if (!elementsToUpdate.length) {
       return;
     }
     if (!key) {
-      element.removeAttribute('data-i18n');
+      elementsToUpdate.forEach((element) => {
+        if (element) {
+          element.removeAttribute('data-i18n');
+        }
+      });
       return;
     }
     const { fallbackKey = key, replacements = {} } = options;
-    element.setAttribute('data-i18n', key);
     const fallback = fallbackFor(fallbackKey, '');
     const template = translate(key, fallback);
     const value = formatMessage(template || fallback, replacements) || fallback;
-    element.textContent = value;
+    elementsToUpdate.forEach((element) => {
+      if (element) {
+        element.setAttribute('data-i18n', key);
+        element.textContent = value;
+      }
+    });
   }
 
-  function clearElementTranslation(element, text = '') {
-    if (!element) {
+  function clearElementTranslation(target, text = '') {
+    const elementsToClear = toElementArray(target);
+    if (!elementsToClear.length) {
       return;
     }
-    element.removeAttribute('data-i18n');
-    element.textContent = text;
+    elementsToClear.forEach((element) => {
+      if (element) {
+        element.removeAttribute('data-i18n');
+        element.textContent = text;
+      }
+    });
   }
 
   let currentTheme = normaliseTheme(resolveInitialTheme());
@@ -700,12 +858,28 @@ import {
     syncFullscreenStateFromDocument();
   }
 
+  function getEmptyProviderState() {
+    return {
+      enabled: false,
+      status: 'idle',
+      lastSync: '',
+      devices: [],
+      message: '',
+      errorCode: '',
+    };
+  }
+
   function getEmptyState() {
+    const system = SUPPORTED_SYNC_PROVIDERS.reduce((accumulator, provider) => {
+      accumulator[provider] = getEmptyProviderState();
+      return accumulator;
+    }, {});
     return {
       user: null,
       lastLogin: '',
       sessionActive: false,
       history: [],
+      system,
     };
   }
 
@@ -721,7 +895,76 @@ import {
         : '';
     const history = normaliseHistory(raw.history);
     const sessionActive = Boolean(raw.sessionActive) && Boolean(user);
-    return { user, lastLogin, history, sessionActive };
+    const system = normaliseSystem(raw.system, base.system);
+    return { user, lastLogin, history, sessionActive, system };
+  }
+
+  function normaliseSystem(rawSystem, baseSystem = getEmptyState().system) {
+    const draft = { ...baseSystem };
+    if (!rawSystem || typeof rawSystem !== 'object') {
+      return draft;
+    }
+    SUPPORTED_SYNC_PROVIDERS.forEach((provider) => {
+      draft[provider] = normaliseProviderState(rawSystem[provider]);
+    });
+    return draft;
+  }
+
+  function normaliseProviderState(rawState) {
+    const base = getEmptyProviderState();
+    if (!rawState || typeof rawState !== 'object') {
+      return base;
+    }
+    const enabled = Boolean(rawState.enabled);
+    const statusKey =
+      typeof rawState.status === 'string' &&
+      Object.prototype.hasOwnProperty.call(SYNC_STATUS_KEYS, rawState.status)
+        ? rawState.status
+        : enabled
+        ? 'ready'
+        : base.status;
+    const lastSync =
+      typeof rawState.lastSync === 'string' && rawState.lastSync.trim()
+        ? rawState.lastSync
+        : '';
+    const devices = Array.isArray(rawState.devices)
+      ? rawState.devices.map((device) => normaliseProviderDevice(device)).filter(Boolean)
+      : [];
+    const message =
+      typeof rawState.message === 'string' ? rawState.message : base.message;
+    const errorCode =
+      typeof rawState.errorCode === 'string' ? rawState.errorCode : base.errorCode;
+    return {
+      ...base,
+      enabled,
+      status: statusKey,
+      lastSync,
+      devices,
+      message,
+      errorCode,
+    };
+  }
+
+  function normaliseProviderDevice(rawDevice) {
+    if (!rawDevice || typeof rawDevice !== 'object') {
+      return null;
+    }
+    const name =
+      typeof rawDevice.name === 'string' ? rawDevice.name.trim() : '';
+    const model =
+      typeof rawDevice.model === 'string' ? rawDevice.model.trim() : '';
+    const lastSeen =
+      typeof rawDevice.lastSeen === 'string' && rawDevice.lastSeen.trim()
+        ? rawDevice.lastSeen
+        : '';
+    if (!name && !model && !lastSeen) {
+      return null;
+    }
+    const device = { name, model };
+    if (lastSeen) {
+      device.lastSeen = lastSeen;
+    }
+    return device;
   }
 
   function normaliseUser(rawUser) {
@@ -776,6 +1019,18 @@ import {
     if (!type || !timestamp) {
       return null;
     }
+    if (type === 'sync') {
+      const provider = SUPPORTED_SYNC_PROVIDERS.includes(rawEntry.provider)
+        ? rawEntry.provider
+        : null;
+      const action = VALID_SYNC_ACTIONS.includes(rawEntry.action)
+        ? rawEntry.action
+        : null;
+      if (!provider || !action) {
+        return null;
+      }
+      return { type, timestamp, provider, action };
+    }
     const mode = rawEntry.mode === 'preserve' || rawEntry.mode === 'clear'
       ? rawEntry.mode
       : undefined;
@@ -808,6 +1063,49 @@ import {
     return hasUser(currentState) && Boolean(currentState.sessionActive);
   }
 
+  function getSystemState(currentState = state) {
+    if (!currentState || typeof currentState !== 'object') {
+      return getEmptyState().system;
+    }
+    return currentState.system && typeof currentState.system === 'object'
+      ? currentState.system
+      : getEmptyState().system;
+  }
+
+  function getProviderState(provider, currentState = state) {
+    if (!SUPPORTED_SYNC_PROVIDERS.includes(provider)) {
+      return getEmptyProviderState();
+    }
+    const system = getSystemState(currentState);
+    const stored = system[provider];
+    return stored && typeof stored === 'object' ? stored : getEmptyProviderState();
+  }
+
+  function isProviderSyncing(providerState) {
+    return Boolean(providerState) && providerState.status === 'syncing';
+  }
+
+  function isAnyProviderEnabled(currentState = state) {
+    const system = getSystemState(currentState);
+    return SUPPORTED_SYNC_PROVIDERS.some((provider) => Boolean(system[provider]?.enabled));
+  }
+
+  function getProviderLabel(provider) {
+    const key = SYNC_PROVIDER_LABEL_KEYS[provider];
+    if (!key) {
+      return provider;
+    }
+    const fallback = fallbackFor(key, provider || '');
+    return translate(key, fallback) || fallback;
+  }
+
+  function formatDeviceLastSeen(lastSeen) {
+    if (!lastSeen) {
+      return '';
+    }
+    return formatDateTime(lastSeen);
+  }
+
   function createHistoryEntry(type, options = {}) {
     if (!VALID_HISTORY_TYPES.includes(type)) {
       return null;
@@ -818,6 +1116,18 @@ import {
         ? options.timestamp
         : nowIso(),
     };
+    if (type === 'sync') {
+      const provider = options.provider;
+      const action = options.action;
+      if (
+        !SUPPORTED_SYNC_PROVIDERS.includes(provider) ||
+        !VALID_SYNC_ACTIONS.includes(action)
+      ) {
+        return null;
+      }
+      base.provider = provider;
+      base.action = action;
+    }
     if (options.mode === 'preserve' || options.mode === 'clear') {
       base.mode = options.mode;
     }
@@ -907,13 +1217,23 @@ import {
     return new Date().toISOString();
   }
 
-  function setState(updater) {
+  function setState(updater, options = {}) {
+    const { dirty, preserveDirty = false } = options;
     const nextRaw = typeof updater === 'function' ? updater(state) : updater;
     const next = normaliseState({ ...state, ...nextRaw });
     state = next;
-    stateDirty = false;
+    if (typeof dirty === 'boolean') {
+      stateDirty = dirty;
+    } else if (!preserveDirty) {
+      stateDirty = false;
+    }
     passwordVisible = false;
     updateUI();
+    if (typeof dirty !== 'boolean' && !preserveDirty) {
+      syncDirtyFlagFromForm();
+    } else if (typeof dirty === 'boolean') {
+      updateStatusSummary();
+    }
     return persistState(state)
       .catch((error) => {
         console.warn('AppBase: falha ao persistir dados', error);
@@ -931,6 +1251,7 @@ import {
     updateStage();
     updateLoginFormFields();
     updateLogHistory();
+    updateSystemPanel();
     updateLogControls();
   }
 
@@ -993,6 +1314,7 @@ import {
 
   function updateStatusSummary() {
     const loggedIn = isLoggedIn();
+    const syncActive = isAnyProviderEnabled();
     const dirtyDisabled = !loggedIn;
     if (elements.footerStatusText) {
       setElementTextFromKey(elements.footerStatusText, FOOTER_STATUS_LABEL_KEY);
@@ -1003,7 +1325,9 @@ import {
     }
     if (elements.footerStatusLabel) {
       const statusKey = loggedIn
-        ? FOOTER_STATUS_KEYS.connected
+        ? syncActive
+          ? FOOTER_STATUS_KEYS.connectedSync
+          : FOOTER_STATUS_KEYS.connected
         : FOOTER_STATUS_KEYS.disconnected;
       setElementTextFromKey(elements.footerStatusLabel, statusKey);
     }
@@ -1079,13 +1403,16 @@ import {
     const historyCount = getHistoryCount();
     const lastLoginValue = hasData ? formatDateTime(state.lastLogin) : '—';
 
-    if (elements.panelStatusDot) {
-      elements.panelStatusDot.classList.toggle('ac-dot--ok', loggedIn);
-      elements.panelStatusDot.classList.toggle('ac-dot--crit', !loggedIn && !hasData);
-      elements.panelStatusDot.classList.toggle('ac-dot--warn', hasData && !loggedIn);
+    const statusDots = toElementArray(elements.panelStatusDot);
+    if (statusDots.length) {
+      statusDots.forEach((dot) => {
+        dot.classList.toggle('ac-dot--ok', loggedIn);
+        dot.classList.toggle('ac-dot--crit', !loggedIn && !hasData);
+        dot.classList.toggle('ac-dot--warn', hasData && !loggedIn);
+      });
     }
 
-    if (elements.panelStatusLabel) {
+    if (toElementArray(elements.panelStatusLabel).length) {
       const statusKey = loggedIn
         ? PANEL_STATUS_LABEL_KEYS.connected
         : PANEL_STATUS_LABEL_KEYS.disconnected;
@@ -1268,6 +1595,32 @@ import {
       });
       return message || fallback;
     }
+    if (entry.type === 'sync') {
+      const providerLabel = getProviderLabel(entry.provider);
+      const replacements = {
+        provider: providerLabel || entry.provider || '',
+      };
+      if (entry.action === 'enabled') {
+        const fallback = fallbackFor(HISTORY_EVENT_KEYS.syncEnabled, '');
+        const template = translate(HISTORY_EVENT_KEYS.syncEnabled, fallback);
+        return formatMessage(template || fallback, replacements) || fallback;
+      }
+      if (entry.action === 'disabled') {
+        const fallback = fallbackFor(HISTORY_EVENT_KEYS.syncDisabled, '');
+        const template = translate(HISTORY_EVENT_KEYS.syncDisabled, fallback);
+        return formatMessage(template || fallback, replacements) || fallback;
+      }
+      if (entry.action === 'logoutAll') {
+        const fallback = fallbackFor(HISTORY_EVENT_KEYS.syncLogoutAll, '');
+        const template = translate(HISTORY_EVENT_KEYS.syncLogoutAll, fallback);
+        return formatMessage(template || fallback, replacements) || fallback;
+      }
+      if (entry.action === 'error') {
+        const fallback = fallbackFor(HISTORY_EVENT_KEYS.syncError, '');
+        const template = translate(HISTORY_EVENT_KEYS.syncError, fallback);
+        return formatMessage(template || fallback, replacements) || fallback;
+      }
+    }
     return '';
   }
 
@@ -1305,6 +1658,122 @@ import {
     elements.logTableWrap.hidden = false;
     elements.logEmpty.forEach((emptyElement) => {
       emptyElement.hidden = true;
+    });
+  }
+
+  function updateSystemPanel() {
+    if (!elements.systemPanel || !elements.syncProviders) {
+      return;
+    }
+    const loggedIn = isLoggedIn();
+    SUPPORTED_SYNC_PROVIDERS.forEach((provider) => {
+      const refs = elements.syncProviders[provider];
+      if (!refs) {
+        return;
+      }
+      const providerState = getProviderState(provider);
+      const providerLabel = getProviderLabel(provider);
+      const busy = isProviderSyncing(providerState);
+      if (refs.toggle) {
+        const labelKey = providerState.enabled
+          ? SYNC_TOGGLE_LABEL_KEYS.disable
+          : SYNC_TOGGLE_LABEL_KEYS.enable;
+        const fallback = fallbackFor(labelKey, '');
+        const template = translate(labelKey, fallback);
+        const label = formatMessage(template || fallback, {
+          provider: providerLabel,
+        });
+        refs.toggle.setAttribute('aria-pressed', providerState.enabled ? 'true' : 'false');
+        refs.toggle.setAttribute('aria-label', label);
+        refs.toggle.setAttribute('title', label);
+        refs.toggle.textContent = label;
+        refs.toggle.disabled = busy || !loggedIn;
+      }
+      if (refs.status) {
+        const statusKey = SYNC_STATUS_KEYS[providerState.status] || SYNC_STATUS_KEYS.idle;
+        setElementTextFromKey(refs.status, statusKey);
+      }
+      if (refs.statusIndicator) {
+        refs.statusIndicator.classList.remove(
+          'ac-dot--ok',
+          'ac-dot--warn',
+          'ac-dot--crit',
+          'ac-dot--idle'
+        );
+        const className = SYNC_STATUS_CLASSNAMES[providerState.status] || SYNC_STATUS_CLASSNAMES.idle;
+        if (className) {
+          refs.statusIndicator.classList.add(className);
+        }
+      }
+      if (refs.message) {
+        if (providerState.message) {
+          clearElementTranslation(refs.message, providerState.message);
+        } else {
+          const key = `app.sync.status.message.${providerState.status}`;
+          setElementTextFromKey(refs.message, key, { fallbackKey: key });
+        }
+      }
+      if (refs.lastUpdate) {
+        if (providerState.lastSync) {
+          const formatted = formatDeviceLastSeen(providerState.lastSync);
+          setElementTextFromKey(refs.lastUpdate, SYNC_LAST_LABEL_KEY, {
+            replacements: { time: formatted },
+          });
+        } else {
+          setElementTextFromKey(refs.lastUpdate, SYNC_LAST_NEVER_KEY);
+        }
+      }
+      if (refs.devices) {
+        refs.devices.textContent = '';
+        const devices = Array.isArray(providerState.devices)
+          ? providerState.devices.filter(Boolean)
+          : [];
+        devices.forEach((device) => {
+          const item = document.createElement('li');
+          item.className = 'ac-sync-card__device';
+          const name = document.createElement('span');
+          name.className = 'ac-sync-card__device-name';
+          name.textContent = device.name || providerLabel;
+          item.appendChild(name);
+          if (device.model) {
+            const model = document.createElement('span');
+            model.className = 'ac-sync-card__device-model';
+            model.textContent = device.model;
+            item.appendChild(model);
+          }
+          if (device.lastSeen) {
+            const formatted = formatDeviceLastSeen(device.lastSeen);
+            if (formatted) {
+              const lastSeen = document.createElement('span');
+              lastSeen.className = 'ac-sync-card__device-last';
+              const fallback = fallbackFor(SYNC_DEVICES_LAST_SEEN_KEY, '');
+              const template = translate(SYNC_DEVICES_LAST_SEEN_KEY, fallback);
+              lastSeen.textContent = formatMessage(template || fallback, {
+                time: formatted,
+              });
+              item.appendChild(lastSeen);
+            }
+          }
+          refs.devices.appendChild(item);
+        });
+        if (refs.devicesEmpty) {
+          refs.devicesEmpty.hidden = devices.length > 0;
+          if (!devices.length) {
+            setElementTextFromKey(refs.devicesEmpty, SYNC_DEVICES_EMPTY_KEY);
+          }
+        }
+      }
+      if (refs.logoutAll) {
+        const label = translate(SYNC_LOGOUT_KEY, fallbackFor(SYNC_LOGOUT_KEY, ''));
+        refs.logoutAll.textContent = label;
+        refs.logoutAll.setAttribute('aria-label', label);
+        refs.logoutAll.setAttribute('title', label);
+        const hasDevices = Array.isArray(providerState.devices)
+          ? providerState.devices.length > 0
+          : false;
+        refs.logoutAll.disabled =
+          busy || !providerState.enabled || !hasDevices || !loggedIn;
+      }
     });
   }
 
@@ -1496,6 +1965,262 @@ import {
     focusPanelAccess();
   }
 
+  async function handleSyncToggle(provider) {
+    if (!SUPPORTED_SYNC_PROVIDERS.includes(provider)) {
+      return;
+    }
+    if (!isLoggedIn()) {
+      return;
+    }
+    const providerState = getProviderState(provider);
+    if (isProviderSyncing(providerState)) {
+      return;
+    }
+    if (providerState.enabled) {
+      await disableProvider(provider);
+    } else {
+      await performProviderSync(provider);
+    }
+  }
+
+  async function performProviderSync(provider) {
+    const providerLabel = getProviderLabel(provider);
+    const previousState = getProviderState(provider);
+    await setState((current) => {
+      const system = getSystemState(current);
+      return {
+        ...current,
+        system: {
+          ...system,
+          [provider]: {
+            ...system[provider],
+            enabled: true,
+            status: 'syncing',
+            message: '',
+            errorCode: '',
+          },
+        },
+      };
+    }, { preserveDirty: true });
+    try {
+      await ensureProvider(provider);
+      const result = await syncProvider(provider);
+      const syncTimestamp =
+        result && typeof result.lastSync === 'string' && result.lastSync
+          ? result.lastSync
+          : nowIso();
+      const devices = Array.isArray(result?.devices) ? result.devices.filter(Boolean) : [];
+      const message =
+        result && typeof result.message === 'string' ? result.message : '';
+      const historyEntry = createHistoryEntry('sync', {
+        provider,
+        action: 'enabled',
+        timestamp: syncTimestamp,
+      });
+      await setState((current) => {
+        const system = getSystemState(current);
+        const nextHistory = historyEntry
+          ? [historyEntry, ...(current.history || [])]
+          : current.history || [];
+        return {
+          ...current,
+          history: nextHistory,
+          system: {
+            ...system,
+            [provider]: {
+              ...system[provider],
+              enabled: true,
+              status: 'ready',
+              lastSync: syncTimestamp,
+              devices,
+              message,
+              errorCode: '',
+            },
+          },
+        };
+      }, { preserveDirty: true });
+      setLoginFeedback('success', SYNC_FEEDBACK_KEYS.enabled, {
+        replacements: { provider: providerLabel },
+      });
+    } catch (error) {
+      const errorCode = error?.code || 'unknown';
+      const normalizedCode =
+        typeof errorCode === 'string' ? errorCode.toLowerCase() : '';
+      const messageKey =
+        normalizedCode.includes('sdk') ||
+        normalizedCode.includes('provider') ||
+        normalizedCode.includes('login')
+          ? SYNC_FEEDBACK_KEYS.providerMissing
+          : SYNC_FEEDBACK_KEYS.networkError;
+      const fallbackMessage =
+        typeof error?.message === 'string' && error.message
+          ? error.message
+          : translate(messageKey, fallbackFor(messageKey, ''));
+      const historyEntry = createHistoryEntry('sync', {
+        provider,
+        action: 'error',
+      });
+      await setState((current) => {
+        const system = getSystemState(current);
+        const nextHistory = historyEntry
+          ? [historyEntry, ...(current.history || [])]
+          : current.history || [];
+        return {
+          ...current,
+          history: nextHistory,
+          system: {
+            ...system,
+            [provider]: {
+              ...system[provider],
+              enabled: Boolean(previousState.enabled),
+              status: 'error',
+              message: fallbackMessage,
+              errorCode,
+            },
+          },
+        };
+      }, { preserveDirty: true });
+      setLoginFeedback('error', messageKey, {
+        replacements: { provider: providerLabel },
+        fallback: fallbackMessage,
+      });
+    }
+  }
+
+  async function disableProvider(provider) {
+    const providerLabel = getProviderLabel(provider);
+    const historyEntry = createHistoryEntry('sync', {
+      provider,
+      action: 'disabled',
+    });
+    await setState((current) => {
+      const system = getSystemState(current);
+      const nextHistory = historyEntry
+        ? [historyEntry, ...(current.history || [])]
+        : current.history || [];
+      return {
+        ...current,
+        history: nextHistory,
+        system: {
+          ...system,
+          [provider]: {
+            ...system[provider],
+            enabled: false,
+            status: 'idle',
+            message: '',
+            errorCode: '',
+          },
+        },
+      };
+    }, { preserveDirty: true });
+    setLoginFeedback('success', SYNC_FEEDBACK_KEYS.disabled, {
+      replacements: { provider: providerLabel },
+    });
+  }
+
+  async function handleSyncLogoutAll(provider) {
+    if (!SUPPORTED_SYNC_PROVIDERS.includes(provider)) {
+      return;
+    }
+    if (!isLoggedIn()) {
+      return;
+    }
+    const providerState = getProviderState(provider);
+    if (isProviderSyncing(providerState) || !providerState.enabled) {
+      return;
+    }
+    if (!Array.isArray(providerState.devices) || providerState.devices.length === 0) {
+      return;
+    }
+    const providerLabel = getProviderLabel(provider);
+    await setState((current) => {
+      const system = getSystemState(current);
+      return {
+        ...current,
+        system: {
+          ...system,
+          [provider]: {
+            ...system[provider],
+            status: 'syncing',
+          },
+        },
+      };
+    }, { preserveDirty: true });
+    try {
+      await ensureProvider(provider);
+      await disconnectAll(provider);
+      const historyEntry = createHistoryEntry('sync', {
+        provider,
+        action: 'logoutAll',
+      });
+      await setState((current) => {
+        const system = getSystemState(current);
+        const nextHistory = historyEntry
+          ? [historyEntry, ...(current.history || [])]
+          : current.history || [];
+        return {
+          ...current,
+          history: nextHistory,
+          system: {
+            ...system,
+            [provider]: {
+              ...system[provider],
+              enabled: false,
+              status: 'idle',
+              devices: [],
+              message: '',
+              errorCode: '',
+            },
+          },
+        };
+      }, { preserveDirty: true });
+      setLoginFeedback('success', SYNC_FEEDBACK_KEYS.logoutAll, {
+        replacements: { provider: providerLabel },
+      });
+    } catch (error) {
+      const errorCode = error?.code || 'unknown';
+      const normalizedCode =
+        typeof errorCode === 'string' ? errorCode.toLowerCase() : '';
+      const messageKey =
+        normalizedCode.includes('sdk') ||
+        normalizedCode.includes('provider') ||
+        normalizedCode.includes('login')
+          ? SYNC_FEEDBACK_KEYS.providerMissing
+          : SYNC_FEEDBACK_KEYS.networkError;
+      const fallbackMessage =
+        typeof error?.message === 'string' && error.message
+          ? error.message
+          : translate(messageKey, fallbackFor(messageKey, ''));
+      const historyEntry = createHistoryEntry('sync', {
+        provider,
+        action: 'error',
+      });
+      await setState((current) => {
+        const system = getSystemState(current);
+        const nextHistory = historyEntry
+          ? [historyEntry, ...(current.history || [])]
+          : current.history || [];
+        return {
+          ...current,
+          history: nextHistory,
+          system: {
+            ...system,
+            [provider]: {
+              ...system[provider],
+              status: 'error',
+              message: fallbackMessage,
+              errorCode,
+            },
+          },
+        };
+      }, { preserveDirty: true });
+      setLoginFeedback('error', messageKey, {
+        replacements: { provider: providerLabel },
+        fallback: fallbackMessage,
+      });
+    }
+  }
+
   window.addEventListener('app:i18n:locale_changed', (event) => {
     const detailLocale = event?.detail?.locale;
     const currentLocale = detailLocale || getActiveLocale();
@@ -1612,6 +2337,27 @@ import {
         }
       });
     }
+
+    SUPPORTED_SYNC_PROVIDERS.forEach((provider) => {
+      const refs = elements.syncProviders?.[provider];
+      if (!refs) {
+        return;
+      }
+      if (refs.toggle) {
+        refs.toggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          applyButtonFeedback(event.currentTarget);
+          void handleSyncToggle(provider);
+        });
+      }
+      if (refs.logoutAll) {
+        refs.logoutAll.addEventListener('click', (event) => {
+          event.preventDefault();
+          applyButtonFeedback(event.currentTarget);
+          void handleSyncLogoutAll(provider);
+        });
+      }
+    });
   }
 
   async function boot() {

--- a/appbase/index.html
+++ b/appbase/index.html
@@ -177,6 +177,37 @@
                 </p>
               </div>
               <div class="ac-stage__actions">
+                <div
+                  class="ac-stage__chips"
+                  role="group"
+                  aria-label="Status das integrações"
+                >
+                  <span class="ac-status-chip" role="status">
+                    <span class="ac-status-chip__icon" aria-hidden="true">☁️</span>
+                    <span
+                      class="ac-status-chip__label"
+                      data-i18n="app.stage.integrations.sync_disabled"
+                    >
+                      Sync desativada
+                    </span>
+                  </span>
+                  <span class="ac-status-chip" role="status">
+                    <span class="ac-status-chip__icon" aria-hidden="true">💾</span>
+                    <span
+                      class="ac-status-chip__label"
+                      data-i18n="app.stage.integrations.backup_disabled"
+                    >
+                      Backup desativado
+                    </span>
+                  </span>
+                  <button
+                    class="ac-btn ac-btn--outline ac-stage__export"
+                    type="button"
+                    data-i18n="app.stage.export"
+                  >
+                    Exportar
+                  </button>
+                </div>
                 <button
                   class="ac-iconbtn ac-iconbtn--small ac-stage__close"
                   type="button"
@@ -189,133 +220,458 @@
             </header>
 
             <div class="ac-panel" data-panel>
-              <article
-                class="ac-panel-card ac-panel-card--kpis"
-                aria-labelledby="painel-insights-title"
-              >
-                <header class="ac-panel-card__head">
-                  <div class="ac-panel-card__titles">
-                    <h3
-                      id="painel-insights-title"
-                      class="ac-panel-card__title"
-                      data-i18n="app.panel.kpis.title"
-                    >
-                      Indicadores
-                    </h3>
-                    <p
-                      class="ac-panel-card__subtitle"
-                      data-i18n="app.panel.kpis.subtitle"
-                    >
-                      Resumo do painel em tempo real.
-                    </p>
-                  </div>
-                </header>
-                <div
-                  class="ac-panel-kpis"
-                  role="group"
-                  aria-label="Indicadores do painel"
-                  data-panel-kpis-group
+              <div class="ac-panel__grid">
+                <article
+                  class="ac-panel-card ac-panel-card--overview"
+                  aria-labelledby="painel-login-title"
                 >
-                  <article class="ac-kpi-card" data-panel-kpi="status">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.status.label"
-                    >
-                      Status do painel
-                    </p>
-                    <div class="ac-kpi-card__value">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        id="painel-login-title"
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.overview.title"
+                      >
+                        Login
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.overview.subtitle"
+                      >
+                        Usuário, conta e últimas credenciais registradas.
+                      </p>
+                    </div>
+                    <span class="ac-status-chip" role="status">
                       <span
                         class="ac-dot ac-dot--crit"
                         aria-hidden="true"
                         data-panel-status-dot
                       ></span>
                       <span
+                        class="ac-status-chip__label"
                         data-panel-status-label
                         data-i18n="app.panel.kpis.status.states.disconnected"
                       >
                         Desconectado
                       </span>
+                    </span>
+                  </header>
+                  <dl class="ac-panel-summary ac-info-list" role="list">
+                    <div>
+                      <dt data-i18n="app.panel.summary.user">Usuário</dt>
+                      <dd data-login-user data-i18n="app.panel.summary.empty">
+                        Não configurado
+                      </dd>
                     </div>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-status-hint
-                      data-i18n="app.panel.kpis.status.hint.empty"
-                    >
-                      Cadastre um usuário para iniciar a sessão.
-                    </p>
-                  </article>
-                  <article class="ac-kpi-card" data-panel-kpi="last-login">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.last_login.label"
-                    >
-                      Último acesso
-                    </p>
-                    <p class="ac-kpi-card__value" data-panel-last-login>—</p>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-last-login-hint
-                      data-i18n="app.panel.kpis.last_login.hint.empty"
-                    >
-                      Nenhum registro disponível.
-                    </p>
-                  </article>
-                  <article class="ac-kpi-card" data-panel-kpi="events">
-                    <p
-                      class="ac-kpi-card__label"
-                      data-i18n="app.panel.kpis.events.label"
-                    >
-                      Eventos registrados
-                    </p>
-                    <p class="ac-kpi-card__value" data-panel-login-count>0</p>
-                    <p
-                      class="ac-kpi-card__meta"
-                      data-panel-login-hint
-                      data-i18n="app.panel.kpis.events.hint.empty"
-                    >
-                      Aguardando primeiro registro.
-                    </p>
-                  </article>
-                </div>
-              </article>
+                    <div>
+                      <dt data-i18n="app.panel.summary.account">Conta</dt>
+                      <dd data-login-account>—</dd>
+                    </div>
+                    <div>
+                      <dt data-i18n="app.panel.summary.last_login">Último acesso</dt>
+                      <dd data-login-last>—</dd>
+                    </div>
+                  </dl>
+                  <div
+                    class="ac-session-status"
+                    role="group"
+                    aria-label="Indicadores do painel"
+                    data-panel-kpis-group
+                  >
+                    <article class="ac-session-status__item" data-panel-kpi="status">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.status.label"
+                      >
+                        Status da sessão
+                      </p>
+                      <p class="ac-session-status__value">
+                        <span
+                          class="ac-dot ac-dot--crit"
+                          aria-hidden="true"
+                          data-panel-status-dot
+                        ></span>
+                        <span
+                          data-panel-status-label
+                          data-i18n="app.panel.kpis.status.states.disconnected"
+                        >
+                          Desconectado
+                        </span>
+                      </p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-status-hint
+                        data-i18n="app.panel.kpis.status.hint.empty"
+                      >
+                        Cadastre um usuário para iniciar a sessão.
+                      </p>
+                    </article>
+                    <article class="ac-session-status__item" data-panel-kpi="last-login">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.last_login.label"
+                      >
+                        Último acesso
+                      </p>
+                      <p class="ac-session-status__value ac-mono" data-panel-last-login>
+                        —
+                      </p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-last-login-hint
+                        data-i18n="app.panel.kpis.last_login.hint.empty"
+                      >
+                        Nenhum registro disponível.
+                      </p>
+                    </article>
+                    <article class="ac-session-status__item" data-panel-kpi="events">
+                      <p
+                        class="ac-session-status__label"
+                        data-i18n="app.panel.kpis.events.label"
+                      >
+                        Eventos registrados
+                      </p>
+                      <p class="ac-session-status__value" data-panel-login-count>0</p>
+                      <p
+                        class="ac-session-status__meta"
+                        data-panel-login-hint
+                        data-i18n="app.panel.kpis.events.hint.empty"
+                      >
+                        Aguardando primeiro registro.
+                      </p>
+                    </article>
+                  </div>
+                </article>
 
               <article
-                class="ac-panel-card ac-panel-card--form"
-                aria-labelledby="painel-cadastro-title"
+                class="ac-panel-card ac-panel-card--sync"
+                aria-labelledby="painel-sync-title"
+                data-system-panel
               >
                 <header class="ac-panel-card__head">
                   <div class="ac-panel-card__titles">
                     <h3
-                      id="painel-cadastro-title"
+                      id="painel-sync-title"
                       class="ac-panel-card__title"
-                      data-i18n="app.panel.form.title"
+                      data-i18n="app.sync.panel.title"
                     >
-                      Cadastro
+                      Sincronização de arquivos
                     </h3>
                     <p
                       class="ac-panel-card__subtitle"
-                      data-i18n="app.panel.form.subtitle"
+                      data-i18n="app.sync.panel.subtitle"
                     >
-                      Atualize os dados salvos neste dispositivo.
+                      Gerencie integrações com Google Drive e OneDrive.
                     </p>
                   </div>
                 </header>
-                <dl class="ac-panel-summary ac-tile__meta" role="list">
-                  <div>
-                    <dt data-i18n="app.panel.summary.user">Usuário</dt>
-                    <dd data-login-user data-i18n="app.panel.summary.empty">
-                      Não configurado
-                    </dd>
-                  </div>
-                  <div>
-                    <dt data-i18n="app.panel.summary.account">Conta</dt>
-                    <dd data-login-account>—</dd>
-                  </div>
-                  <div>
-                    <dt data-i18n="app.panel.summary.last_login">Último acesso</dt>
-                    <dd data-login-last>—</dd>
-                  </div>
-                </dl>
+                <div class="ac-sync-providers">
+                  <section
+                    class="ac-sync-card"
+                    data-sync-provider="googleDrive"
+                  >
+                    <header class="ac-sync-card__head">
+                      <div class="ac-sync-card__info">
+                        <h4
+                          class="ac-sync-card__title"
+                          data-i18n="app.sync.provider.googleDrive"
+                        >
+                          Google Drive
+                        </h4>
+                        <p
+                          class="ac-sync-card__status"
+                          data-sync-status="googleDrive"
+                          data-i18n="app.sync.status.idle"
+                        >
+                          Inativo
+                        </p>
+                      </div>
+                      <button
+                        class="ac-btn ac-btn--ghost ac-sync-card__toggle"
+                        type="button"
+                        data-sync-toggle="googleDrive"
+                        aria-pressed="false"
+                      >
+                        Ativar Google Drive
+                      </button>
+                    </header>
+                    <div class="ac-sync-card__indicator">
+                      <span
+                        class="ac-dot ac-dot--idle"
+                        aria-hidden="true"
+                        data-sync-status-indicator="googleDrive"
+                      ></span>
+                      <p
+                        class="ac-sync-card__message"
+                        data-sync-message="googleDrive"
+                        data-i18n="app.sync.status.message.idle"
+                      >
+                        Sincronização aguardando acionamento.
+                      </p>
+                    </div>
+                    <p
+                      class="ac-sync-card__last"
+                      data-sync-last-update="googleDrive"
+                      data-i18n="app.sync.last_sync.never"
+                    >
+                      Nunca sincronizado
+                    </p>
+                    <h5
+                      class="ac-sync-card__devices-title"
+                      data-i18n="app.sync.devices.title"
+                    >
+                      Dispositivos autorizados
+                    </h5>
+                    <ul
+                      class="ac-sync-card__devices"
+                      data-sync-devices="googleDrive"
+                    ></ul>
+                    <p
+                      class="ac-sync-card__devices-empty"
+                      data-sync-devices-empty="googleDrive"
+                      data-i18n="app.sync.devices.empty"
+                    >
+                      Nenhum dispositivo conectado.
+                    </p>
+                    <button
+                      class="ac-btn ac-btn--danger ac-sync-card__logout"
+                      type="button"
+                      data-sync-logout-all="googleDrive"
+                    >
+                      Deslogar de todos
+                    </button>
+                  </section>
+                  <section class="ac-sync-card" data-sync-provider="oneDrive">
+                    <header class="ac-sync-card__head">
+                      <div class="ac-sync-card__info">
+                        <h4
+                          class="ac-sync-card__title"
+                          data-i18n="app.sync.provider.oneDrive"
+                        >
+                          OneDrive
+                        </h4>
+                        <p
+                          class="ac-sync-card__status"
+                          data-sync-status="oneDrive"
+                          data-i18n="app.sync.status.idle"
+                        >
+                          Inativo
+                        </p>
+                      </div>
+                      <button
+                        class="ac-btn ac-btn--ghost ac-sync-card__toggle"
+                        type="button"
+                        data-sync-toggle="oneDrive"
+                        aria-pressed="false"
+                      >
+                        Ativar OneDrive
+                      </button>
+                    </header>
+                    <div class="ac-sync-card__indicator">
+                      <span
+                        class="ac-dot ac-dot--idle"
+                        aria-hidden="true"
+                        data-sync-status-indicator="oneDrive"
+                      ></span>
+                      <p
+                        class="ac-sync-card__message"
+                        data-sync-message="oneDrive"
+                        data-i18n="app.sync.status.message.idle"
+                      >
+                        Sincronização aguardando acionamento.
+                      </p>
+                    </div>
+                    <p
+                      class="ac-sync-card__last"
+                      data-sync-last-update="oneDrive"
+                      data-i18n="app.sync.last_sync.never"
+                    >
+                      Nunca sincronizado
+                    </p>
+                    <h5
+                      class="ac-sync-card__devices-title"
+                      data-i18n="app.sync.devices.title"
+                    >
+                      Dispositivos autorizados
+                    </h5>
+                    <ul
+                      class="ac-sync-card__devices"
+                      data-sync-devices="oneDrive"
+                    ></ul>
+                    <p
+                      class="ac-sync-card__devices-empty"
+                      data-sync-devices-empty="oneDrive"
+                      data-i18n="app.sync.devices.empty"
+                    >
+                      Nenhum dispositivo conectado.
+                    </p>
+                    <button
+                      class="ac-btn ac-btn--danger ac-sync-card__logout"
+                      type="button"
+                      data-sync-logout-all="oneDrive"
+                    >
+                      Deslogar de todos
+                    </button>
+                  </section>
+                </div>
+              </article>
+
+                <article class="ac-panel-card ac-panel-card--backup">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.backup.title"
+                      >
+                        Backup
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.backup.subtitle"
+                      >
+                        Proteja registros críticos e restaure configurações em segundos.
+                      </p>
+                    </div>
+                    <span class="ac-status-chip" role="status">
+                      <span class="ac-status-chip__icon" aria-hidden="true">💾</span>
+                      <span
+                        class="ac-status-chip__label"
+                        data-i18n="app.panel.backup.status.disabled"
+                      >
+                        Backup desativado
+                      </span>
+                    </span>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Último backup</dt>
+                      <dd class="ac-mono" data-backup-last>—</dd>
+                    </div>
+                    <div>
+                      <dt>Armazenamento</dt>
+                      <dd class="ac-mono" data-backup-target>Sem destino</dd>
+                    </div>
+                    <div>
+                      <dt>Tamanho estimado</dt>
+                      <dd class="ac-mono" data-backup-size>0 KB</dd>
+                    </div>
+                  </dl>
+                  <p
+                    class="ac-panel-card__note"
+                    data-i18n="app.panel.backup.note"
+                  >
+                    Configure uma conta de nuvem ou exporte manualmente os dados para
+                    garantir redundância.
+                  </p>
+                </article>
+
+                <article class="ac-panel-card ac-panel-card--connectivity">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.connectivity.title"
+                      >
+                        Conectividade
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.connectivity.subtitle"
+                      >
+                        Parâmetros ativos e latência dos serviços em tempo real.
+                      </p>
+                    </div>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Endpoint</dt>
+                      <dd class="ac-mono" data-connect-endpoint>api.marco.local</dd>
+                    </div>
+                    <div>
+                      <dt>Região</dt>
+                      <dd class="ac-mono" data-connect-region>br-south</dd>
+                    </div>
+                    <div>
+                      <dt>Latência média</dt>
+                      <dd class="ac-mono" data-connect-latency>—</dd>
+                    </div>
+                  </dl>
+                  <p
+                    class="ac-panel-card__note"
+                    data-i18n="app.panel.connectivity.note"
+                  >
+                    Monitore tempo de resposta e priorize links redundantes durante janelas
+                    críticas de operação.
+                  </p>
+                </article>
+
+                <article class="ac-panel-card ac-panel-card--security">
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.security.title"
+                      >
+                        Segurança
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.security.subtitle"
+                      >
+                        Sessões autenticadas, políticas aplicadas e eventos recentes.
+                      </p>
+                    </div>
+                  </header>
+                  <dl class="ac-info-list" role="list">
+                    <div>
+                      <dt>Última revisão</dt>
+                      <dd class="ac-mono" data-security-last>—</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd class="ac-mono" data-security-status>Em análise</dd>
+                    </div>
+                    <div>
+                      <dt>Alertas ativos</dt>
+                      <dd class="ac-mono" data-security-alerts>0</dd>
+                    </div>
+                  </dl>
+                  <p
+                    class="ac-panel-card__note"
+                    data-i18n="app.panel.security.note"
+                  >
+                    Garanta autenticação multifator nos dispositivos conectados e revise
+                    logs semanalmente.
+                  </p>
+                </article>
+
+                <article
+                  class="ac-panel-card ac-panel-card--form"
+                  aria-labelledby="painel-cadastro-title"
+                >
+                  <header class="ac-panel-card__head">
+                    <div class="ac-panel-card__titles">
+                      <h3
+                        id="painel-cadastro-title"
+                        class="ac-panel-card__title"
+                        data-i18n="app.panel.form.title"
+                      >
+                        Cadastro
+                      </h3>
+                      <p
+                        class="ac-panel-card__subtitle"
+                        data-i18n="app.panel.form.subtitle"
+                      >
+                        Atualize os dados salvos neste dispositivo.
+                      </p>
+                    </div>
+                    <span
+                      class="ac-panel-card__badge"
+                      data-i18n="app.panel.form.badge"
+                    >
+                      Editar
+                    </span>
+                  </header>
                 <form
                   id="login-form"
                   class="ac-form-grid"
@@ -449,16 +805,48 @@
                       class="ac-panel-card__title"
                       data-i18n="app.panel.history.title"
                     >
-                      Histórico de atividades
+                      Eventos
                     </h3>
                     <p
                       class="ac-panel-card__subtitle ac-history__subtitle"
                       data-i18n="app.panel.history.subtitle"
                     >
-                      Acompanhe logins, logoffs e trocas de idioma registradas
-                      neste navegador.
+                      Acompanhe logins, backups e alertas registrados neste dispositivo.
                     </p>
                   </div>
+                  <form class="ac-history__filters" role="search">
+                    <label class="ac-history__search">
+                      <span class="ac-visually-hidden">Filtrar eventos</span>
+                      <input
+                        type="search"
+                        name="history-search"
+                        placeholder="Eventos (ex.: backup, login, 09)"
+                        data-i18n="app.panel.history.search.placeholder"
+                        autocomplete="off"
+                        data-history-search
+                      />
+                    </label>
+                    <label class="ac-history__select">
+                      <span class="ac-visually-hidden">Tipo de evento</span>
+                      <select name="history-type" data-history-filter>
+                        <option value="all" data-i18n="app.panel.history.filter.all">
+                          Todos os tipos
+                        </option>
+                        <option value="login" data-i18n="app.panel.history.filter.login">
+                          Logins
+                        </option>
+                        <option value="logout" data-i18n="app.panel.history.filter.logout">
+                          Logoffs
+                        </option>
+                        <option value="backup" data-i18n="app.panel.history.filter.backup">
+                          Backups
+                        </option>
+                        <option value="alert" data-i18n="app.panel.history.filter.alert">
+                          Alertas
+                        </option>
+                      </select>
+                    </label>
+                  </form>
                 </header>
                 <div class="ac-history__body">
                   <div
@@ -488,6 +876,7 @@
                   </p>
                 </div>
               </article>
+              </div>
             </div>
           </section>
         </main>

--- a/appbase/sync/providers.js
+++ b/appbase/sync/providers.js
@@ -1,0 +1,139 @@
+const PROVIDER_CONFIGS = {
+  googleDrive: {
+    check() {
+      return (
+        typeof window !== 'undefined' &&
+        (window.gapi || window.google || window.googleDriveNative)
+      );
+    },
+    missingCode: 'GOOGLE_PROVIDER_MISSING',
+    missingMessage:
+      'Instale o Google Drive para Desktop e conecte sua conta corporativa.',
+    scopes: ['https://www.googleapis.com/auth/drive.appdata'],
+  },
+  oneDrive: {
+    check() {
+      return (
+        typeof window !== 'undefined' &&
+        (window.OneDrive || window.Microsoft || window.msOnedrive)
+      );
+    },
+    missingCode: 'ONEDRIVE_PROVIDER_MISSING',
+    missingMessage:
+      'Instale o cliente OneDrive e faça login com sua conta antes de continuar.',
+    scopes: ['Files.ReadWrite.AppFolder'],
+  },
+};
+
+const sessions = {
+  googleDrive: null,
+  oneDrive: null,
+};
+
+function getSession(provider) {
+  const config = PROVIDER_CONFIGS[provider];
+  if (!config) {
+    throw new Error(`Provider não suportado: ${provider}`);
+  }
+  if (!sessions[provider]) {
+    sessions[provider] = {
+      token: null,
+      scopes: [...config.scopes],
+      lastSync: '',
+      devices: [],
+      message: '',
+    };
+  }
+  return sessions[provider];
+}
+
+function ensureProvider(provider) {
+  return new Promise((resolve, reject) => {
+    const config = PROVIDER_CONFIGS[provider];
+    if (!config) {
+      const error = new Error(`Provider não suportado: ${provider}`);
+      error.code = 'UNSUPPORTED_PROVIDER';
+      reject(error);
+      return;
+    }
+    if (!config.check()) {
+      const error = new Error(config.missingMessage);
+      error.code = config.missingCode;
+      reject(error);
+      return;
+    }
+    const session = getSession(provider);
+    resolve({
+      provider,
+      scopes: [...session.scopes],
+    });
+  });
+}
+
+function syncProvider(provider) {
+  return ensureProvider(provider).then(() => {
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      const offlineError = new Error('Sincronização indisponível offline.');
+      offlineError.code = 'NETWORK_UNAVAILABLE';
+      throw offlineError;
+    }
+    const session = getSession(provider);
+    const now = new Date().toISOString();
+    session.token = `token-${provider}-${now}`;
+    const localDevice = buildLocalDevice();
+    localDevice.lastSeen = now;
+    session.lastSync = now;
+    session.devices = mergeDevices(session.devices, localDevice);
+    session.message = 'Sincronização concluída.';
+    return {
+      lastSync: session.lastSync,
+      devices: session.devices.map((device) => ({ ...device })),
+      message: session.message,
+    };
+  });
+}
+
+function disconnectAll(provider) {
+  return ensureProvider(provider).then(() => {
+    const session = getSession(provider);
+    session.token = null;
+    session.lastSync = '';
+    session.devices = [];
+    session.message = '';
+    return {
+      lastSync: session.lastSync,
+      devices: [],
+      message: session.message,
+    };
+  });
+}
+
+function buildLocalDevice() {
+  const agent =
+    (typeof navigator !== 'undefined' && navigator.userAgent) || 'Navegador';
+  let model = agent;
+  if (agent.includes('(') && agent.includes(')')) {
+    model = agent.slice(agent.indexOf('(') + 1, agent.indexOf(')'));
+  }
+  return {
+    name: 'Este dispositivo',
+    model: model.trim(),
+  };
+}
+
+function mergeDevices(devices, current) {
+  const registry = Array.isArray(devices) ? [...devices] : [];
+  const existingIndex = registry.findIndex((device) => device.name === current.name);
+  if (existingIndex > -1) {
+    registry[existingIndex] = {
+      ...registry[existingIndex],
+      ...current,
+      lastSeen: current.lastSeen,
+    };
+  } else {
+    registry.unshift({ ...current });
+  }
+  return registry;
+}
+
+export { ensureProvider, syncProvider, disconnectAll };


### PR DESCRIPTION
## Summary
- rebuild the painel stage markup to merge the refreshed overview/status cards with the Google Drive and OneDrive sync controls
- extend the stylesheet for the new layout grid, stage chips, session indicators, and history filters
- update the app state helpers to support multiple status indicators and provide fallbacks for the new strings

## Testing
- npm test *(fails: playwright not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5933e92a88320aec26f5c0958173b